### PR TITLE
Fix JSON unmarshaling

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -264,23 +264,11 @@ func SendHTTPGetRequest(url string, jsonDecode bool, result interface{}) (err er
 }
 
 func JSONEncode(v interface{}) ([]byte, error) {
-	json, err := json.Marshal(&v)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return json, nil
+	return json.Marshal(v)
 }
 
 func JSONDecode(data []byte, to interface{}) error {
-	err := json.Unmarshal(data, &to)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(data, to)
 }
 
 func EncodeURLValues(url string, values url.Values) string {


### PR DESCRIPTION
You have to pass a pointer to `JSONDecode` and if you don't `JSONDecode` will pass a pointer to `json.Unmarshal` and no error will occur but message won't be unmarshaled.