### PR TITLE
GDAX support

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"hash"
 	"io"
 	"io/ioutil"
@@ -337,4 +338,16 @@ func WriteFile(file string, data []byte) error {
 		return err
 	}
 	return nil
+}
+
+// GetURIPath returns the path of a URL given a URL
+func GetURIPath(uri string) string {
+	urip, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+	if urip.RawQuery != "" {
+		return fmt.Sprintf("%s?%s", urip.Path, urip.RawQuery)
+	}
+	return urip.Path
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -272,11 +272,17 @@ func TestUnixTimestampStrToTime(t *testing.T) {
 }
 
 func TestGetURIPath(t *testing.T) {
-	testURI := "https://api.gdax.com/accounts"
-	expectedOutput := "/accounts"
-	actualOutput := GetURIPath(testURI)
-	if actualOutput != expectedOutput {
-		t.Error(fmt.Sprintf("Test failed. Expected '%s'. Actual '%s'.",
-			expectedOutput, actualOutput))
+	// mapping of input vs expected result
+	testTable := map[string]string{
+		"https://api.gdax.com/accounts":         "/accounts",
+		"https://api.gdax.com/accounts?a=1&b=2": "/accounts?a=1&b=2",
+		"ht:tp:/invalidurl":                     "",
+	}
+	for testInput, expectedOutput := range testTable {
+		actualOutput := GetURIPath(testInput)
+		if actualOutput != expectedOutput {
+			t.Error(fmt.Sprintf("Test failed. Expected '%s'. Actual '%s'.",
+				expectedOutput, actualOutput))
+		}
 	}
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -272,6 +272,7 @@ func TestUnixTimestampStrToTime(t *testing.T) {
 }
 
 func TestGetURIPath(t *testing.T) {
+	t.Parallel()
 	// mapping of input vs expected result
 	testTable := map[string]string{
 		"https://api.gdax.com/accounts":         "/accounts",

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -270,3 +270,13 @@ func TestUnixTimestampStrToTime(t *testing.T) {
 		t.Error(fmt.Sprintf("Test failed. Expected '%s'. Actual '%s'.", expectedOutput, actualResult))
 	}
 }
+
+func TestURIPath(t *testing.T) {
+	testURI := "https://api.gdax.com/accounts"
+	expectedOutput := "/accounts"
+	actualOutput := GetURIPath(testURI)
+	if actualOutput != expectedOutput {
+		t.Error(fmt.Sprintf("Test failed. Expected '%s'. Actual '%s'.",
+			expectedOutput, actualOutput))
+	}
+}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -271,7 +271,7 @@ func TestUnixTimestampStrToTime(t *testing.T) {
 	}
 }
 
-func TestURIPath(t *testing.T) {
+func TestGetURIPath(t *testing.T) {
 	testURI := "https://api.gdax.com/accounts"
 	expectedOutput := "/accounts"
 	actualOutput := GetURIPath(testURI)

--- a/exchanges/gdax/gdax.go
+++ b/exchanges/gdax/gdax.go
@@ -227,18 +227,17 @@ func (g *GDAX) GetCurrencies() ([]GDAXCurrency, error) {
 
 func (g *GDAX) GetAccounts() ([]GDAXAccountResponse, error) {
 	resp := []GDAXAccountResponse{}
-	err := g.SendAuthenticatedHTTPRequest("GET", GDAX_API_URL+GDAX_ACCOUNTS, nil, &resp)
+	err := g.SendAuthenticatedHTTPRequest("GET", GDAX_ACCOUNTS, nil, &resp)
 	if err != nil {
 		return nil, err
 	}
-
 	return resp, nil
 }
 
 func (g *GDAX) GetAccount(account string) (GDAXAccountResponse, error) {
 	resp := GDAXAccountResponse{}
 	path := fmt.Sprintf("%s/%s", GDAX_ACCOUNTS, account)
-	err := g.SendAuthenticatedHTTPRequest("GET", GDAX_API_URL+path, nil, &resp)
+	err := g.SendAuthenticatedHTTPRequest("GET", path, nil, &resp)
 	if err != nil {
 		return resp, err
 	}
@@ -248,7 +247,7 @@ func (g *GDAX) GetAccount(account string) (GDAXAccountResponse, error) {
 func (g *GDAX) GetAccountHistory(accountID string) ([]GDAXAccountLedgerResponse, error) {
 	resp := []GDAXAccountLedgerResponse{}
 	path := fmt.Sprintf("%s/%s/%s", GDAX_ACCOUNTS, accountID, GDAX_LEDGER)
-	err := g.SendAuthenticatedHTTPRequest("GET", GDAX_API_URL+path, nil, &resp)
+	err := g.SendAuthenticatedHTTPRequest("GET", path, nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +257,7 @@ func (g *GDAX) GetAccountHistory(accountID string) ([]GDAXAccountLedgerResponse,
 func (g *GDAX) GetHolds(accountID string) ([]GDAXAccountHolds, error) {
 	resp := []GDAXAccountHolds{}
 	path := fmt.Sprintf("%s/%s/%s", GDAX_ACCOUNTS, accountID, GDAX_HOLDS)
-	err := g.SendAuthenticatedHTTPRequest("GET", GDAX_API_URL+path, nil, &resp)
+	err := g.SendAuthenticatedHTTPRequest("GET", path, nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +285,7 @@ func (g *GDAX) PlaceOrder(clientRef string, price, amount float64, side string, 
 	}
 
 	resp := OrderResponse{}
-	err := g.SendAuthenticatedHTTPRequest("POST", GDAX_API_URL+GDAX_ORDERS, request, &resp)
+	err := g.SendAuthenticatedHTTPRequest("POST", GDAX_ORDERS, request, &resp)
 	if err != nil {
 		return "", err
 	}
@@ -296,7 +295,7 @@ func (g *GDAX) PlaceOrder(clientRef string, price, amount float64, side string, 
 
 func (g *GDAX) CancelOrder(orderID string) error {
 	path := fmt.Sprintf("%s/%s", GDAX_ORDERS, orderID)
-	err := g.SendAuthenticatedHTTPRequest("DELETE", GDAX_API_URL+path, nil, nil)
+	err := g.SendAuthenticatedHTTPRequest("DELETE", path, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -306,7 +305,7 @@ func (g *GDAX) CancelOrder(orderID string) error {
 func (g *GDAX) GetOrders(params url.Values) ([]GDAXOrdersResponse, error) {
 	path := common.EncodeURLValues(GDAX_API_URL+GDAX_ORDERS, params)
 	resp := []GDAXOrdersResponse{}
-	err := g.SendAuthenticatedHTTPRequest("GET", path, nil, &resp)
+	err := g.SendAuthenticatedHTTPRequest("GET", common.GetURIPath(path), nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +315,7 @@ func (g *GDAX) GetOrders(params url.Values) ([]GDAXOrdersResponse, error) {
 func (g *GDAX) GetOrder(orderID string) (GDAXOrderResponse, error) {
 	path := fmt.Sprintf("%s/%s", GDAX_ORDERS, orderID)
 	resp := GDAXOrderResponse{}
-	err := g.SendAuthenticatedHTTPRequest("GET", GDAX_API_URL+path, nil, &resp)
+	err := g.SendAuthenticatedHTTPRequest("GET", path, nil, &resp)
 	if err != nil {
 		return resp, err
 	}
@@ -326,7 +325,7 @@ func (g *GDAX) GetOrder(orderID string) (GDAXOrderResponse, error) {
 func (g *GDAX) GetFills(params url.Values) ([]GDAXFillResponse, error) {
 	path := common.EncodeURLValues(GDAX_API_URL+GDAX_FILLS, params)
 	resp := []GDAXFillResponse{}
-	err := g.SendAuthenticatedHTTPRequest("GET", path, nil, &resp)
+	err := g.SendAuthenticatedHTTPRequest("GET", common.GetURIPath(path), nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +338,7 @@ func (g *GDAX) Transfer(transferType string, amount float64, accountID string) e
 	request["amount"] = strconv.FormatFloat(amount, 'f', -1, 64)
 	request["GDAX_account_id"] = accountID
 
-	err := g.SendAuthenticatedHTTPRequest("POST", GDAX_API_URL+GDAX_TRANSFERS, request, nil)
+	err := g.SendAuthenticatedHTTPRequest("POST", GDAX_TRANSFERS, request, nil)
 	if err != nil {
 		return err
 	}
@@ -353,7 +352,7 @@ func (g *GDAX) GetReport(reportType, startDate, endDate string) (GDAXReportRespo
 	request["end_date"] = endDate
 
 	resp := GDAXReportResponse{}
-	err := g.SendAuthenticatedHTTPRequest("POST", GDAX_API_URL+GDAX_REPORTS, request, &resp)
+	err := g.SendAuthenticatedHTTPRequest("POST", GDAX_REPORTS, request, &resp)
 	if err != nil {
 		return resp, err
 	}
@@ -363,7 +362,7 @@ func (g *GDAX) GetReport(reportType, startDate, endDate string) (GDAXReportRespo
 func (g *GDAX) GetReportStatus(reportID string) (GDAXReportResponse, error) {
 	path := fmt.Sprintf("%s/%s", GDAX_REPORTS, reportID)
 	resp := GDAXReportResponse{}
-	err := g.SendAuthenticatedHTTPRequest("POST", GDAX_API_URL+path, nil, &resp)
+	err := g.SendAuthenticatedHTTPRequest("POST", path, nil, &resp)
 	if err != nil {
 		return resp, err
 	}
@@ -386,7 +385,7 @@ func (g *GDAX) SendAuthenticatedHTTPRequest(method, path string, params map[stri
 		}
 	}
 
-	message := timestamp + method + path + string(payload)
+	message := timestamp + method + "/" + path + string(payload)
 	hmac := common.GetHMAC(common.HASH_SHA256, []byte(message), []byte(g.APISecret))
 	headers := make(map[string]string)
 	headers["CB-ACCESS-SIGN"] = common.Base64Encode([]byte(hmac))

--- a/exchanges/gdax/gdax.go
+++ b/exchanges/gdax/gdax.go
@@ -370,7 +370,8 @@ func (g *GDAX) GetReportStatus(reportID string) (GDAXReportResponse, error) {
 }
 
 func (g *GDAX) SendAuthenticatedHTTPRequest(method, path string, params map[string]interface{}, result interface{}) (err error) {
-	timestamp := strconv.FormatInt(time.Now().UnixNano(), 10)[0:13]
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
 	payload := []byte("")
 
 	if params != nil {

--- a/exchanges/gdax/gdax_websocket.go
+++ b/exchanges/gdax/gdax_websocket.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	GDAX_WEBSOCKET_URL = "wss://ws-feed.exchange.gdax.com"
+	GDAX_WEBSOCKET_URL = "wss://ws-feed.gdax.com"
 )
 
 func (g *GDAX) WebsocketSubscribe(product string, conn *websocket.Conn) error {

--- a/exchanges/gdax/gdax_wrapper.go
+++ b/exchanges/gdax/gdax_wrapper.go
@@ -1,6 +1,7 @@
 package gdax
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -80,6 +81,9 @@ func (e *GDAX) GetExchangeAccountInfo() (exchange.ExchangeAccountInfo, error) {
 }
 
 func (g *GDAX) GetTickerPrice(currency string) (ticker.TickerPrice, error) {
+	if len(currency) == 6 {
+		currency = fmt.Sprintf("%s-%s", currency[0:3], currency[3:])
+	}
 	tickerNew, err := ticker.GetTicker(g.GetName(), currency[0:3], currency[4:])
 	if err == nil {
 		return tickerNew, nil


### PR DESCRIPTION
This aims to address a few issues with GDAX:
- update websocket API endpoint to restore websocket feed data (old one no longer resolves)
- API auth based on unix time stamp and hashed path instead of URL (auth fails otherwise).
- support alternate currency notation on GDAX (AAA-BBB and AAABBB). the configuration currently uses AAABBB format on GDAX for calls to GetTickerPrice() but that method requires AAA-BBB format. this is used by example AllActiveExchangesAndCurrencies and addresses account retrieval via that.