### PR TITLE
Fix typo and type error in PoloniexDepositsWithdrawals

### DIFF
--- a/exchanges/poloniex/poloniex_types.go
+++ b/exchanges/poloniex/poloniex_types.go
@@ -1,9 +1,5 @@
 package poloniex
 
-import (
-	"time"
-)
-
 type PoloniexTicker struct {
 	Last          float64 `json:"last,string"`
 	LowestAsk     float64 `json:"lowestAsk,string"`
@@ -92,24 +88,24 @@ type PoloniexDepositAddresses struct {
 
 type PoloniexDepositsWithdrawals struct {
 	Deposits []struct {
-		Currency      string    `json:"currency"`
-		Address       string    `json:"address"`
-		Amount        float64   `json:"amount,string"`
-		Confirmations int       `json:"confirmations"`
-		TransactionID string    `json:"txid"`
-		Timestamp     time.Time `json:"timestamp"`
-		Status        string    `json:"string"`
+		Currency      string  `json:"currency"`
+		Address       string  `json:"address"`
+		Amount        float64 `json:"amount,string"`
+		Confirmations int     `json:"confirmations"`
+		TransactionID string  `json:"txid"`
+		Timestamp     int64   `json:"timestamp"`
+		Status        string  `json:"status"`
 	} `json:"deposits"`
 	Withdrawals []struct {
-		WithdrawalNumber int64     `json:"withdrawalNumber"`
-		Currency         string    `json:"currency"`
-		Address          string    `json:"address"`
-		Amount           float64   `json:"amount,string"`
-		Confirmations    int       `json:"confirmations"`
-		TransactionID    string    `json:"txid"`
-		Timestamp        time.Time `json:"timestamp"`
-		Status           string    `json:"string"`
-		IPAddress        string    `json:"ipAddress"`
+		WithdrawalNumber int64   `json:"withdrawalNumber"`
+		Currency         string  `json:"currency"`
+		Address          string  `json:"address"`
+		Amount           float64 `json:"amount,string"`
+		Confirmations    int     `json:"confirmations"`
+		TransactionID    string  `json:"txid"`
+		Timestamp        int64   `json:"timestamp"`
+		Status           string  `json:"status"`
+		IPAddress        string  `json:"ipAddress"`
 	} `json:"withdrawals"`
 }
 


### PR DESCRIPTION
## Golang cannot parse timestamp as time.Time

example code

https://play.golang.org/p/FLrGM2x4v8

```golang
package main

import (
	"fmt"
	"time"
	"encoding/json"
)

type Dummy struct {
	Val time.Time `json:"val"`
}

func main() {
	str := `{"val":1497314214}`
	data := []byte(str)

	var resp Dummy
	err := json.Unmarshal(data, &resp)
	if err != nil {
		panic(err)
	}
	fmt.Println(resp)
}
```

output
```
panic: parsing time "1497314214" as ""2006-01-02T15:04:05Z07:00"": cannot parse "1497314214" as """
```

so I modify type from `time.Time` to `int64`

## typo
string -> status
```
- Status string `json:"string"`
+Status string `json:"status"`
```
