### PR TITLE
Implement Poloniex API wrapper, returnLendingHistory

### DIFF
--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -42,6 +42,7 @@ const (
 	POLONIEX_CANCEL_LOAN_OFFER      = "cancelLoanOffer"
 	POLONIEX_OPEN_LOAN_OFFERS       = "returnOpenLoanOffers"
 	POLONIEX_ACTIVE_LOANS           = "returnActiveLoans"
+	POLONIEX_LENDING_HISTORY        = "returnLendingHistory"
 	POLONIEX_AUTO_RENEW             = "toggleAutoRenew"
 )
 
@@ -703,6 +704,26 @@ func (p *Poloniex) GetActiveLoans() (PoloniexActiveLoans, error) {
 	}
 
 	return result, nil
+}
+
+func (p *Poloniex) GetLendingHistory(start, end string) ([]PoloniexLendingHistory, error) {
+	vals := url.Values{}
+
+	if start != "" {
+		vals.Set("start", start)
+	}
+
+	if end != "" {
+		vals.Set("end", end)
+	}
+
+	resp := []PoloniexLendingHistory{}
+	err := p.SendAuthenticatedHTTPRequest("POST", POLONIEX_LENDING_HISTORY, vals, &resp)
+
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (p *Poloniex) ToggleAutoRenew(orderNumber int64) (bool, error) {

--- a/exchanges/poloniex/poloniex_types.go
+++ b/exchanges/poloniex/poloniex_types.go
@@ -218,3 +218,16 @@ type PoloniexActiveLoans struct {
 	Provided []PoloniexLoanOffer `json:"provided"`
 	Used     []PoloniexLoanOffer `json:"used"`
 }
+
+type PoloniexLendingHistory struct {
+	ID       int64   `json:"id"`
+	Currency string  `json:"currency"`
+	Rate     float64 `json:"rate,string"`
+	Amount   float64 `json:"amount,string"`
+	Duration float64 `json:"duration,string"`
+	Interest float64 `json:"interest,string"`
+	Fee      float64 `json:"fee,string"`
+	Earned   float64 `json:"earned,string"`
+	Open     string  `json:"open"`
+	Close    string  `json:"close"`
+}


### PR DESCRIPTION
gocryptotrader is a trading bot, but I use it as poloniex API wrapper.
I implement missing poloniex api, returnLendingHistory

test code

```golang
package main

import (
	"fmt"

	"github.com/thrasher-/gocryptotrader/config"
	"github.com/thrasher-/gocryptotrader/exchanges/poloniex"
)

func makePoloniex(apikey, secret string) *poloniex.Poloniex {
	conf := config.ExchangeConfig{
		Enabled:                 true,
		APIKey:                  apikey,
		APISecret:               secret,
		AuthenticatedAPISupport: true,
		Verbose:                 true,
		Websocket:               true,
	}
	exchange := poloniex.Poloniex{}
	exchange.Setup(conf)
	return &exchange
}

func main() {
	apikey := "your-api-key"
	secret := "your-secret-key"
	p := makePoloniex(apikey, secret)
	histories, err := p.GetLendingHistory("", "")
	if err != nil {
		panic(err)
	}
	fmt.Println(histories)
}
```

