### PR TITLE
Fixed misspellings of separator

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -142,16 +142,16 @@ func DataContains(haystack []string, needle string) bool {
 	return strings.Contains(data, needle)
 }
 
-// JoinStrings joins an array together with the required seperator and returns
+// JoinStrings joins an array together with the required separator and returns
 // it as a string
-func JoinStrings(input []string, seperator string) string {
-	return strings.Join(input, seperator)
+func JoinStrings(input []string, separator string) string {
+	return strings.Join(input, separator)
 }
 
 // SplitStrings splits blocks of strings from string into a string array using
-// a seperator ie "," or "_"
-func SplitStrings(input, seperator string) []string {
-	return strings.Split(input, seperator)
+// a separator ie "," or "_"
+func SplitStrings(input, separator string) []string {
+	return strings.Split(input, separator)
 }
 
 // TrimString trims unwanted prefixes or postfixes

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -274,9 +274,9 @@ func TestDataContains(t *testing.T) {
 func TestJoinStrings(t *testing.T) {
 	t.Parallel()
 	originalInputOne := []string{"hello", "moto"}
-	seperator := ","
+	separator := ","
 	expectedOutput := "hello,moto"
-	actualResult := JoinStrings(originalInputOne, seperator)
+	actualResult := JoinStrings(originalInputOne, separator)
 	if expectedOutput != actualResult {
 		t.Error(fmt.Sprintf(
 			"Test failed. Expected '%s'. Actual '%s'", expectedOutput, actualResult),
@@ -287,9 +287,9 @@ func TestJoinStrings(t *testing.T) {
 func TestSplitStrings(t *testing.T) {
 	t.Parallel()
 	originalInputOne := "hello,moto"
-	seperator := ","
+	separator := ","
 	expectedOutput := []string{"hello", "moto"}
-	actualResult := SplitStrings(originalInputOne, seperator)
+	actualResult := SplitStrings(originalInputOne, separator)
 	if !reflect.DeepEqual(expectedOutput, actualResult) {
 		t.Error(fmt.Sprintf(
 			"Test failed. Expected '%s'. Actual '%s'", expectedOutput, actualResult),


### PR DESCRIPTION
I know this is an annoying pull request, but thought I would submit it anyway since it is spelled correctly in other places of the repo. 