### PR TITLE
increase limit for GetAuthenticatedTradeHistory poloniex

### DIFF
--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -369,11 +369,15 @@ func (p *Poloniex) GetOpenOrders(currency string) (interface{}, error) {
 	}
 }
 
-func (p *Poloniex) GetAuthenticatedTradeHistory(currency, start, end string) (interface{}, error) {
+func (p *Poloniex) GetAuthenticatedTradeHistory(currency, start, end, limit string) (interface{}, error) {
 	values := url.Values{}
 
 	if start != "" {
 		values.Set("start", start)
+	}
+
+	if limit != "" {
+		values.Set("limit", limit)
 	}
 
 	if end != "" {


### PR DESCRIPTION
>>> returnTradeHistory
Returns your trade history for a given market, specified by the "currencyPair" POST parameter. You may specify "all" as the currencyPair to receive your trade history for all markets. You may optionally specify a range via "start" and/or "end" POST parameters, given in UNIX timestamp format; if you do not specify a range, it will be limited to one day. You may optionally limit the number of entries returned using the "limit" parameter, up to a maximum of 10,000. If the "limit" parameter is not specified, no more than 500 entries will be returned.

Before it was limited to 500. Now it could be extended  