### PR TITLE
Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.idea
+doc
+web

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,13 @@
-FROM golang:onbuild
-COPY config_example.json config.json
+FROM golang:1.9.4 as build
+WORKDIR /go/src/github.com/thrasher-/gocryptotrader
+COPY . .
+RUN mv -vn config_example.json config.json \
+ && go get -v -d \
+ && GOARCH=386 GOOS=linux CGO_ENABLED=0 go install -v \
+ && mv /go/bin/linux_386 /go/bin/gocryptotrader
+
+FROM alpine:latest
+COPY --from=build /go/bin/gocryptotrader /app/
+COPY --from=build /go/src/github.com/thrasher-/gocryptotrader/config.json /app/
+EXPOSE 9050
+CMD ["/app/gocryptotrader"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,15 @@
-version: '2'
+version: '3'
+
 services:
-    web:
-        build: web/
-        hostname: gocryptotraderweb
-        container_name: web
-        ports:
-            - "3333:80"
-    cli:
-        build: .
-        hostname: gocryptotrader
-        container_name: daemon
-        privileged: true
+
+  web:
+    build: ./web
+    depends_on:
+      - cli
+    ports:
+      - "9051:80"
+
+  cli:
+    build: .
+    ports:
+      - "9050:9050"

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:9-alpine as build
+COPY package.json package-lock.json ./
+RUN npm set progress=false \
+ && npm config set depth 0 \
+ && npm cache clean --force
+RUN npm i \
+ && mkdir /app \
+ && cp -R ./node_modules /app
+WORKDIR /app
+COPY . .
+RUN $(npm bin)/ng build --prod --build-optimizer
+
+FROM nginx:1.13.3-alpine
+RUN rm -rf /var/www/html/*
+COPY nginx/default.conf /etc/nginx/conf.d/
+COPY --from=build /app/dist /var/www/html
+CMD ["nginx", "-g", "daemon off;"]

--- a/web/nginx/default.conf
+++ b/web/nginx/default.conf
@@ -1,0 +1,20 @@
+server {
+  listen 80;
+  sendfile on;
+  default_type application/octet-stream;
+  gzip              on;
+  gzip_http_version 1.1;
+  gzip_disable      "MSIE [1-6]\.";
+  gzip_min_length   256;
+  gzip_vary         on;
+  gzip_proxied      expired no-cache no-store private auth;
+  gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_comp_level   9;
+
+  root /var/www/html;
+
+  location / {
+    try_files $uri $uri/ /index.html =404;
+  }
+
+}


### PR DESCRIPTION
Here is a proposal of working docker builds for the CLI and web app and a docker-compose setup. It uses optimized and cacheable layer structure and multi-stage builds resulting in tiny image sizes.
Simply execute `docker-compose up` and open http://localhost:9051/.

Here's what `docker images` says about the images:
```
REPOSITORY            TAG        IMAGE ID        CREATED             SIZE
gocryptotrader_web    latest     8bc6f6475793    11 minutes ago      17.6MB
gocryptotrader_cli    latest     d57add7f97d3    17 minutes ago      19.3MB
```

A full build until everything is build, up and running takes 2m59.591s (Output of `time docker-compose up -d`).