### PR TITLE
Type assertion when using gdax GetHistoricRates

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -173,8 +173,10 @@ func LoadExchange(name string) error {
 		exch = new(localbitcoins.LocalBitcoins)
 	case "okcoin china":
 		exch = new(okcoin.OKCoin)
+		okcoin.OkcoinDefaultsSet = false
 	case "okcoin international":
 		exch = new(okcoin.OKCoin)
+		okcoin.OkcoinDefaultsSet = true
 	case "okex":
 		exch = new(okex.OKEX)
 	case "poloniex":
@@ -190,8 +192,8 @@ func LoadExchange(name string) error {
 	if exch == nil {
 		return ErrExchangeFailedToLoad
 	}
-
 	exch.SetDefaults()
+
 	bot.exchanges = append(bot.exchanges, exch)
 	exchCfg, err := bot.config.GetExchangeConfig(name)
 	if err != nil {

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -6,133 +6,138 @@ import (
 	"github.com/thrasher-/gocryptotrader/config"
 )
 
-var testSetup = false
-
-func SetupTest(t *testing.T) {
-	if !testSetup {
-		bot.config = &config.Cfg
-		err := bot.config.LoadConfig("./testdata/configtest.json")
-		if err != nil {
-			t.Fatalf("Test failed. SetupTest: Failed to load config: %s", err)
-		}
-		testSetup = true
-	}
-
-	if CheckExchangeExists("Bitfinex") {
-		return
-	}
-	err := LoadExchange("Bitfinex")
+func getEnabledExchanges() []string {
+	bot.config = &config.Cfg
+	err := bot.config.LoadConfig("./testdata/configtest.json")
 	if err != nil {
-		t.Errorf("Test failed. SetupTest: Failed to load exchange: %s", err)
+		return []string{}
+	}
+	return bot.config.GetEnabledExchanges()
+
+}
+
+func TestNSetupExchanges(t *testing.T) {
+	exchs := getEnabledExchanges()
+	t.Logf("\nNumber of exchanges is %d", len(exchs))
+	for _, e := range exchs {
+		t.Logf(e)
+		t.Run(e, func(t *testing.T) {
+			err := LoadExchange(e)
+			if err != nil {
+				t.Errorf("Test failed. SetupTest: Failed to load exchange: %s", err)
+			}
+			SetupExchanges()
+			err = UnloadExchange(e)
+			if err != nil {
+				t.Fatalf("Test failed. Failed to unload exchange: %s",
+					err)
+			}
+		})
+	}
+
+}
+
+func TestNExchangeExists(t *testing.T) {
+	exchs := getEnabledExchanges()
+	for _, e := range exchs {
+		t.Run(e, func(t *testing.T) {
+			err := LoadExchange(e)
+			if err != nil {
+				t.Errorf("Test failed. SetupTest: Failed to load exchange: %s", err)
+			}
+
+			if !CheckExchangeExists(e) {
+				t.Errorf("Test failed. TestGetExchangeExists: Unable to find exchange")
+			}
+			err = UnloadExchange(e)
+			if err != nil {
+				t.Fatalf("Test failed. Failed to unload exchange: %s",
+					err)
+			}
+		})
+	}
+
+}
+
+func TestNUnloadExchange(t *testing.T) {
+	exchs := getEnabledExchanges()
+	for _, e := range exchs {
+		t.Run(e, func(t *testing.T) {
+			err := LoadExchange(e)
+			if err != nil {
+				t.Errorf("Test failed. SetupTest: Failed to load exchange: %s", err)
+			}
+			err = UnloadExchange(e)
+			if err != nil {
+				t.Errorf("Test failed. TestUnloadExchange: Failed to get exchange. %s",
+					err)
+			}
+
+			err = UnloadExchange(e)
+			if err == nil {
+				t.Fatalf("Test failed. Failed to unload exchange: %s",
+					err)
+			}
+
+		})
+	}
+
+}
+
+func TestNReloadExchange(t *testing.T) {
+	exchs := getEnabledExchanges()
+	for _, e := range exchs {
+		t.Run(e, func(t *testing.T) {
+			err := LoadExchange(e)
+			if err != nil {
+				t.Errorf("Test failed. SetupTest: Failed to load exchange: %s", err)
+			}
+			err = ReloadExchange(e)
+			if err != nil {
+				t.Errorf("Test failed. TestReloadExchange: Incorrect result: %s",
+					err)
+			}
+			err = UnloadExchange(e)
+			if err != nil {
+				t.Fatalf("Test failed. Failed to unload exchange: %s",
+					err)
+			}
+		})
 	}
 }
 
-func CleanupTest(t *testing.T) {
-	if !CheckExchangeExists("Bitfinex") {
-		return
+func TestNGetExchangeByName(t *testing.T) {
+	exchs := getEnabledExchanges()
+	for _, e := range exchs {
+		t.Run(e, func(t *testing.T) {
+			err := LoadExchange(e)
+			if err != nil {
+				t.Errorf("Test failed. SetupTest: Failed to load exchange: %s", err)
+			}
+			exch := GetExchangeByName(e)
+			if exch == nil {
+				t.Errorf("Test failed. TestGetExchangeByName: Failed to get exchange")
+			}
+
+			if !exch.IsEnabled() {
+				t.Errorf("Test failed. TestGetExchangeByName: Unexpected result")
+			}
+
+			exch.SetEnabled(false)
+			bfx := GetExchangeByName(e)
+			if bfx.IsEnabled() {
+				t.Errorf("Test failed. TestGetExchangeByName: Unexpected result")
+			}
+
+			if exch.GetName() != e {
+				t.Errorf("Test failed. TestGetExchangeByName: Unexpected result")
+			}
+			err = UnloadExchange(e)
+			if err != nil {
+				t.Fatalf("Test failed. Failed to unload exchange: %s",
+					err)
+			}
+
+		})
 	}
-
-	err := UnloadExchange("Bitfinex")
-	if err != nil {
-		t.Fatalf("Test failed. CleanupTest: Failed to unload exchange: %s",
-			err)
-	}
-}
-
-func TestCheckExchangeExists(t *testing.T) {
-	SetupTest(t)
-
-	if !CheckExchangeExists("Bitfinex") {
-		t.Errorf("Test failed. TestGetExchangeExists: Unable to find exchange")
-	}
-
-	if CheckExchangeExists("Asdsad") {
-		t.Errorf("Test failed. TestGetExchangeExists: Non-existant exchange found")
-	}
-
-	CleanupTest(t)
-}
-
-func TestGetExchangeByName(t *testing.T) {
-	SetupTest(t)
-
-	exch := GetExchangeByName("Bitfinex")
-	if exch == nil {
-		t.Errorf("Test failed. TestGetExchangeByName: Failed to get exchange")
-	}
-
-	if !exch.IsEnabled() {
-		t.Errorf("Test failed. TestGetExchangeByName: Unexpected result")
-	}
-
-	exch.SetEnabled(false)
-	bfx := GetExchangeByName("Bitfinex")
-	if bfx.IsEnabled() {
-		t.Errorf("Test failed. TestGetExchangeByName: Unexpected result")
-	}
-
-	if exch.GetName() != "Bitfinex" {
-		t.Errorf("Test failed. TestGetExchangeByName: Unexpected result")
-	}
-
-	exch = GetExchangeByName("Asdasd")
-	if exch != nil {
-		t.Errorf("Test failed. TestGetExchangeByName: Non-existant exchange found")
-	}
-
-	CleanupTest(t)
-}
-
-func TestReloadExchange(t *testing.T) {
-	SetupTest(t)
-
-	err := ReloadExchange("asdf")
-	if err != ErrExchangeNotFound {
-		t.Errorf("Test failed. TestReloadExchange: Incorrect result: %s",
-			err)
-	}
-
-	err = ReloadExchange("Bitfinex")
-	if err != nil {
-		t.Errorf("Test failed. TestReloadExchange: Incorrect result: %s",
-			err)
-	}
-
-	CleanupTest(t)
-
-	err = ReloadExchange("asdf")
-	if err != ErrNoExchangesLoaded {
-		t.Errorf("Test failed. TestReloadExchange: Incorrect result: %s",
-			err)
-	}
-}
-
-func TestUnloadExchange(t *testing.T) {
-	SetupTest(t)
-
-	err := UnloadExchange("asdf")
-	if err != ErrExchangeNotFound {
-		t.Errorf("Test failed. TestUnloadExchange: Incorrect result: %s",
-			err)
-	}
-
-	err = UnloadExchange("Bitfinex")
-	if err != nil {
-		t.Errorf("Test failed. TestUnloadExchange: Failed to get exchange. %s",
-			err)
-	}
-
-	err = UnloadExchange("asdf")
-	if err != ErrNoExchangesLoaded {
-		t.Errorf("Test failed. TestUnloadExchange: Incorrect result: %s",
-			err)
-	}
-
-	CleanupTest(t)
-}
-
-func TestSetupExchanges(t *testing.T) {
-	SetupTest(t)
-	SetupExchanges()
-	CleanupTest(t)
 }

--- a/exchanges/gdax/gdax.go
+++ b/exchanges/gdax/gdax.go
@@ -250,15 +250,6 @@ func (g *GDAX) GetHistoricRates(currencyPair string, start, end, granularity int
 		s.Close = e
 		f, _ := single[5].(float64)
 		s.Volume = f
-		/* type assertion poosible here, since sometimes gdax returns empty value
-		s := History{
-			Time:   int64(single[0].(float64)),
-			Low:    single[1].(float64),
-			High:   single[2].(float64),
-			Open:   single[3].(float64),
-			Close:  single[4].(float64),
-			Volume: single[5].(float64),
-		}*/
 		history = append(history, s)
 	}
 

--- a/exchanges/gdax/gdax.go
+++ b/exchanges/gdax/gdax.go
@@ -237,6 +237,20 @@ func (g *GDAX) GetHistoricRates(currencyPair string, start, end, granularity int
 	}
 
 	for _, single := range resp {
+		var s History
+		a, _ := single[0].(float64)
+		s.Time = int64(a)
+		b, _ := single[1].(float64)
+		s.Low = b
+		c, _ := single[2].(float64)
+		s.High = c
+		d, _ := single[3].(float64)
+		s.Open = d
+		e, _ := single[4].(float64)
+		s.Close = e
+		f, _ := single[5].(float64)
+		s.Volume = f
+		/* type assertion poosible here, since sometimes gdax returns empty value
 		s := History{
 			Time:   int64(single[0].(float64)),
 			Low:    single[1].(float64),
@@ -244,7 +258,7 @@ func (g *GDAX) GetHistoricRates(currencyPair string, start, end, granularity int
 			Open:   single[3].(float64),
 			Close:  single[4].(float64),
 			Volume: single[5].(float64),
-		}
+		}*/
 		history = append(history, s)
 	}
 

--- a/exchanges/okcoin/okcoin.go
+++ b/exchanges/okcoin/okcoin.go
@@ -68,7 +68,7 @@ const (
 )
 
 var (
-	okcoinDefaultsSet = false
+	OkcoinDefaultsSet = false
 )
 
 // OKCoin is the overarching type across this package

--- a/exchanges/okcoin/okcoin.go
+++ b/exchanges/okcoin/okcoin.go
@@ -99,7 +99,7 @@ func (o *OKCoin) SetDefaults() {
 	o.FuturesValues = []string{"this_week", "next_week", "quarter"}
 	o.AssetTypes = []string{ticker.Spot}
 
-	if okcoinDefaultsSet {
+	if OkcoinDefaultsSet {
 		o.AssetTypes = append(o.AssetTypes, o.FuturesValues...)
 		o.APIUrl = okcoinAPIURL
 		o.Name = "OKCOIN International"
@@ -109,7 +109,7 @@ func (o *OKCoin) SetDefaults() {
 		o.APIUrl = okcoinAPIURLChina
 		o.Name = "OKCOIN China"
 		o.WebsocketURL = okcoinWebsocketURLChina
-		okcoinDefaultsSet = true
+		OkcoinDefaultsSet = true
 		o.setCurrencyPairFormats()
 	}
 }


### PR DESCRIPTION
Notice that sometimes gdax seems to return empty values when using GetHistoricRates. This caused 
```
s := History{
			Time:   int64(single[0].(float64)),
			Low:    single[1].(float64),
			High:   single[2].(float64),
			Open:   single[3].(float64),
			Close:  single[4].(float64),
			Volume: single[5].(float64),
		}*/
```
the type assertions to fail and then cause panic. 
the fix is not pretty here it is .
```
var s History
		a, _ := single[0].(float64)
		s.Time = int64(a)
		b, _ := single[1].(float64)
		s.Low = b
		c, _ := single[2].(float64)
		s.High = c
		d, _ := single[3].(float64)
		s.Open = d
		e, _ := single[4].(float64)
		s.Close = e
		f, _ := single[5].(float64)
		s.Volume = f
```
Now if the type assertion fails, then the value assigned will be zero of type float64 or int64. 
Let me know if you come up with better way than this. 