### PR TITLE
bitfinex websocket trade fix

### DIFF
--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -281,10 +281,14 @@ func (b *Bitfinex) WebsocketClient() {
 								data := chanData[1].([]interface{})
 								for _, x := range data {
 									y := x.([]interface{})
+									y := x.([]interface{})
+									if _, ok := y[0].(string); ok {
+										continue
+									}
 									trades = append(trades, WebsocketTrade{ID: int64(y[0].(float64)), Timestamp: int64(y[1].(float64)), Price: y[2].(float64), Amount: y[3].(float64)})
 								}
-							case 5:
-								trade := WebsocketTrade{ID: int64(chanData[1].(float64)), Timestamp: int64(chanData[2].(float64)), Price: chanData[3].(float64), Amount: chanData[4].(float64)}
+							case 7:
+								trade := WebsocketTrade{ID: int64(chanData[3].(float64)), Timestamp: int64(chanData[4].(float64)), Price: chanData[5].(float64), Amount: chanData[6].(float64)}
 								trades = append(trades, trade)
 
 								if b.Verbose {

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -281,7 +281,6 @@ func (b *Bitfinex) WebsocketClient() {
 								data := chanData[1].([]interface{})
 								for _, x := range data {
 									y := x.([]interface{})
-									y := x.([]interface{})
 									if _, ok := y[0].(string); ok {
 										continue
 									}


### PR DESCRIPTION
According to: https://docs.bitfinex.com/v1/reference#ws-public-trades bitfinex sends a SEQ which is a string and is a trade id. Later it sends the real ID, so we can discard it the first time we receive it. 

Furthermore, bitfinex sends each trade in two messages: "te" and "tu". The "tu" messages contains the real trade id.