### PR TITLE
fix typo in package.json

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
         "github": "https://github.com/gloriousCode/",
         "website": "https://www.gloriousedge.com"
     },
-    "contributers": [{
+    "contributors": [{
         "name": "Maxime GRIS",
         "email": "maxime.gris@gmail.com",
         "github": "https://github.com/maximegris/"


### PR DESCRIPTION
warning gocryptotrader-web@0.4.0: Potential typo "contributers", did you mean "contributors"?