### PR TITLE
fix(dockerfile) binary runned inside docker container cannot execute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN mv -vn config_example.json config.json \
  && mv /go/bin/linux_386 /go/bin/gocryptotrader
 
 FROM alpine:latest
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 COPY --from=build /go/bin/gocryptotrader /app/
 COPY --from=build /go/src/github.com/thrasher-/gocryptotrader/config.json /app/
 EXPOSE 9050


### PR DESCRIPTION
Error produced in logs is related to to missing CA-Certificates. This PR fixes that by updating the image packages and installing ca-certificates.