### PR TITLE
Fix Huobi's POST requests

### DIFF
--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -560,10 +560,15 @@ func (h *HUOBI) GetOrdersMatch(symbol, types, start, end, from, direct, size str
 
 // MarginTransfer transfers assets into or out of the margin account
 func (h *HUOBI) MarginTransfer(symbol, currency string, amount float64, in bool) (int64, error) {
-	vals := url.Values{}
-	vals.Set("symbol", symbol)
-	vals.Set("currency", currency)
-	vals.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
+	data := struct {
+		Symbol   string `json:"symbol"`
+		Currency string `json:"currency"`
+		Amount   string `json:"amount"`
+	}{
+		Symbol:   symbol,
+		Currency: currency,
+		Amount:   strconv.FormatFloat(amount, 'f', -1, 64),
+	}
 
 	path := huobiMarginTransferIn
 	if !in {
@@ -576,7 +581,7 @@ func (h *HUOBI) MarginTransfer(symbol, currency string, amount float64, in bool)
 	}
 
 	var result response
-	err := h.SendAuthenticatedHTTPRequest("POST", path, vals, nil, &result)
+	err := h.SendAuthenticatedHTTPRequest("POST", path, nil, data, &result)
 
 	if result.ErrorMessage != "" {
 		return 0, errors.New(result.ErrorMessage)
@@ -586,10 +591,15 @@ func (h *HUOBI) MarginTransfer(symbol, currency string, amount float64, in bool)
 
 // MarginOrder submits a margin order application
 func (h *HUOBI) MarginOrder(symbol, currency string, amount float64) (int64, error) {
-	vals := url.Values{}
-	vals.Set("symbol", symbol)
-	vals.Set("currency", currency)
-	vals.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
+	data := struct {
+		Symbol   string `json:"symbol"`
+		Currency string `json:"currency"`
+		Amount   string `json:"amount"`
+	}{
+		Symbol:   symbol,
+		Currency: currency,
+		Amount:   strconv.FormatFloat(amount, 'f', -1, 64),
+	}
 
 	type response struct {
 		Response
@@ -597,7 +607,7 @@ func (h *HUOBI) MarginOrder(symbol, currency string, amount float64) (int64, err
 	}
 
 	var result response
-	err := h.SendAuthenticatedHTTPRequest("POST", huobiMarginOrders, vals, nil, &result)
+	err := h.SendAuthenticatedHTTPRequest("POST", huobiMarginOrders, nil, data, &result)
 
 	if result.ErrorMessage != "" {
 		return 0, errors.New(result.ErrorMessage)
@@ -698,21 +708,28 @@ func (h *HUOBI) Withdraw(address, currency, addrTag string, amount, fee float64)
 		WithdrawID int64 `json:"data"`
 	}
 
-	vals := url.Values{}
-	vals.Set("address", address)
-	vals.Set("currency", currency)
-	vals.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
+	data := struct {
+		Address  string `json:"address"`
+		Amount   string `json:"amount"`
+		Currency string `json:"currency"`
+		Fee      string `json:"fee"`
+		AddrTag  string `json:"addr-tag"`
+	}{
+		Address:  address,
+		Currency: currency,
+		Amount:   strconv.FormatFloat(amount, 'f', -1, 64),
+	}
 
 	if fee != 0 {
-		vals.Set("fee", strconv.FormatFloat(fee, 'f', -1, 64))
+		data.Fee = strconv.FormatFloat(fee, 'f', -1, 64)
 	}
 
 	if currency == "XRP" {
-		vals.Set("addr-tag", addrTag)
+		data.AddrTag = addrTag
 	}
 
 	var result response
-	err := h.SendAuthenticatedHTTPRequest("POST", huobiWithdrawCreate, vals, nil, &result)
+	err := h.SendAuthenticatedHTTPRequest("POST", huobiWithdrawCreate, nil, data, &result)
 
 	if result.ErrorMessage != "" {
 		return 0, errors.New(result.ErrorMessage)

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -617,9 +617,11 @@ func (h *HUOBI) MarginOrder(symbol, currency string, amount float64) (int64, err
 
 // MarginRepayment repays a margin amount for a margin ID
 func (h *HUOBI) MarginRepayment(orderID int64, amount float64) (int64, error) {
-	vals := url.Values{}
-	vals.Set("order-id", strconv.FormatInt(orderID, 10))
-	vals.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
+	data := struct {
+		Amount string `json:"amount"`
+	}{
+		Amount: strconv.FormatFloat(amount, 'f', -1, 64),
+	}
 
 	type response struct {
 		Response
@@ -628,7 +630,7 @@ func (h *HUOBI) MarginRepayment(orderID int64, amount float64) (int64, error) {
 
 	var result response
 	endpoint := fmt.Sprintf(huobiMarginRepay, strconv.FormatInt(orderID, 10))
-	err := h.SendAuthenticatedHTTPRequest("POST", endpoint, vals, nil, &result)
+	err := h.SendAuthenticatedHTTPRequest("POST", endpoint, nil, data, &result)
 
 	if result.ErrorMessage != "" {
 		return 0, errors.New(result.ErrorMessage)

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -752,7 +753,12 @@ func (h *HUOBI) SendAuthenticatedHTTPRequest(method, endpoint string, values url
 		method, endpoint, values.Encode())
 
 	headers := make(map[string]string)
-	headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+	if method == http.MethodGet {
+		headers["Content-Type"] = "application/x-www-form-urlencoded"
+	} else {
+		headers["Content-Type"] = "application/json"
+	}
 
 	hmac := common.GetHMAC(common.HashSHA256, []byte(payload), []byte(h.APISecret))
 	signature := common.Base64Encode(hmac)


### PR DESCRIPTION
This PR fixes 2 things:

1) When sending in a POST request, we need to use a different "Content-Type" header (application/json).
2) We were sending in POST data via the query string, actually, we need to send it as json via the request body (we don't need to sign this data).