### PR TITLE
Exchange withdraw capabilities

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -135,6 +135,8 @@
    "httpTimeout": 15000000000,
    "httpUserAgent": "",
    "authenticatedApiSupport": false,
+   "apiWithdrawalSupport": true,
+   "automaticApiWithdrawlSupport": false,
    "apiKey": "Key",
    "apiSecret": "Secret",
    "apiUrl": "NON_DEFAULT_HTTP_LINK_TO_EXCHANGE_API",

--- a/config_example.json
+++ b/config_example.json
@@ -135,8 +135,6 @@
    "httpTimeout": 15000000000,
    "httpUserAgent": "",
    "authenticatedApiSupport": false,
-   "apiWithdrawalSupport": true,
-   "automaticApiWithdrawlSupport": false,
    "apiKey": "Key",
    "apiSecret": "Secret",
    "apiUrl": "NON_DEFAULT_HTTP_LINK_TO_EXCHANGE_API",

--- a/exchanges/alphapoint/alphapoint.go
+++ b/exchanges/alphapoint/alphapoint.go
@@ -55,6 +55,7 @@ func (a *Alphapoint) SetDefaults() {
 	a.AssetTypes = []string{ticker.Spot}
 	a.SupportsAutoPairUpdating = false
 	a.SupportsRESTTickerBatching = false
+	a.APIWithdrawPermissions = exchange.WithdrawCryptoWith2FA | exchange.AutoWithdrawCryptoWithAPIPermission
 	a.Requester = request.New(a.Name,
 		request.NewRateLimit(time.Minute*10, alphapointAuthRate),
 		request.NewRateLimit(time.Minute*10, alphapointUnauthRate),

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/common"
+	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
 
 const (
@@ -488,5 +489,18 @@ func TestGetOrderFee(t *testing.T) {
 	_, err := a.GetOrderFee("", "", 1, 1)
 	if err == nil {
 		t.Error("Test Failed - GetUserInfo() error")
+	}
+}
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	a := &Alphapoint{}
+	a.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.WithdrawCryptoWith2FAText
+	// Act
+	withdrawPermissions := a.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -501,6 +501,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := a.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -492,13 +492,13 @@ func TestGetOrderFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	a := &Alphapoint{}
 	a.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.WithdrawCryptoWith2FAText
 	// Act
-	withdrawPermissions := a.GetWithdrawPermissions()
+	withdrawPermissions := a.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -181,3 +181,8 @@ func (a *Alphapoint) GetWebsocket() (*exchange.Websocket, error) {
 func (a *Alphapoint) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return 0, errors.New("not yet implemented")
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (a *Alphapoint) GetWithdrawCapabilities() string {
+	return a.GetWithdrawPermissions()
+}

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -183,6 +183,6 @@ func (a *Alphapoint) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, erro
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (a *Alphapoint) GetWithdrawCapabilities() string {
+func (a *Alphapoint) GetWithdrawCapabilities() uint32 {
 	return a.GetWithdrawPermissions()
 }

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -50,8 +50,6 @@ func (a *ANX) SetDefaults() {
 	a.TakerFee = 0.02
 	a.MakerFee = 0.01
 	a.Verbose = false
-	a.APIWithdrawalPermission = false
-	a.AutomaticAPIWithdrawlSupport = false
 	a.RESTPollingDelay = 10
 	a.RequestCurrencyPairFormat.Delimiter = ""
 	a.RequestCurrencyPairFormat.Uppercase = true
@@ -403,7 +401,6 @@ func (a *ANX) SendAuthenticatedHTTPRequest(path string, params map[string]interf
 	return a.SendPayload("POST", a.APIUrl+path, headers, bytes.NewBuffer(PayloadJSON), result, true, a.Verbose)
 }
 
-
 // GetFee returns an estimate of fee based on type of transaction
 func (a *ANX) GetFee(feeBuilder exchange.FeeBuilder) (float64, error) {
 	var fee float64
@@ -434,11 +431,6 @@ func (a *ANX) calculateTradingFee(purchasePrice, amount float64, isMaker bool) f
 	return fee
 }
 
-
-
-
-
-
 func getCryptocurrencyWithdrawalFee(currency string) float64 {
 	return WithdrawalFees[currency]
 }
@@ -453,6 +445,7 @@ func getInternationalBankWithdrawalFee(currency string, amount float64) float64 
 	return fee
 }
 
+// GetAccountInformation retrieves details including API permissions
 func (a *ANX) GetAccountInformation() (AccountInformation, error) {
 	request := make(map[string]interface{})
 
@@ -471,6 +464,7 @@ func (a *ANX) GetAccountInformation() (AccountInformation, error) {
 	return response, nil
 }
 
+// CheckAPIWithdrawPermission checks if the API key is allowed to withdraw
 func (a *ANX) CheckAPIWithdrawPermission() (bool, error) {
 	accountInfo, err := a.GetAccountInformation()
 	if err != nil {

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -57,6 +57,8 @@ func (a *ANX) SetDefaults() {
 	a.ConfigCurrencyPairFormat.Delimiter = "_"
 	a.ConfigCurrencyPairFormat.Uppercase = true
 	a.ConfigCurrencyPairFormat.Index = ""
+	a.APIWithdrawPermissions = exchange.WithdrawCryptoWithEmail | exchange.AutoWithdrawCryptoWithSetup | exchange.WithdrawCryptoWith2FA |
+		exchange.AutoWithdrawFiatWithSetup | exchange.WithdrawFiatWith2FA | exchange.WithdrawFiatWithEmail
 	a.AssetTypes = []string{ticker.Spot}
 	a.SupportsAutoPairUpdating = true
 	a.SupportsRESTTickerBatching = false

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -57,8 +57,8 @@ func (a *ANX) SetDefaults() {
 	a.ConfigCurrencyPairFormat.Delimiter = "_"
 	a.ConfigCurrencyPairFormat.Uppercase = true
 	a.ConfigCurrencyPairFormat.Index = ""
-	a.APIWithdrawPermissions = exchange.WithdrawCryptoWithEmail | exchange.AutoWithdrawCryptoWithSetup | exchange.WithdrawCryptoWith2FA |
-		exchange.AutoWithdrawFiatWithSetup | exchange.WithdrawFiatWith2FA | exchange.WithdrawFiatWithEmail
+	a.APIWithdrawPermissions = exchange.WithdrawCryptoWithEmail | exchange.AutoWithdrawCryptoWithSetup |
+		exchange.WithdrawCryptoWith2FA | exchange.WithdrawFiatViaWebsiteOnly
 	a.AssetTypes = []string{ticker.Spot}
 	a.SupportsAutoPairUpdating = true
 	a.SupportsRESTTickerBatching = false

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -469,15 +469,22 @@ func (a *ANX) GetAccountInformation() (AccountInformation, error) {
 // CheckAPIWithdrawPermission checks if the API key is allowed to withdraw
 func (a *ANX) CheckAPIWithdrawPermission() (bool, error) {
 	accountInfo, err := a.GetAccountInformation()
+
 	if err != nil {
 		return false, err
 	}
+
 	var apiAllowsWithdraw bool
+
 	for _, a := range accountInfo.Rights {
 		if a == "withdraw" {
-			log.Printf("API key is missing withdrawal permissions")
 			apiAllowsWithdraw = true
 		}
 	}
+
+	if !apiAllowsWithdraw {
+		log.Printf("API key is missing withdrawal permissions")
+	}
+
 	return apiAllowsWithdraw, nil
 }

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -208,13 +208,13 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	a.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawCryptoWith2FAText + " & " +
 		exchange.WithdrawCryptoWithEmailText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := a.GetWithdrawPermissions()
+	withdrawPermissions := a.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -207,3 +207,16 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	a.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawCryptoWith2FAText + " & " +
+		exchange.WithdrawCryptoWithEmailText + " & " + exchange.AutoWithdrawFiatWithSetupText + " & " + exchange.WithdrawFiatWith2FAText + " & " + exchange.WithdrawFiatWithEmailText
+	// Act
+	withdrawPermissions := a.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -212,11 +212,11 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
 	a.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawCryptoWith2FAText + " & " +
-		exchange.WithdrawCryptoWithEmailText + " & " + exchange.AutoWithdrawFiatWithSetupText + " & " + exchange.WithdrawFiatWith2FAText + " & " + exchange.WithdrawFiatWithEmailText
+		exchange.WithdrawCryptoWithEmailText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
 	withdrawPermissions := a.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/anx/anx_types.go
+++ b/exchanges/anx/anx_types.go
@@ -57,6 +57,29 @@ type CurrencyPair struct {
 	SimpleTradeEnabled   bool    `json:"simpleTradeEnabled"`
 }
 
+// AccountInformation Used by Get account information
+// Retrieves details of the account and api's
+type AccountInformation struct {
+	UserUUID   string   `json:"userUuid"`
+	Rights     []string `json:"Rights"`
+	ResultCode string   `json:"resultCode"`
+	Wallets    struct {
+		Balance              Amount `json:"Balance"`
+		AvailableBalance     Amount `json:"Available_Balance"`
+		DailyWithdrawalLimit Amount `json:"Daily_Withdrawal_Limit"`
+		MaxWithdraw          Amount `json:"Max_Withdraw"`
+	}
+}
+
+// Amount basic storage of wallet details
+type Amount struct {
+	DisplayShort string  `json:"displayShort"`
+	ValueInt     int64   `json:"valueInt"`
+	Currency     string  `json:"currency"`
+	Display      string  `json:"display"`
+	Value        float64 `json:"value"`
+}
+
 // CurrencyPairs stores currency pair info
 type CurrencyPairs map[string]CurrencyPair
 

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -256,6 +256,6 @@ func (a *ANX) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (a *ANX) GetWithdrawCapabilities() string {
+func (a *ANX) GetWithdrawCapabilities() uint32 {
 	return a.GetWithdrawPermissions()
 }

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -254,3 +254,8 @@ func (a *ANX) GetWebsocket() (*exchange.Websocket, error) {
 func (a *ANX) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return a.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (a *ANX) GetWithdrawCapabilities() string {
+	return a.GetWithdrawPermissions()
+}

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -69,6 +69,7 @@ func (b *Binance) SetDefaults() {
 	b.AssetTypes = []string{ticker.Spot}
 	b.SupportsAutoPairUpdating = true
 	b.SupportsRESTTickerBatching = true
+	b.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
 	b.SetValues()
 	b.Requester = request.New(b.Name,
 		request.NewRateLimit(time.Second, binanceAuthRate),

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -69,7 +69,7 @@ func (b *Binance) SetDefaults() {
 	b.AssetTypes = []string{ticker.Spot}
 	b.SupportsAutoPairUpdating = true
 	b.SupportsRESTTickerBatching = true
-	b.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
+	b.APIWithdrawPermissions = exchange.AutoWithdrawCrypto
 	b.SetValues()
 	b.Requester = request.New(b.Name,
 		request.NewRateLimit(time.Second, binanceAuthRate),

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -316,3 +316,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -320,11 +320,11 @@ func TestGetFee(t *testing.T) {
 func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
-	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	expectedResult := exchange.AutoWithdrawCryptoText
 	// Act
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -317,12 +317,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -201,6 +201,6 @@ func (b *Binance) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) 
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *Binance) GetWithdrawCapabilities() string {
+func (b *Binance) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -199,3 +199,8 @@ func (b *Binance) GetWebsocket() (*exchange.Websocket, error) {
 func (b *Binance) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return b.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *Binance) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
+}

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -93,6 +93,7 @@ func (b *Bitfinex) SetDefaults() {
 	b.Verbose = false
 	b.RESTPollingDelay = 10
 	b.WebsocketSubdChannels = make(map[int]WebsocketChanInfo)
+	b.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission | exchange.AutoWithdrawFiatWithAPIPermission
 	b.RequestCurrencyPairFormat.Delimiter = ""
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -715,6 +715,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -707,12 +707,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawFiatWithAPIPermissionText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -706,3 +706,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawFiatWithAPIPermissionText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -231,3 +231,8 @@ func (b *Bitfinex) GetWebsocket() (*exchange.Websocket, error) {
 func (b *Bitfinex) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return b.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *Bitfinex) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
+}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -233,6 +233,6 @@ func (b *Bitfinex) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error)
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *Bitfinex) GetWithdrawCapabilities() string {
+func (b *Bitfinex) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/bitflyer/bitflyer.go
+++ b/exchanges/bitflyer/bitflyer.go
@@ -81,6 +81,7 @@ func (b *Bitflyer) SetDefaults() {
 	b.Enabled = false
 	b.Verbose = false
 	b.RESTPollingDelay = 10
+	b.APIWithdrawPermissions = exchange.WithdrawCryptoViaWebsiteOnly | exchange.AutoWithdrawFiat
 	b.RequestCurrencyPairFormat.Delimiter = "_"
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = "_"

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -235,12 +235,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.AutoWithdrawFiatText + " & " + exchange.WithdrawCryptoViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -243,6 +243,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -183,7 +183,6 @@ func TestGetFee(t *testing.T) {
 			t.Error(err)
 		}
 
-
 		// CryptocurrencyTradeFee IsMaker
 		feeBuilder = setFeeBuilder()
 		feeBuilder.IsMaker = true
@@ -233,5 +232,17 @@ func TestGetFee(t *testing.T) {
 	if resp, err := b.GetFee(feeBuilder); resp != float64(540) || err != nil {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(540), resp)
 		t.Error(err)
+	}
+}
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.AutoWithdrawFiatText + " & " + exchange.WithdrawCryptoViaWebsiteOnlyText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -206,3 +206,14 @@ func (b *Bitflyer) WithdrawFiatExchangeFundsToInternationalBank(currency pair.Cu
 func (b *Bitflyer) GetWebsocket() (*exchange.Websocket, error) {
 	return nil, errors.New("not yet implemented")
 }
+
+// CanAutomaticallyWithdrawViaAPI checks if the exchange can withdraw without any additional verificantion
+// eg 2FA, email confirmation
+func (b *Bitflyer) CanAutomaticallyWithdrawViaAPI() (bool, error) {
+	return false, errors.New("not yet implemented")
+}
+
+// CanWithdrawViaAPI checks the permissions on the API keys to verify it can withdraw
+func (b *Bitflyer) CanWithdrawViaAPI() (bool, error) {
+	return false, errors.New("not yet implemented")
+}

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -208,6 +208,6 @@ func (b *Bitflyer) GetWebsocket() (*exchange.Websocket, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *Bitflyer) GetWithdrawCapabilities() string {
+func (b *Bitflyer) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -207,13 +207,7 @@ func (b *Bitflyer) GetWebsocket() (*exchange.Websocket, error) {
 	return nil, errors.New("not yet implemented")
 }
 
-// CanAutomaticallyWithdrawViaAPI checks if the exchange can withdraw without any additional verificantion
-// eg 2FA, email confirmation
-func (b *Bitflyer) CanAutomaticallyWithdrawViaAPI() (bool, error) {
-	return false, errors.New("not yet implemented")
-}
-
-// CanWithdrawViaAPI checks the permissions on the API keys to verify it can withdraw
-func (b *Bitflyer) CanWithdrawViaAPI() (bool, error) {
-	return false, errors.New("not yet implemented")
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *Bitflyer) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
 }

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -62,6 +62,7 @@ func (b *Bithumb) SetDefaults() {
 	b.Enabled = false
 	b.Verbose = false
 	b.RESTPollingDelay = 10
+	b.APIWithdrawPermissions = exchange.AutoWithdrawCrypto | exchange.AutoWithdrawFiat
 	b.RequestCurrencyPairFormat.Delimiter = ""
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -219,7 +219,6 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 
-
 	// CryptocurrencyTradeFee IsMaker
 	feeBuilder = setFeeBuilder()
 	feeBuilder.IsMaker = true
@@ -268,5 +267,17 @@ func TestGetFee(t *testing.T) {
 	if resp, err := b.GetFee(feeBuilder); resp != float64(0) || err != nil {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(0), resp)
 		t.Error(err)
+	}
+}
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.AutoWithdrawFiatText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -270,12 +270,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.AutoWithdrawFiatText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -278,6 +278,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -198,3 +198,8 @@ func (b *Bithumb) GetWebsocket() (*exchange.Websocket, error) {
 func (b *Bithumb) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return b.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *Bithumb) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
+}

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -200,6 +200,6 @@ func (b *Bithumb) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) 
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *Bithumb) GetWithdrawCapabilities() string {
+func (b *Bithumb) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -114,6 +114,7 @@ func (b *Bitmex) SetDefaults() {
 	b.Enabled = false
 	b.Verbose = false
 	b.RESTPollingDelay = 10
+	b.APIWithdrawPermissions = exchange.WithdrawCryptoWithAPIPermission | exchange.WithdrawCryptoWithEmail | exchange.WithdrawCryptoWith2FA
 	b.RequestCurrencyPairFormat.Delimiter = ""
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -114,7 +114,7 @@ func (b *Bitmex) SetDefaults() {
 	b.Enabled = false
 	b.Verbose = false
 	b.RESTPollingDelay = 10
-	b.APIWithdrawPermissions = exchange.WithdrawCryptoWithAPIPermission | exchange.WithdrawCryptoWithEmail | exchange.WithdrawCryptoWith2FA
+	b.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission | exchange.WithdrawCryptoWithEmail | exchange.WithdrawCryptoWith2FA
 	b.RequestCurrencyPairFormat.Delimiter = ""
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -453,11 +453,11 @@ func TestGetFee(t *testing.T) {
 func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
-	expectedResult := exchange.WithdrawCryptoWith2FAText + " & " + exchange.WithdrawCryptoWithEmailText + " & " + exchange.WithdrawCryptoWithAPIPermissionText
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.WithdrawCryptoWith2FAText + " & " + exchange.WithdrawCryptoWithEmailText
 	// Act
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -449,3 +449,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.WithdrawCryptoWith2FAText + " & " + exchange.WithdrawCryptoWithEmailText + " & " + exchange.WithdrawCryptoWithAPIPermissionText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -450,12 +450,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.WithdrawCryptoWith2FAText + " & " + exchange.WithdrawCryptoWithEmailText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -202,3 +202,8 @@ func (b *Bitmex) GetWebsocket() (*exchange.Websocket, error) {
 func (b *Bitmex) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return b.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *Bitmex) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
+}

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -204,6 +204,6 @@ func (b *Bitmex) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *Bitmex) GetWithdrawCapabilities() string {
+func (b *Bitmex) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -67,6 +67,7 @@ func (b *Bitstamp) SetDefaults() {
 	b.Enabled = false
 	b.Verbose = false
 	b.RESTPollingDelay = 10
+	b.APIWithdrawPermissions = exchange.AutoWithdrawCrypto | exchange.AutoWithdrawFiat
 	b.RequestCurrencyPairFormat.Delimiter = ""
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -343,6 +343,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -335,12 +335,12 @@ func TestTransferAccountBalance(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.AutoWithdrawFiatText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -334,3 +334,15 @@ func TestTransferAccountBalance(t *testing.T) {
 		t.Error("Test Failed - TransferAccountBalance() error", err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.AutoWithdrawFiatText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -218,3 +218,14 @@ func (b *Bitstamp) WithdrawFiatExchangeFundsToInternationalBank(currency pair.Cu
 func (b *Bitstamp) GetWebsocket() (*exchange.Websocket, error) {
 	return b.Websocket, nil
 }
+
+// CanAutomaticallyWithdrawViaAPI checks if the exchange can withdraw without any additional verificantion
+// eg 2FA, email confirmation
+func (b *Bitstamp) CanAutomaticallyWithdrawViaAPI() (bool, error) {
+	return false, errors.New("not yet implemented")
+}
+
+// CanWithdrawViaAPI checks the permissions on the API keys to verify it can withdraw
+func (b *Bitstamp) CanWithdrawViaAPI() (bool, error) {
+	return false, errors.New("not yet implemented")
+}

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -220,6 +220,6 @@ func (b *Bitstamp) GetWebsocket() (*exchange.Websocket, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *Bitstamp) GetWithdrawCapabilities() string {
+func (b *Bitstamp) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -219,13 +219,7 @@ func (b *Bitstamp) GetWebsocket() (*exchange.Websocket, error) {
 	return b.Websocket, nil
 }
 
-// CanAutomaticallyWithdrawViaAPI checks if the exchange can withdraw without any additional verificantion
-// eg 2FA, email confirmation
-func (b *Bitstamp) CanAutomaticallyWithdrawViaAPI() (bool, error) {
-	return false, errors.New("not yet implemented")
-}
-
-// CanWithdrawViaAPI checks the permissions on the API keys to verify it can withdraw
-func (b *Bitstamp) CanWithdrawViaAPI() (bool, error) {
-	return false, errors.New("not yet implemented")
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *Bitstamp) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
 }

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -68,6 +68,7 @@ func (b *Bittrex) SetDefaults() {
 	b.Enabled = false
 	b.Verbose = false
 	b.RESTPollingDelay = 10
+	b.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission
 	b.RequestCurrencyPairFormat.Delimiter = "-"
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = "-"

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -316,12 +316,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -324,6 +324,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -315,3 +315,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -230,6 +230,6 @@ func (b *Bittrex) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) 
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *Bittrex) GetWithdrawCapabilities() string {
+func (b *Bittrex) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -228,3 +228,8 @@ func (b *Bittrex) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) 
 	return b.GetFee(feeBuilder)
 
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *Bittrex) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
+}

--- a/exchanges/btcc/btcc.go
+++ b/exchanges/btcc/btcc.go
@@ -32,6 +32,7 @@ func (b *BTCC) SetDefaults() {
 	b.Fee = 0
 	b.Verbose = false
 	b.RESTPollingDelay = 10
+	b.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
 	b.RequestCurrencyPairFormat.Delimiter = ""
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = ""
@@ -92,8 +93,6 @@ func (b *BTCC) Setup(exch config.ExchangeConfig) {
 		}
 	}
 }
-
-
 
 // GetFee returns an estimate of fee based on type of transaction
 func (b *BTCC) GetFee(feeBuilder exchange.FeeBuilder) (float64, error) {

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -165,6 +165,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -157,12 +157,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.NoAPIWithdrawalMethodsText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -156,3 +156,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -211,6 +211,6 @@ func (b *BTCC) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *BTCC) GetWithdrawCapabilities() string {
+func (b *BTCC) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -209,3 +209,8 @@ func (b *BTCC) GetWebsocket() (*exchange.Websocket, error) {
 func (b *BTCC) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return b.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *BTCC) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
+}

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -58,6 +58,7 @@ func (b *BTCMarkets) SetDefaults() {
 	b.Verbose = false
 	b.RESTPollingDelay = 10
 	b.Ticker = make(map[string]Ticker)
+	b.APIWithdrawPermissions = exchange.AutoWithdrawCrypto | exchange.AutoWithdrawFiat
 	b.RequestCurrencyPairFormat.Delimiter = ""
 	b.RequestCurrencyPairFormat.Uppercase = true
 	b.ConfigCurrencyPairFormat.Delimiter = "-"

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -296,3 +296,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.AutoWithdrawFiatText
+	// Act
+	withdrawPermissions := b.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -305,6 +305,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := b.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -297,12 +297,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	b.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.AutoWithdrawFiatText
 	// Act
-	withdrawPermissions := b.GetWithdrawPermissions()
+	withdrawPermissions := b.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -260,3 +260,8 @@ func (b *BTCMarkets) GetWebsocket() (*exchange.Websocket, error) {
 func (b *BTCMarkets) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return b.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (b *BTCMarkets) GetWithdrawCapabilities() string {
+	return b.GetWithdrawPermissions()
+}

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -262,6 +262,6 @@ func (b *BTCMarkets) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, erro
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (b *BTCMarkets) GetWithdrawCapabilities() string {
+func (b *BTCMarkets) GetWithdrawCapabilities() uint32 {
 	return b.GetWithdrawPermissions()
 }

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -70,6 +70,7 @@ func (c *CoinbasePro) SetDefaults() {
 	c.TakerFee = 0.25
 	c.MakerFee = 0
 	c.RESTPollingDelay = 10
+	c.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission | exchange.AutoWithdrawFiatWithAPIPermission
 	c.RequestCurrencyPairFormat.Delimiter = "-"
 	c.RequestCurrencyPairFormat.Uppercase = true
 	c.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -399,6 +399,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := c.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -391,12 +391,12 @@ func TestCalculateTradingFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	c.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawFiatWithAPIPermissionText
 	// Act
-	withdrawPermissions := c.GetWithdrawPermissions()
+	withdrawPermissions := c.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -390,3 +390,15 @@ func TestCalculateTradingFee(t *testing.T) {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(0), resp)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	c.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawFiatWithAPIPermissionText
+	// Act
+	withdrawPermissions := c.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -198,6 +198,6 @@ func (c *CoinbasePro) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, err
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (c *CoinbasePro) GetWithdrawCapabilities() string {
+func (c *CoinbasePro) GetWithdrawCapabilities() uint32 {
 	return c.GetWithdrawPermissions()
 }

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -196,3 +196,8 @@ func (c *CoinbasePro) GetWebsocket() (*exchange.Websocket, error) {
 func (c *CoinbasePro) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return c.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (c *CoinbasePro) GetWithdrawCapabilities() string {
+	return c.GetWithdrawPermissions()
+}

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -56,6 +56,7 @@ func (c *COINUT) SetDefaults() {
 	c.MakerFee = 0
 	c.Verbose = false
 	c.RESTPollingDelay = 10
+	c.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
 	c.RequestCurrencyPairFormat.Delimiter = ""
 	c.RequestCurrencyPairFormat.Uppercase = true
 	c.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -56,7 +56,7 @@ func (c *COINUT) SetDefaults() {
 	c.MakerFee = 0
 	c.Verbose = false
 	c.RESTPollingDelay = 10
-	c.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
+	c.APIWithdrawPermissions = exchange.WithdrawCryptoViaWebsiteOnly | exchange.WithdrawFiatViaWebsiteOnly
 	c.RequestCurrencyPairFormat.Delimiter = ""
 	c.RequestCurrencyPairFormat.Uppercase = true
 	c.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -178,11 +178,11 @@ func TestGetFee(t *testing.T) {
 func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
 	c.SetDefaults()
-	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	expectedResult := exchange.WithdrawCryptoViaWebsiteOnlyText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
 	withdrawPermissions := c.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -174,3 +174,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	c.SetDefaults()
+	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	// Act
+	withdrawPermissions := c.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -175,12 +175,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	c.SetDefaults()
 	expectedResult := exchange.WithdrawCryptoViaWebsiteOnlyText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := c.GetWithdrawPermissions()
+	withdrawPermissions := c.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -199,3 +199,8 @@ func (c *COINUT) GetWebsocket() (*exchange.Websocket, error) {
 func (c *COINUT) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return c.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (c *COINUT) GetWithdrawCapabilities() string {
+	return c.GetWithdrawPermissions()
+}

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -201,6 +201,6 @@ func (c *COINUT) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (c *COINUT) GetWithdrawCapabilities() string {
+func (c *COINUT) GetWithdrawCapabilities() uint32 {
 	return c.GetWithdrawPermissions()
 }

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -86,42 +86,42 @@ type FeeBuilder struct {
 // Definitions for each type of withdrawal method for a given exchange
 const (
 	// No withdraw
-	NoAPIWithdrawalMethods                  uint64 = 0
+	NoAPIWithdrawalMethods                  uint32 = 0
 	NoAPIWithdrawalMethodsText              string = "NONE, WEBSITE ONLY"
-	AutoWithdrawCrypto                      uint64 = (1 << 0)
-	AutoWithdrawCryptoWithAPIPermission     uint64 = (1 << 1)
-	AutoWithdrawCryptoWithSetup             uint64 = (1 << 2)
+	AutoWithdrawCrypto                      uint32 = (1 << 0)
+	AutoWithdrawCryptoWithAPIPermission     uint32 = (1 << 1)
+	AutoWithdrawCryptoWithSetup             uint32 = (1 << 2)
 	AutoWithdrawCryptoText                  string = "AUTO WITHDRAW CRYPTO"
 	AutoWithdrawCryptoWithAPIPermissionText string = "AUTO WITHDRAW CRYPTO WITH API PERMISSION"
 	AutoWithdrawCryptoWithSetupText         string = "AUTO WITHDRAW CRYPTO WITH SETUP"
-	WithdrawCryptoWith2FA                   uint64 = (1 << 3)
-	WithdrawCryptoWithSMS                   uint64 = (1 << 4)
-	WithdrawCryptoWithEmail                 uint64 = (1 << 5)
-	WithdrawCryptoWithWebsiteApproval       uint64 = (1 << 6)
-	WithdrawCryptoWithAPIPermission         uint64 = (1 << 7)
+	WithdrawCryptoWith2FA                   uint32 = (1 << 3)
+	WithdrawCryptoWithSMS                   uint32 = (1 << 4)
+	WithdrawCryptoWithEmail                 uint32 = (1 << 5)
+	WithdrawCryptoWithWebsiteApproval       uint32 = (1 << 6)
+	WithdrawCryptoWithAPIPermission         uint32 = (1 << 7)
 	WithdrawCryptoWith2FAText               string = "WITHDRAW CRYPTO WITH 2FA"
 	WithdrawCryptoWithSMSText               string = "WITHDRAW CRYPTO WITH SMS"
 	WithdrawCryptoWithEmailText             string = "WITHDRAW CRYPTO WITH EMAIL"
 	WithdrawCryptoWithWebsiteApprovalText   string = "WITHDRAW CRYPTO WITH WEBSITE APPROVAL"
 	WithdrawCryptoWithAPIPermissionText     string = "WITHDRAW CRYPTO WITH API PERMISSION"
-	AutoWithdrawFiat                        uint64 = (1 << 8)
-	AutoWithdrawFiatWithAPIPermission       uint64 = (1 << 9)
-	AutoWithdrawFiatWithSetup               uint64 = (1 << 10)
+	AutoWithdrawFiat                        uint32 = (1 << 8)
+	AutoWithdrawFiatWithAPIPermission       uint32 = (1 << 9)
+	AutoWithdrawFiatWithSetup               uint32 = (1 << 10)
 	AutoWithdrawFiatText                    string = "AUTO WITHDRAW FIAT"
 	AutoWithdrawFiatWithAPIPermissionText   string = "AUTO WITHDRAW FIAT WITH API PERMISSION"
 	AutoWithdrawFiatWithSetupText           string = "AUTO WITHDRAW FIAT WITH SETUP"
-	WithdrawFiatWith2FA                     uint64 = (1 << 11)
-	WithdrawFiatWithSMS                     uint64 = (1 << 12)
-	WithdrawFiatWithEmail                   uint64 = (1 << 13)
-	WithdrawFiatWithWebsiteApproval         uint64 = (1 << 14)
-	WithdrawFiatWithAPIPermission           uint64 = (1 << 15)
+	WithdrawFiatWith2FA                     uint32 = (1 << 11)
+	WithdrawFiatWithSMS                     uint32 = (1 << 12)
+	WithdrawFiatWithEmail                   uint32 = (1 << 13)
+	WithdrawFiatWithWebsiteApproval         uint32 = (1 << 14)
+	WithdrawFiatWithAPIPermission           uint32 = (1 << 15)
 	WithdrawFiatWith2FAText                 string = "WITHDRAW FIAT WITH 2FA"
 	WithdrawFiatWithSMSText                 string = "WITHDRAW FIAT WITH SMS"
 	WithdrawFiatWithEmailText               string = "WITHDRAW FIAT WITH EMAIL"
 	WithdrawFiatWithWebsiteApprovalText     string = "WITHDRAW FIAT WITH WEBSITE APPROVAL"
 	WithdrawFiatWithAPIPermissionText       string = "WITHDRAW FIAT WITH API PERMISSION"
-	WithdrawCryptoViaWebsiteOnly            uint64 = (1 << 16)
-	WithdrawFiatViaWebsiteOnly              uint64 = (1 << 17)
+	WithdrawCryptoViaWebsiteOnly            uint32 = (1 << 16)
+	WithdrawFiatViaWebsiteOnly              uint32 = (1 << 17)
 	WithdrawCryptoViaWebsiteOnlyText        string = "WITHDRAW CRYPTO VIA WEBSITE ONLY"
 	WithdrawFiatViaWebsiteOnlyText          string = "WITHDRAW FIAT VIA WEBSITE ONLY"
 
@@ -192,7 +192,7 @@ type Base struct {
 	Verbose                                    bool
 	RESTPollingDelay                           time.Duration
 	AuthenticatedAPISupport                    bool
-	APIWithdrawPermissions                     uint64
+	APIWithdrawPermissions                     uint32
 	APIAuthPEMKeySupport                       bool
 	APISecret, APIKey, APIAuthPEMKey, ClientID string
 	Nonce                                      nonce.Nonce
@@ -823,8 +823,8 @@ func (e *Base) GetAPIURLSecondaryDefault() string {
 // GetWithdrawPermissions will return each of the exchange's compatible withdrawal methods
 func (e *Base) GetWithdrawPermissions() string {
 	services := []string{}
-	for i := 0; i < 8; i++ {
-		var check uint64 = 1 << uint64(i)
+	for i := 0; i < 32; i++ {
+		var check uint32 = 1 << uint32(i)
 		if e.APIWithdrawPermissions&check != 0 {
 			switch check {
 			case AutoWithdrawCrypto:

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -832,7 +832,7 @@ func (e *Base) GetWithdrawPermissions() uint32 {
 // SupportsWithdrawPermissions compares the supplied permissions with the exchange's to verify they're supported
 func (e *Base) SupportsWithdrawPermissions(permissions uint32) bool {
 	exchangePermissions := e.GetWithdrawPermissions()
-	if permissions&exchangePermissions == exchangePermissions {
+	if permissions&exchangePermissions == permissions {
 		return true
 	}
 	return false

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -86,37 +86,46 @@ type FeeBuilder struct {
 // Definitions for each type of withdrawal method for a given exchange
 const (
 	// No withdraw
-	NoWithdrawalMethods                   uint64 = 0
-	NoWithdrawalMethodsText               string = "NONE"
-	AutoWithdrawCrypto                    uint64 = (1 << 0)
-	AutoWithdrawCryptoWithPermission      uint64 = (1 << 1)
-	AutoWithdrawCryptoWithSetup           uint64 = (1 << 2)
-	AutoWithdrawCryptoText                string = "AUTO WITHDRAW CRYPTO"
-	AutoWithdrawCryptoWithPermissionText  string = "AUTO WITHDRAW CRYPTO WITH PERMISSION"
-	AutoWithdrawCryptoWithSetupText       string = "AUTO WITHDRAW CRYPTO WITH SETUP"
-	WithdrawCryptoWith2FA                 uint64 = (1 << 3)
-	WithdrawCryptoWithSMS                 uint64 = (1 << 4)
-	WithdrawCryptoWithEmail               uint64 = (1 << 5)
-	WithdrawCryptoWithWebsiteApproval     uint64 = (1 << 6)
-	WithdrawCryptoWith2FAText             string = "WITHDRAW CRYPTO WITH 2FA"
-	WithdrawCryptoWithSMSText             string = "WITHDRAW CRYPTO WITH SMS"
-	WithdrawCryptoWithEmailText           string = "WITHDRAW CRYPTO WITH EMAIL"
-	WithdrawCryptoWithWebsiteApprovalText string = "WITHDRAW CRYPTO WITH WEBSITE APPROVAL"
-	AutoWithdrawFiat                      uint64 = (1 << 7)
-	AutoWithdrawFiatWithPermission        uint64 = (1 << 8)
-	AutoWithdrawFiatWithSetup             uint64 = (1 << 9)
-	AutoWithdrawFiatText                  string = "AUTO WITHDRAW FIAT"
-	AutoWithdrawFiatWithPermissionText    string = "AUTO WITHDRAW FIAT WITH PERMISSION"
-	AutoWithdrawFiatWithSetupText         string = "AUTO WITHDRAW FIAT WITH SETUP"
-	WithdrawFiatWith2FA                   uint64 = (1 << 10)
-	WithdrawFiatWithSMS                   uint64 = (1 << 11)
-	WithdrawFiatWithEmail                 uint64 = (1 << 12)
-	WithdrawFiatWithWebsiteApproval       uint64 = (1 << 13)
-	WithdrawFiatWith2FAText               string = "WITHDRAW FIAT WITH 2FA"
-	WithdrawFiatWithSMSText               string = "WITHDRAW FIAT WITH SMS"
-	WithdrawFiatWithEmailText             string = "WITHDRAW FIAT WITH EMAIL"
-	WithdrawFiatWithWebsiteApprovalText   string = "WITHDRAW FIAT WITH WEBSITE APPROVAL"
-	UnknownWithdrawalTypeText             string = "UNKNOWN"
+	NoAPIWithdrawalMethods                  uint64 = 0
+	NoAPIWithdrawalMethodsText              string = "NONE, WEBSITE ONLY"
+	AutoWithdrawCrypto                      uint64 = (1 << 0)
+	AutoWithdrawCryptoWithAPIPermission     uint64 = (1 << 1)
+	AutoWithdrawCryptoWithSetup             uint64 = (1 << 2)
+	AutoWithdrawCryptoText                  string = "AUTO WITHDRAW CRYPTO"
+	AutoWithdrawCryptoWithAPIPermissionText string = "AUTO WITHDRAW CRYPTO WITH API PERMISSION"
+	AutoWithdrawCryptoWithSetupText         string = "AUTO WITHDRAW CRYPTO WITH SETUP"
+	WithdrawCryptoWith2FA                   uint64 = (1 << 3)
+	WithdrawCryptoWithSMS                   uint64 = (1 << 4)
+	WithdrawCryptoWithEmail                 uint64 = (1 << 5)
+	WithdrawCryptoWithWebsiteApproval       uint64 = (1 << 6)
+	WithdrawCryptoWithAPIPermission         uint64 = (1 << 7)
+	WithdrawCryptoWith2FAText               string = "WITHDRAW CRYPTO WITH 2FA"
+	WithdrawCryptoWithSMSText               string = "WITHDRAW CRYPTO WITH SMS"
+	WithdrawCryptoWithEmailText             string = "WITHDRAW CRYPTO WITH EMAIL"
+	WithdrawCryptoWithWebsiteApprovalText   string = "WITHDRAW CRYPTO WITH WEBSITE APPROVAL"
+	WithdrawCryptoWithAPIPermissionText     string = "WITHDRAW CRYPTO WITH API PERMISSION"
+	AutoWithdrawFiat                        uint64 = (1 << 8)
+	AutoWithdrawFiatWithAPIPermission       uint64 = (1 << 9)
+	AutoWithdrawFiatWithSetup               uint64 = (1 << 10)
+	AutoWithdrawFiatText                    string = "AUTO WITHDRAW FIAT"
+	AutoWithdrawFiatWithAPIPermissionText   string = "AUTO WITHDRAW FIAT WITH API PERMISSION"
+	AutoWithdrawFiatWithSetupText           string = "AUTO WITHDRAW FIAT WITH SETUP"
+	WithdrawFiatWith2FA                     uint64 = (1 << 11)
+	WithdrawFiatWithSMS                     uint64 = (1 << 12)
+	WithdrawFiatWithEmail                   uint64 = (1 << 13)
+	WithdrawFiatWithWebsiteApproval         uint64 = (1 << 14)
+	WithdrawFiatWithAPIPermission           uint64 = (1 << 15)
+	WithdrawFiatWith2FAText                 string = "WITHDRAW FIAT WITH 2FA"
+	WithdrawFiatWithSMSText                 string = "WITHDRAW FIAT WITH SMS"
+	WithdrawFiatWithEmailText               string = "WITHDRAW FIAT WITH EMAIL"
+	WithdrawFiatWithWebsiteApprovalText     string = "WITHDRAW FIAT WITH WEBSITE APPROVAL"
+	WithdrawFiatWithAPIPermissionText       string = "WITHDRAW FIAT WITH API PERMISSION"
+	WithdrawCryptoViaWebsiteOnly            uint64 = (1 << 16)
+	WithdrawFiatViaWebsiteOnly              uint64 = (1 << 17)
+	WithdrawCryptoViaWebsiteOnlyText        string = "WITHDRAW CRYPTO VIA WEBSITE ONLY"
+	WithdrawFiatViaWebsiteOnlyText          string = "WITHDRAW FIAT VIA WEBSITE ONLY"
+
+	UnknownWithdrawalTypeText string = "UNKNOWN"
 )
 
 // AccountInfo is a Generic type to hold each exchange's holdings in
@@ -821,8 +830,8 @@ func (e *Base) GetWithdrawPermissions() string {
 			case AutoWithdrawCrypto:
 				services = append(services, AutoWithdrawCryptoText)
 				break
-			case AutoWithdrawCryptoWithPermission:
-				services = append(services, AutoWithdrawCryptoWithPermissionText)
+			case AutoWithdrawCryptoWithAPIPermission:
+				services = append(services, AutoWithdrawCryptoWithAPIPermissionText)
 				break
 			case AutoWithdrawCryptoWithSetup:
 				services = append(services, AutoWithdrawCryptoWithSetupText)
@@ -839,11 +848,14 @@ func (e *Base) GetWithdrawPermissions() string {
 			case WithdrawCryptoWithWebsiteApproval:
 				services = append(services, WithdrawCryptoWithWebsiteApprovalText)
 				break
+			case WithdrawCryptoWithAPIPermission:
+				services = append(services, WithdrawCryptoWithAPIPermissionText)
+				break
 			case AutoWithdrawFiat:
 				services = append(services, AutoWithdrawFiatText)
 				break
-			case AutoWithdrawFiatWithPermission:
-				services = append(services, AutoWithdrawFiatWithPermissionText)
+			case AutoWithdrawFiatWithAPIPermission:
+				services = append(services, AutoWithdrawFiatWithAPIPermissionText)
 				break
 			case AutoWithdrawFiatWithSetup:
 				services = append(services, AutoWithdrawFiatWithSetupText)
@@ -860,6 +872,15 @@ func (e *Base) GetWithdrawPermissions() string {
 			case WithdrawFiatWithWebsiteApproval:
 				services = append(services, WithdrawFiatWithWebsiteApprovalText)
 				break
+			case WithdrawFiatWithAPIPermission:
+				services = append(services, WithdrawFiatWithAPIPermissionText)
+				break
+			case WithdrawCryptoViaWebsiteOnly:
+				services = append(services, WithdrawCryptoViaWebsiteOnlyText)
+				break
+			case WithdrawFiatViaWebsiteOnly:
+				services = append(services, WithdrawFiatViaWebsiteOnlyText)
+				break
 			default:
 				services = append(services, fmt.Sprintf("%s[%v]", UnknownWithdrawalTypeText, check))
 			}
@@ -869,5 +890,5 @@ func (e *Base) GetWithdrawPermissions() string {
 		return strings.Join(services, " & ")
 	}
 
-	return NoWithdrawalMethodsText
+	return NoAPIWithdrawalMethodsText
 }

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -147,6 +147,8 @@ type Base struct {
 	Verbose                                    bool
 	RESTPollingDelay                           time.Duration
 	AuthenticatedAPISupport                    bool
+	APIWithdrawalPermission                    bool
+	AutomaticAPIWithdrawlSupport               bool
 	APIAuthPEMKeySupport                       bool
 	APISecret, APIKey, APIAuthPEMKey, ClientID string
 	Nonce                                      nonce.Nonce

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -829,58 +829,40 @@ func (e *Base) GetWithdrawPermissions() string {
 			switch check {
 			case AutoWithdrawCrypto:
 				services = append(services, AutoWithdrawCryptoText)
-				break
 			case AutoWithdrawCryptoWithAPIPermission:
 				services = append(services, AutoWithdrawCryptoWithAPIPermissionText)
-				break
 			case AutoWithdrawCryptoWithSetup:
 				services = append(services, AutoWithdrawCryptoWithSetupText)
-				break
 			case WithdrawCryptoWith2FA:
 				services = append(services, WithdrawCryptoWith2FAText)
-				break
 			case WithdrawCryptoWithSMS:
 				services = append(services, WithdrawCryptoWithSMSText)
-				break
 			case WithdrawCryptoWithEmail:
 				services = append(services, WithdrawCryptoWithEmailText)
-				break
 			case WithdrawCryptoWithWebsiteApproval:
 				services = append(services, WithdrawCryptoWithWebsiteApprovalText)
-				break
 			case WithdrawCryptoWithAPIPermission:
 				services = append(services, WithdrawCryptoWithAPIPermissionText)
-				break
 			case AutoWithdrawFiat:
 				services = append(services, AutoWithdrawFiatText)
-				break
 			case AutoWithdrawFiatWithAPIPermission:
 				services = append(services, AutoWithdrawFiatWithAPIPermissionText)
-				break
 			case AutoWithdrawFiatWithSetup:
 				services = append(services, AutoWithdrawFiatWithSetupText)
-				break
 			case WithdrawFiatWith2FA:
 				services = append(services, WithdrawFiatWith2FAText)
-				break
 			case WithdrawFiatWithSMS:
 				services = append(services, WithdrawFiatWithSMSText)
-				break
 			case WithdrawFiatWithEmail:
 				services = append(services, WithdrawFiatWithEmailText)
-				break
 			case WithdrawFiatWithWebsiteApproval:
 				services = append(services, WithdrawFiatWithWebsiteApprovalText)
-				break
 			case WithdrawFiatWithAPIPermission:
 				services = append(services, WithdrawFiatWithAPIPermissionText)
-				break
 			case WithdrawCryptoViaWebsiteOnly:
 				services = append(services, WithdrawCryptoViaWebsiteOnlyText)
-				break
 			case WithdrawFiatViaWebsiteOnly:
 				services = append(services, WithdrawFiatViaWebsiteOnlyText)
-				break
 			default:
 				services = append(services, fmt.Sprintf("%s[%v]", UnknownWithdrawalTypeText, check))
 			}

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -845,7 +845,7 @@ func TestAPIURL(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestSupportsWithdrawPermissions(t *testing.T) {
 	cfg := config.GetConfig()
 	err := cfg.LoadConfig(config.ConfigTestFile)
 	if err != nil {
@@ -854,7 +854,37 @@ func TestGetWithdrawPermissions(t *testing.T) {
 
 	UAC := Base{Name: "ANX"}
 	UAC.APIWithdrawPermissions = AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission
-	withdrawPermissions := UAC.GetWithdrawPermissions()
+	withdrawPermissions := UAC.SupportsWithdrawPermissions(AutoWithdrawCrypto)
+	if withdrawPermissions {
+		t.Errorf("Expected: %v, Recieved: %v", false, withdrawPermissions)
+	}
+
+	withdrawPermissions = UAC.SupportsWithdrawPermissions(AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission)
+	if !withdrawPermissions {
+		t.Errorf("Expected: %v, Recieved: %v", true, withdrawPermissions)
+	}
+
+	withdrawPermissions = UAC.SupportsWithdrawPermissions(AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission | WithdrawCryptoWith2FA)
+	if !withdrawPermissions {
+		t.Errorf("Expected: %v, Recieved: %v", true, withdrawPermissions)
+	}
+
+	withdrawPermissions = UAC.SupportsWithdrawPermissions(WithdrawCryptoWith2FA)
+	if withdrawPermissions {
+		t.Errorf("Expected: %v, Recieved: %v", false, withdrawPermissions)
+	}
+}
+
+func TestFormatWithdrawPermissions(t *testing.T) {
+	cfg := config.GetConfig()
+	err := cfg.LoadConfig(config.ConfigTestFile)
+	if err != nil {
+		t.Fatal("Test failed. TestUpdateEnabledCurrencies failed to load config")
+	}
+
+	UAC := Base{Name: "ANX"}
+	UAC.APIWithdrawPermissions = AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission
+	withdrawPermissions := UAC.FormatWithdrawPermissions()
 	if withdrawPermissions != AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithAPIPermissionText {
 		t.Errorf("Expected: %s, Recieved: %s", AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithAPIPermissionText, withdrawPermissions)
 	}

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -846,17 +846,12 @@ func TestAPIURL(t *testing.T) {
 }
 
 func TestSupportsWithdrawPermissions(t *testing.T) {
-	cfg := config.GetConfig()
-	err := cfg.LoadConfig(config.ConfigTestFile)
-	if err != nil {
-		t.Fatal("Test failed. TestUpdateEnabledCurrencies failed to load config")
-	}
-
 	UAC := Base{Name: "ANX"}
 	UAC.APIWithdrawPermissions = AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission
 	withdrawPermissions := UAC.SupportsWithdrawPermissions(AutoWithdrawCrypto)
-	if withdrawPermissions {
-		t.Errorf("Expected: %v, Recieved: %v", false, withdrawPermissions)
+
+	if !withdrawPermissions {
+		t.Errorf("Expected: %v, Recieved: %v", true, withdrawPermissions)
 	}
 
 	withdrawPermissions = UAC.SupportsWithdrawPermissions(AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission)
@@ -864,9 +859,14 @@ func TestSupportsWithdrawPermissions(t *testing.T) {
 		t.Errorf("Expected: %v, Recieved: %v", true, withdrawPermissions)
 	}
 
+	withdrawPermissions = UAC.SupportsWithdrawPermissions(AutoWithdrawCrypto | WithdrawCryptoWith2FA)
+	if withdrawPermissions {
+		t.Errorf("Expected: %v, Recieved: %v", false, withdrawPermissions)
+	}
+
 	withdrawPermissions = UAC.SupportsWithdrawPermissions(AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission | WithdrawCryptoWith2FA)
-	if !withdrawPermissions {
-		t.Errorf("Expected: %v, Recieved: %v", true, withdrawPermissions)
+	if withdrawPermissions {
+		t.Errorf("Expected: %v, Recieved: %v", false, withdrawPermissions)
 	}
 
 	withdrawPermissions = UAC.SupportsWithdrawPermissions(WithdrawCryptoWith2FA)

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -856,7 +856,7 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	UAC.APIWithdrawPermissions = AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission
 	withdrawPermissions := UAC.GetWithdrawPermissions()
 	if withdrawPermissions != AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithAPIPermissionText {
-		t.Errorf("Excpected: %s, Recieved: %s", AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithAPIPermissionText, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithAPIPermissionText, withdrawPermissions)
 	}
 
 }

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -853,10 +853,10 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	}
 
 	UAC := Base{Name: "ANX"}
-	UAC.APIWithdrawPermissions = AutoWithdrawCrypto | AutoWithdrawCryptoWithPermission
+	UAC.APIWithdrawPermissions = AutoWithdrawCrypto | AutoWithdrawCryptoWithAPIPermission
 	withdrawPermissions := UAC.GetWithdrawPermissions()
-	if withdrawPermissions != AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithPermissionText {
-		t.Errorf("Excpected: %s, Recieved: %s", AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithPermissionText, withdrawPermissions)
+	if withdrawPermissions != AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithAPIPermissionText {
+		t.Errorf("Excpected: %s, Recieved: %s", AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithAPIPermissionText, withdrawPermissions)
 	}
 
 }

--- a/exchanges/exchange_test.go
+++ b/exchanges/exchange_test.go
@@ -844,3 +844,19 @@ func TestAPIURL(t *testing.T) {
 		t.Error("test failed - incorrect return URL")
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	cfg := config.GetConfig()
+	err := cfg.LoadConfig(config.ConfigTestFile)
+	if err != nil {
+		t.Fatal("Test failed. TestUpdateEnabledCurrencies failed to load config")
+	}
+
+	UAC := Base{Name: "ANX"}
+	UAC.APIWithdrawPermissions = AutoWithdrawCrypto | AutoWithdrawCryptoWithPermission
+	withdrawPermissions := UAC.GetWithdrawPermissions()
+	if withdrawPermissions != AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithPermissionText {
+		t.Errorf("Excpected: %s, Recieved: %s", AutoWithdrawCryptoText+" & "+AutoWithdrawCryptoWithPermissionText, withdrawPermissions)
+	}
+
+}

--- a/exchanges/exmo/exmo.go
+++ b/exchanges/exmo/exmo.go
@@ -57,6 +57,7 @@ func (e *EXMO) SetDefaults() {
 	e.Enabled = false
 	e.Verbose = false
 	e.RESTPollingDelay = 10
+	e.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithSetup | exchange.NoAPIWithdrawalMethods
 	e.RequestCurrencyPairFormat.Delimiter = "_"
 	e.RequestCurrencyPairFormat.Uppercase = true
 	e.RequestCurrencyPairFormat.Separator = ","

--- a/exchanges/exmo/exmo.go
+++ b/exchanges/exmo/exmo.go
@@ -57,7 +57,7 @@ func (e *EXMO) SetDefaults() {
 	e.Enabled = false
 	e.Verbose = false
 	e.RESTPollingDelay = 10
-	e.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithSetup | exchange.NoAPIWithdrawalMethods
+	e.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithSetup
 	e.RequestCurrencyPairFormat.Delimiter = "_"
 	e.RequestCurrencyPairFormat.Uppercase = true
 	e.RequestCurrencyPairFormat.Separator = ","

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -242,6 +242,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := e.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -234,12 +234,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	e.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText
 	// Act
-	withdrawPermissions := e.GetWithdrawPermissions()
+	withdrawPermissions := e.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -233,3 +233,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	e.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithSetupText
+	// Act
+	withdrawPermissions := e.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -236,6 +236,6 @@ func (e *EXMO) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (e *EXMO) GetWithdrawCapabilities() string {
+func (e *EXMO) GetWithdrawCapabilities() uint32 {
 	return e.GetWithdrawPermissions()
 }

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -234,3 +234,8 @@ func (e *EXMO) GetWebsocket() (*exchange.Websocket, error) {
 func (e *EXMO) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return e.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (e *EXMO) GetWithdrawCapabilities() string {
+	return e.GetWithdrawPermissions()
+}

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -46,6 +46,7 @@ func (g *Gateio) SetDefaults() {
 	g.Enabled = false
 	g.Verbose = false
 	g.RESTPollingDelay = 10
+	g.APIWithdrawPermissions = exchange.AutoWithdrawCrypto | exchange.NoAPIWithdrawalMethods
 	g.RequestCurrencyPairFormat.Delimiter = "_"
 	g.RequestCurrencyPairFormat.Uppercase = false
 	g.ConfigCurrencyPairFormat.Delimiter = "_"

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -46,7 +46,7 @@ func (g *Gateio) SetDefaults() {
 	g.Enabled = false
 	g.Verbose = false
 	g.RESTPollingDelay = 10
-	g.APIWithdrawPermissions = exchange.AutoWithdrawCrypto | exchange.NoAPIWithdrawalMethods
+	g.APIWithdrawPermissions = exchange.AutoWithdrawCrypto
 	g.RequestCurrencyPairFormat.Delimiter = "_"
 	g.RequestCurrencyPairFormat.Uppercase = false
 	g.ConfigCurrencyPairFormat.Delimiter = "_"

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -236,12 +236,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	g.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText
 	// Act
-	withdrawPermissions := g.GetWithdrawPermissions()
+	withdrawPermissions := g.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -235,3 +235,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	g.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText
+	// Act
+	withdrawPermissions := g.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -244,6 +244,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := g.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -185,3 +185,8 @@ func (g *Gateio) GetWebsocket() (*exchange.Websocket, error) {
 func (g *Gateio) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return g.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (g *Gateio) GetWithdrawCapabilities() string {
+	return g.GetWithdrawPermissions()
+}

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -187,6 +187,6 @@ func (g *Gateio) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (g *Gateio) GetWithdrawCapabilities() string {
+func (g *Gateio) GetWithdrawCapabilities() uint32 {
 	return g.GetWithdrawPermissions()
 }

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -102,6 +102,7 @@ func (g *Gemini) SetDefaults() {
 	g.Enabled = false
 	g.Verbose = false
 	g.RESTPollingDelay = 10
+	g.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission | exchange.AutoWithdrawCryptoWithSetup | exchange.WithdrawFiatViaWebsiteOnly
 	g.RequestCurrencyPairFormat.Delimiter = ""
 	g.RequestCurrencyPairFormat.Uppercase = true
 	g.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -312,8 +312,6 @@ func TestGetFee(t *testing.T) {
 
 func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
-	TestAddSession(t)
-	TestSetDefaults(t)
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
 	withdrawPermissions := Session[1].GetWithdrawPermissions()

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -309,3 +309,16 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	TestAddSession(t)
+	TestSetDefaults(t)
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
+	// Act
+	withdrawPermissions := Session[1].GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -319,6 +319,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := Session[1].GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -310,11 +310,11 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := Session[1].GetWithdrawPermissions()
+	withdrawPermissions := Session[1].FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -185,3 +185,8 @@ func (g *Gemini) GetWebsocket() (*exchange.Websocket, error) {
 func (g *Gemini) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return g.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (g *Gemini) GetWithdrawCapabilities() string {
+	return g.GetWithdrawPermissions()
+}

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -187,6 +187,6 @@ func (g *Gemini) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (g *Gemini) GetWithdrawCapabilities() string {
+func (g *Gemini) GetWithdrawCapabilities() uint32 {
 	return g.GetWithdrawPermissions()
 }

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -61,6 +61,7 @@ func (h *HitBTC) SetDefaults() {
 	h.Fee = 0
 	h.Verbose = false
 	h.RESTPollingDelay = 10
+	h.APIWithdrawPermissions = exchange.AutoWithdrawCrypto
 	h.RequestCurrencyPairFormat.Delimiter = ""
 	h.RequestCurrencyPairFormat.Uppercase = true
 	h.ConfigCurrencyPairFormat.Delimiter = "-"

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -161,12 +161,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	h.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText
 	// Act
-	withdrawPermissions := h.GetWithdrawPermissions()
+	withdrawPermissions := h.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -160,3 +160,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	h.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText
+	// Act
+	withdrawPermissions := h.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -169,6 +169,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := h.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -215,6 +215,6 @@ func (h *HitBTC) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (h *HitBTC) GetWithdrawCapabilities() string {
+func (h *HitBTC) GetWithdrawCapabilities() uint32 {
 	return h.GetWithdrawPermissions()
 }

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -213,3 +213,8 @@ func (h *HitBTC) GetWebsocket() (*exchange.Websocket, error) {
 func (h *HitBTC) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return h.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (h *HitBTC) GetWithdrawCapabilities() string {
+	return h.GetWithdrawPermissions()
+}

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -73,6 +73,7 @@ func (h *HUOBI) SetDefaults() {
 	h.Fee = 0
 	h.Verbose = false
 	h.RESTPollingDelay = 10
+	h.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithSetup
 	h.RequestCurrencyPairFormat.Delimiter = ""
 	h.RequestCurrencyPairFormat.Uppercase = false
 	h.ConfigCurrencyPairFormat.Delimiter = "-"

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -382,12 +382,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	h.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText
 	// Act
-	withdrawPermissions := h.GetWithdrawPermissions()
+	withdrawPermissions := h.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -390,6 +390,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := h.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -381,3 +381,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	h.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithSetupText
+	// Act
+	withdrawPermissions := h.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -228,3 +228,8 @@ func (h *HUOBI) GetWebsocket() (*exchange.Websocket, error) {
 func (h *HUOBI) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return h.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (h *HUOBI) GetWithdrawCapabilities() string {
+	return h.GetWithdrawPermissions()
+}

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -230,6 +230,6 @@ func (h *HUOBI) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (h *HUOBI) GetWithdrawCapabilities() string {
+func (h *HUOBI) GetWithdrawCapabilities() uint32 {
 	return h.GetWithdrawPermissions()
 }

--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -65,6 +65,7 @@ func (h *HUOBIHADAX) SetDefaults() {
 	h.Fee = 0
 	h.Verbose = false
 	h.RESTPollingDelay = 10
+	h.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithSetup
 	h.RequestCurrencyPairFormat.Delimiter = ""
 	h.RequestCurrencyPairFormat.Uppercase = false
 	h.ConfigCurrencyPairFormat.Delimiter = "-"

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -369,6 +369,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := h.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -360,3 +360,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	h.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithSetupText
+	// Act
+	withdrawPermissions := h.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -361,12 +361,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	h.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText
 	// Act
-	withdrawPermissions := h.GetWithdrawPermissions()
+	withdrawPermissions := h.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -193,3 +193,8 @@ func (h *HUOBIHADAX) GetWebsocket() (*exchange.Websocket, error) {
 func (h *HUOBIHADAX) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return h.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (h *HUOBIHADAX) GetWithdrawCapabilities() string {
+	return h.GetWithdrawPermissions()
+}

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -195,6 +195,6 @@ func (h *HUOBIHADAX) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, erro
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (h *HUOBIHADAX) GetWithdrawCapabilities() string {
+func (h *HUOBIHADAX) GetWithdrawCapabilities() uint32 {
 	return h.GetWithdrawPermissions()
 }

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -48,6 +48,7 @@ func (i *ItBit) SetDefaults() {
 	i.TakerFee = 0.50
 	i.Verbose = false
 	i.RESTPollingDelay = 10
+	i.APIWithdrawPermissions = exchange.WithdrawCryptoViaWebsiteOnly | exchange.WithdrawFiatViaWebsiteOnly
 	i.RequestCurrencyPairFormat.Delimiter = ""
 	i.RequestCurrencyPairFormat.Uppercase = true
 	i.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -48,7 +48,7 @@ func (i *ItBit) SetDefaults() {
 	i.TakerFee = 0.50
 	i.Verbose = false
 	i.RESTPollingDelay = 10
-	i.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
+	i.APIWithdrawPermissions = exchange.WithdrawCryptoViaWebsiteOnly | exchange.WithdrawFiatViaWebsiteOnly
 	i.RequestCurrencyPairFormat.Delimiter = ""
 	i.RequestCurrencyPairFormat.Uppercase = true
 	i.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -48,7 +48,7 @@ func (i *ItBit) SetDefaults() {
 	i.TakerFee = 0.50
 	i.Verbose = false
 	i.RESTPollingDelay = 10
-	i.APIWithdrawPermissions = exchange.WithdrawCryptoViaWebsiteOnly | exchange.WithdrawFiatViaWebsiteOnly
+	i.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
 	i.RequestCurrencyPairFormat.Delimiter = ""
 	i.RequestCurrencyPairFormat.Uppercase = true
 	i.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -230,12 +230,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	i.SetDefaults()
 	expectedResult := exchange.WithdrawCryptoViaWebsiteOnlyText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := i.GetWithdrawPermissions()
+	withdrawPermissions := i.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -233,11 +233,11 @@ func TestGetFee(t *testing.T) {
 func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
 	i.SetDefaults()
-	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	expectedResult := exchange.WithdrawCryptoViaWebsiteOnlyText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
 	withdrawPermissions := i.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -229,3 +229,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	i.SetDefaults()
+	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	// Act
+	withdrawPermissions := i.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -187,3 +187,8 @@ func (i *ItBit) GetWebsocket() (*exchange.Websocket, error) {
 func (i *ItBit) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return i.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (i *ItBit) GetWithdrawCapabilities() string {
+	return i.GetWithdrawPermissions()
+}

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -189,6 +189,6 @@ func (i *ItBit) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (i *ItBit) GetWithdrawCapabilities() string {
+func (i *ItBit) GetWithdrawCapabilities() uint32 {
 	return i.GetWithdrawPermissions()
 }

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -60,6 +60,7 @@ func (k *Kraken) SetDefaults() {
 	k.CryptoFee = 0.10
 	k.Verbose = false
 	k.RESTPollingDelay = 10
+	k.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithSetup | exchange.WithdrawCryptoWith2FA | exchange.AutoWithdrawFiatWithSetup | exchange.WithdrawFiatWith2FA
 	k.RequestCurrencyPairFormat.Delimiter = ""
 	k.RequestCurrencyPairFormat.Uppercase = true
 	k.RequestCurrencyPairFormat.Separator = ","
@@ -960,9 +961,9 @@ func (k *Kraken) GetFee(feeBuilder exchange.FeeBuilder) (float64, error) {
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.CurrencyItem)
 	}
-		if fee < 0 {
-			fee = 0
-		}
+	if fee < 0 {
+		fee = 0
+	}
 
 	return fee, nil
 }

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -315,3 +315,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	k.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawCryptoWith2FAText + " & " + exchange.AutoWithdrawFiatWithSetupText + " & " + exchange.WithdrawFiatWith2FAText
+	// Act
+	withdrawPermissions := k.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -324,6 +324,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := k.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -316,12 +316,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	k.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawCryptoWith2FAText + " & " + exchange.AutoWithdrawFiatWithSetupText + " & " + exchange.WithdrawFiatWith2FAText
 	// Act
-	withdrawPermissions := k.GetWithdrawPermissions()
+	withdrawPermissions := k.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -219,3 +219,8 @@ func (k *Kraken) GetWebsocket() (*exchange.Websocket, error) {
 func (k *Kraken) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return k.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (k *Kraken) GetWithdrawCapabilities() string {
+	return k.GetWithdrawPermissions()
+}

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -221,6 +221,6 @@ func (k *Kraken) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (k *Kraken) GetWithdrawCapabilities() string {
+func (k *Kraken) GetWithdrawCapabilities() uint32 {
 	return k.GetWithdrawPermissions()
 }

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -49,7 +49,7 @@ func (l *LakeBTC) SetDefaults() {
 	l.MakerFee = 0.15
 	l.Verbose = false
 	l.RESTPollingDelay = 10
-	l.APIWithdrawPermissions = exchange.AutoWithdrawCrypto
+	l.APIWithdrawPermissions = exchange.AutoWithdrawCrypto | exchange.WithdrawFiatViaWebsiteOnly
 	l.RequestCurrencyPairFormat.Delimiter = ""
 	l.RequestCurrencyPairFormat.Uppercase = true
 	l.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -49,6 +49,7 @@ func (l *LakeBTC) SetDefaults() {
 	l.MakerFee = 0.15
 	l.Verbose = false
 	l.RESTPollingDelay = 10
+	l.APIWithdrawPermissions = exchange.AutoWithdrawCrypto
 	l.RequestCurrencyPairFormat.Delimiter = ""
 	l.RequestCurrencyPairFormat.Uppercase = true
 	l.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -237,11 +237,11 @@ func TestGetFee(t *testing.T) {
 func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
 	l.SetDefaults()
-	expectedResult := exchange.AutoWithdrawCryptoText
+	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
 	withdrawPermissions := l.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -234,12 +234,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	l.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := l.GetWithdrawPermissions()
+	withdrawPermissions := l.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -146,12 +146,12 @@ func TestCreateWithdraw(t *testing.T) {
 
 func setFeeBuilder() exchange.FeeBuilder {
 	return exchange.FeeBuilder{
-		Amount:         1,
-		Delimiter:      "_",
-		FeeType:        exchange.CryptocurrencyTradeFee,
-		FirstCurrency:  symbol.BTC,
-		SecondCurrency: symbol.LTC,
-		IsMaker:        false,
+		Amount:              1,
+		Delimiter:           "_",
+		FeeType:             exchange.CryptocurrencyTradeFee,
+		FirstCurrency:       symbol.BTC,
+		SecondCurrency:      symbol.LTC,
+		IsMaker:             false,
 		PurchasePrice:       1,
 		CurrencyItem:        symbol.USD,
 		BankTransactionType: exchange.WireTransfer,
@@ -231,5 +231,17 @@ func TestGetFee(t *testing.T) {
 	if resp, err := l.GetFee(feeBuilder); resp != float64(0) || err != nil {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(0), resp)
 		t.Error(err)
+	}
+}
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	l.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText
+	// Act
+	withdrawPermissions := l.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -199,6 +199,6 @@ func (l *LakeBTC) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) 
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (l *LakeBTC) GetWithdrawCapabilities() string {
+func (l *LakeBTC) GetWithdrawCapabilities() uint32 {
 	return l.GetWithdrawPermissions()
 }

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -197,3 +197,8 @@ func (l *LakeBTC) GetWebsocket() (*exchange.Websocket, error) {
 func (l *LakeBTC) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return l.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (l *LakeBTC) GetWithdrawCapabilities() string {
+	return l.GetWithdrawPermissions()
+}

--- a/exchanges/liqui/liqui.go
+++ b/exchanges/liqui/liqui.go
@@ -51,6 +51,7 @@ func (l *Liqui) SetDefaults() {
 	l.Verbose = false
 	l.RESTPollingDelay = 10
 	l.Ticker = make(map[string]Ticker)
+	l.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
 	l.RequestCurrencyPairFormat.Delimiter = "_"
 	l.RequestCurrencyPairFormat.Uppercase = false
 	l.RequestCurrencyPairFormat.Separator = "-"

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -228,6 +228,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := l.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -220,12 +220,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	l.SetDefaults()
 	expectedResult := exchange.NoAPIWithdrawalMethodsText
 	// Act
-	withdrawPermissions := l.GetWithdrawPermissions()
+	withdrawPermissions := l.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -219,3 +219,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	l.SetDefaults()
+	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	// Act
+	withdrawPermissions := l.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/liqui/liqui_wrapper.go
+++ b/exchanges/liqui/liqui_wrapper.go
@@ -206,3 +206,8 @@ func (l *Liqui) GetWebsocket() (*exchange.Websocket, error) {
 func (l *Liqui) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return l.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (l *Liqui) GetWithdrawCapabilities() string {
+	return l.GetWithdrawPermissions()
+}

--- a/exchanges/liqui/liqui_wrapper.go
+++ b/exchanges/liqui/liqui_wrapper.go
@@ -208,6 +208,6 @@ func (l *Liqui) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (l *Liqui) GetWithdrawCapabilities() string {
+func (l *Liqui) GetWithdrawCapabilities() uint32 {
 	return l.GetWithdrawPermissions()
 }

--- a/exchanges/localbitcoins/localbitcoins.go
+++ b/exchanges/localbitcoins/localbitcoins.go
@@ -117,6 +117,7 @@ func (l *LocalBitcoins) SetDefaults() {
 	l.Verbose = false
 	l.Verbose = false
 	l.RESTPollingDelay = 10
+	l.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
 	l.RequestCurrencyPairFormat.Delimiter = ""
 	l.RequestCurrencyPairFormat.Uppercase = true
 	l.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/localbitcoins/localbitcoins.go
+++ b/exchanges/localbitcoins/localbitcoins.go
@@ -117,7 +117,7 @@ func (l *LocalBitcoins) SetDefaults() {
 	l.Verbose = false
 	l.Verbose = false
 	l.RESTPollingDelay = 10
-	l.APIWithdrawPermissions = exchange.NoAPIWithdrawalMethods
+	l.APIWithdrawPermissions = exchange.WithdrawCryptoViaWebsiteOnly
 	l.RequestCurrencyPairFormat.Delimiter = ""
 	l.RequestCurrencyPairFormat.Uppercase = true
 	l.ConfigCurrencyPairFormat.Delimiter = ""

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -80,12 +80,12 @@ func TestEditAd(t *testing.T) {
 
 func setFeeBuilder() exchange.FeeBuilder {
 	return exchange.FeeBuilder{
-		Amount:         1,
-		Delimiter:      "-",
-		FeeType:        exchange.CryptocurrencyTradeFee,
-		FirstCurrency:  symbol.LTC,
-		SecondCurrency: symbol.BTC,
-		IsMaker:        false,
+		Amount:              1,
+		Delimiter:           "-",
+		FeeType:             exchange.CryptocurrencyTradeFee,
+		FirstCurrency:       symbol.LTC,
+		SecondCurrency:      symbol.BTC,
+		IsMaker:             false,
 		PurchasePrice:       1,
 		CurrencyItem:        symbol.USD,
 		BankTransactionType: exchange.WireTransfer,
@@ -165,5 +165,17 @@ func TestGetFee(t *testing.T) {
 	if resp, err := l.GetFee(feeBuilder); resp != float64(0) || err != nil {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(0), resp)
 		t.Error(err)
+	}
+}
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	l.SetDefaults()
+	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	// Act
+	withdrawPermissions := l.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -168,12 +168,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	l.SetDefaults()
 	expectedResult := exchange.WithdrawCryptoViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := l.GetWithdrawPermissions()
+	withdrawPermissions := l.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -171,11 +171,11 @@ func TestGetFee(t *testing.T) {
 func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
 	l.SetDefaults()
-	expectedResult := exchange.NoAPIWithdrawalMethodsText
+	expectedResult := exchange.WithdrawCryptoViaWebsiteOnlyText
 	// Act
 	withdrawPermissions := l.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -180,6 +180,6 @@ func (l *LocalBitcoins) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, e
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (l *LocalBitcoins) GetWithdrawCapabilities() string {
+func (l *LocalBitcoins) GetWithdrawCapabilities() uint32 {
 	return l.GetWithdrawPermissions()
 }

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -178,3 +178,8 @@ func (l *LocalBitcoins) GetWebsocket() (*exchange.Websocket, error) {
 func (l *LocalBitcoins) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return l.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (l *LocalBitcoins) GetWithdrawCapabilities() string {
+	return l.GetWithdrawPermissions()
+}

--- a/exchanges/okcoin/okcoin.go
+++ b/exchanges/okcoin/okcoin.go
@@ -99,6 +99,7 @@ func (o *OKCoin) SetDefaults() {
 	o.Verbose = false
 	o.RESTPollingDelay = 10
 	o.AssetTypes = []string{ticker.Spot}
+	o.APIWithdrawPermissions = exchange.AutoWithdrawCrypto | exchange.WithdrawFiatViaWebsiteOnly
 	o.SupportsAutoPairUpdating = false
 	o.SupportsRESTTickerBatching = false
 	o.WebsocketInit()

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -126,12 +126,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	o.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := o.GetWithdrawPermissions()
+	withdrawPermissions := o.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -38,12 +38,12 @@ func TestSetup(t *testing.T) {
 
 func setFeeBuilder() exchange.FeeBuilder {
 	return exchange.FeeBuilder{
-		Amount:         1,
-		Delimiter:      "-",
-		FeeType:        exchange.CryptocurrencyTradeFee,
-		FirstCurrency:  symbol.LTC,
-		SecondCurrency: symbol.BTC,
-		IsMaker:        false,
+		Amount:              1,
+		Delimiter:           "-",
+		FeeType:             exchange.CryptocurrencyTradeFee,
+		FirstCurrency:       symbol.LTC,
+		SecondCurrency:      symbol.BTC,
+		IsMaker:             false,
 		PurchasePrice:       1,
 		CurrencyItem:        symbol.USD,
 		BankTransactionType: exchange.WireTransfer,
@@ -123,5 +123,17 @@ func TestGetFee(t *testing.T) {
 	if resp, err := o.GetFee(feeBuilder); resp != float64(15) || err != nil {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(15), resp)
 		t.Error(err)
+	}
+}
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	o.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
+	// Act
+	withdrawPermissions := o.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -134,6 +134,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := o.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -246,6 +246,6 @@ func (o *OKCoin) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (o *OKCoin) GetWithdrawCapabilities() string {
+func (o *OKCoin) GetWithdrawCapabilities() uint32 {
 	return o.GetWithdrawPermissions()
 }

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -244,3 +244,8 @@ func (o *OKCoin) GetWebsocket() (*exchange.Websocket, error) {
 func (o *OKCoin) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return o.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (o *OKCoin) GetWithdrawCapabilities() string {
+	return o.GetWithdrawPermissions()
+}

--- a/exchanges/okex/okex.go
+++ b/exchanges/okex/okex.go
@@ -102,6 +102,7 @@ func (o *OKEX) SetDefaults() {
 	o.Enabled = false
 	o.Verbose = false
 	o.RESTPollingDelay = 10
+	o.APIWithdrawPermissions = exchange.AutoWithdrawCrypto
 	o.RequestCurrencyPairFormat.Delimiter = "_"
 	o.RequestCurrencyPairFormat.Uppercase = false
 	o.ConfigCurrencyPairFormat.Delimiter = "_"

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -383,6 +383,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := o.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -374,3 +374,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	o.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText
+	// Act
+	withdrawPermissions := o.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -375,12 +375,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	o.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText
 	// Act
-	withdrawPermissions := o.GetWithdrawPermissions()
+	withdrawPermissions := o.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -210,3 +210,8 @@ func (o *OKEX) GetWebsocket() (*exchange.Websocket, error) {
 func (o *OKEX) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return o.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (o *OKEX) GetWithdrawCapabilities() string {
+	return o.GetWithdrawPermissions()
+}

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -212,6 +212,6 @@ func (o *OKEX) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (o *OKEX) GetWithdrawCapabilities() string {
+func (o *OKEX) GetWithdrawCapabilities() uint32 {
 	return o.GetWithdrawPermissions()
 }

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -66,6 +66,7 @@ func (p *Poloniex) SetDefaults() {
 	p.Fee = 0
 	p.Verbose = false
 	p.RESTPollingDelay = 10
+	p.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission
 	p.RequestCurrencyPairFormat.Delimiter = "_"
 	p.RequestCurrencyPairFormat.Uppercase = true
 	p.ConfigCurrencyPairFormat.Delimiter = "_"

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -179,12 +179,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	p.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
 	// Act
-	withdrawPermissions := p.GetWithdrawPermissions()
+	withdrawPermissions := p.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -187,6 +187,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := p.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -178,3 +178,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	p.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
+	// Act
+	withdrawPermissions := p.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -213,3 +213,8 @@ func (p *Poloniex) GetWebsocket() (*exchange.Websocket, error) {
 func (p *Poloniex) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return p.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (p *Poloniex) GetWithdrawCapabilities() string {
+	return p.GetWithdrawPermissions()
+}

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -215,6 +215,6 @@ func (p *Poloniex) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error)
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (p *Poloniex) GetWithdrawCapabilities() string {
+func (p *Poloniex) GetWithdrawCapabilities() uint32 {
 	return p.GetWithdrawPermissions()
 }

--- a/exchanges/wex/wex.go
+++ b/exchanges/wex/wex.go
@@ -56,6 +56,7 @@ func (w *WEX) SetDefaults() {
 	w.Verbose = false
 	w.RESTPollingDelay = 10
 	w.Ticker = make(map[string]Ticker)
+	w.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission
 	w.RequestCurrencyPairFormat.Delimiter = "_"
 	w.RequestCurrencyPairFormat.Uppercase = false
 	w.RequestCurrencyPairFormat.Separator = "-"

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -164,12 +164,12 @@ func TestRedeemCoupon(t *testing.T) {
 
 func setFeeBuilder() exchange.FeeBuilder {
 	return exchange.FeeBuilder{
-		Amount:         1,
-		Delimiter:      "_",
-		FeeType:        exchange.CryptocurrencyTradeFee,
-		FirstCurrency:  symbol.LTC,
-		SecondCurrency: symbol.BTC,
-		IsMaker:        false,
+		Amount:              1,
+		Delimiter:           "_",
+		FeeType:             exchange.CryptocurrencyTradeFee,
+		FirstCurrency:       symbol.LTC,
+		SecondCurrency:      symbol.BTC,
+		IsMaker:             false,
 		PurchasePrice:       1,
 		CurrencyItem:        symbol.USD,
 		BankTransactionType: exchange.WireTransfer,
@@ -195,7 +195,6 @@ func TestGetFee(t *testing.T) {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(2000), resp)
 		t.Error(err)
 	}
-
 
 	// CryptocurrencyTradeFee IsMaker
 	feeBuilder = setFeeBuilder()
@@ -252,5 +251,17 @@ func TestGetFee(t *testing.T) {
 	if resp, err := w.GetFee(feeBuilder); resp != float64(0) || err != nil {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(0), resp)
 		t.Error(err)
+	}
+}
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	w.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
+	// Act
+	withdrawPermissions := w.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -254,12 +254,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	w.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
 	// Act
-	withdrawPermissions := w.GetWithdrawPermissions()
+	withdrawPermissions := w.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -262,6 +262,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := w.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -216,3 +216,8 @@ func (w *WEX) GetWebsocket() (*exchange.Websocket, error) {
 func (w *WEX) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return w.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (w *WEX) GetWithdrawCapabilities() string {
+	return w.GetWithdrawPermissions()
+}

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -218,6 +218,6 @@ func (w *WEX) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (w *WEX) GetWithdrawCapabilities() string {
+func (w *WEX) GetWithdrawCapabilities() uint32 {
 	return w.GetWithdrawPermissions()
 }

--- a/exchanges/yobit/yobit.go
+++ b/exchanges/yobit/yobit.go
@@ -55,6 +55,7 @@ func (y *Yobit) SetDefaults() {
 	y.RESTPollingDelay = 10
 	y.AuthenticatedAPISupport = true
 	y.Ticker = make(map[string]Ticker)
+	y.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission
 	y.RequestCurrencyPairFormat.Delimiter = "_"
 	y.RequestCurrencyPairFormat.Uppercase = false
 	y.RequestCurrencyPairFormat.Separator = "-"

--- a/exchanges/yobit/yobit.go
+++ b/exchanges/yobit/yobit.go
@@ -55,7 +55,7 @@ func (y *Yobit) SetDefaults() {
 	y.RESTPollingDelay = 10
 	y.AuthenticatedAPISupport = true
 	y.Ticker = make(map[string]Ticker)
-	y.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission
+	y.APIWithdrawPermissions = exchange.AutoWithdrawCryptoWithAPIPermission | exchange.WithdrawFiatViaWebsiteOnly
 	y.RequestCurrencyPairFormat.Delimiter = "_"
 	y.RequestCurrencyPairFormat.Uppercase = false
 	y.RequestCurrencyPairFormat.Separator = "-"

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -298,12 +298,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	y.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
-	withdrawPermissions := y.GetWithdrawPermissions()
+	withdrawPermissions := y.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -301,11 +301,11 @@ func TestGetFee(t *testing.T) {
 func TestGetWithdrawPermissions(t *testing.T) {
 	// Arrange
 	y.SetDefaults()
-	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText + " & " + exchange.WithdrawFiatViaWebsiteOnlyText
 	// Act
 	withdrawPermissions := y.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -148,12 +148,12 @@ func TestRedeemYobicode(t *testing.T) {
 
 func setFeeBuilder() exchange.FeeBuilder {
 	return exchange.FeeBuilder{
-		Amount:         1,
-		Delimiter:      "-",
-		FeeType:        exchange.CryptocurrencyTradeFee,
-		FirstCurrency:  symbol.LTC,
-		SecondCurrency: symbol.BTC,
-		IsMaker:        false,
+		Amount:              1,
+		Delimiter:           "-",
+		FeeType:             exchange.CryptocurrencyTradeFee,
+		FirstCurrency:       symbol.LTC,
+		SecondCurrency:      symbol.BTC,
+		IsMaker:             false,
 		PurchasePrice:       1,
 		CurrencyItem:        symbol.USD,
 		BankTransactionType: exchange.WireTransfer,
@@ -295,5 +295,17 @@ func TestGetFee(t *testing.T) {
 	if resp, err := y.GetFee(feeBuilder); resp != float64(0) || err != nil {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Recieved: %f", float64(0), resp)
 		t.Error(err)
+	}
+}
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	y.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
+	// Act
+	withdrawPermissions := y.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -198,3 +198,8 @@ func (y *Yobit) GetWebsocket() (*exchange.Websocket, error) {
 func (y *Yobit) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return y.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (y *Yobit) GetWithdrawCapabilities() string {
+	return y.GetWithdrawPermissions()
+}

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -200,6 +200,6 @@ func (y *Yobit) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (y *Yobit) GetWithdrawCapabilities() string {
+func (y *Yobit) GetWithdrawCapabilities() uint32 {
 	return y.GetWithdrawPermissions()
 }

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -49,6 +49,7 @@ func (z *ZB) SetDefaults() {
 	z.Fee = 0
 	z.Verbose = false
 	z.RESTPollingDelay = 10
+	z.APIWithdrawPermissions = exchange.AutoWithdrawCrypto
 	z.RequestCurrencyPairFormat.Delimiter = "_"
 	z.RequestCurrencyPairFormat.Uppercase = false
 	z.ConfigCurrencyPairFormat.Delimiter = "_"

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -229,12 +229,12 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
-func TestGetWithdrawPermissions(t *testing.T) {
+func TestFormatWithdrawPermissions(t *testing.T) {
 	// Arrange
 	z.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoText
 	// Act
-	withdrawPermissions := z.GetWithdrawPermissions()
+	withdrawPermissions := z.FormatWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -237,6 +237,6 @@ func TestGetWithdrawPermissions(t *testing.T) {
 	withdrawPermissions := z.GetWithdrawPermissions()
 	// Assert
 	if withdrawPermissions != expectedResult {
-		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
 	}
 }

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -228,3 +228,15 @@ func TestGetFee(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetWithdrawPermissions(t *testing.T) {
+	// Arrange
+	z.SetDefaults()
+	expectedResult := exchange.AutoWithdrawCryptoText
+	// Act
+	withdrawPermissions := z.GetWithdrawPermissions()
+	// Assert
+	if withdrawPermissions != expectedResult {
+		t.Errorf("Excpected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -194,3 +194,8 @@ func (z *ZB) GetWebsocket() (*exchange.Websocket, error) {
 func (z *ZB) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 	return z.GetFee(feeBuilder)
 }
+
+// GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
+func (z *ZB) GetWithdrawCapabilities() string {
+	return z.GetWithdrawPermissions()
+}

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -196,6 +196,6 @@ func (z *ZB) GetFeeByType(feeBuilder exchange.FeeBuilder) (float64, error) {
 }
 
 // GetWithdrawCapabilities returns the types of withdrawal methods permitted by the exchange
-func (z *ZB) GetWithdrawCapabilities() string {
+func (z *ZB) GetWithdrawCapabilities() uint32 {
 	return z.GetWithdrawPermissions()
 }


### PR DESCRIPTION
This PR adds a property to the base exchange struct type to determine what types of withdrawal methods an exchange supports; fiat and/or crypto, via api or website

Also adds account information API endpoint to ANX. Don't need it anymore, but can be used to determine API permissions and other things later anyway.