### PR TITLE
Update GetDefaultDataDir to return platform best practice location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-get:
-	dep ensure
-
-build:
-	go build .
-
-install:
-	go install

--- a/README.md
+++ b/README.md
@@ -90,41 +90,37 @@ When submitting a PR, please abide by our coding guidelines:
 Download and install Go from [Go Downloads](https://golang.org/dl/) for your
 platform.
 
-### Linux/OSX
+GoCryptoTrader is built using Go Modules and requires Go 1.11 or above
 
-We use the `dep` tool provided by Golang for managing dependencies. As it is not officially part
-of the go tools package suite, you will need to manually install it if you have not already.
+Using Go Modules you now clone this repository outside your GOPATH
 
-On MacOS you can install or upgrade to the latest released version with Homebrew:
-
-```sh
-brew install dep
-brew upgrade dep
-```
-
-On linux or MacOS, you can also install it via `go get`:
-
-```sh
-go get -u github.com/golang/dep/cmd/dep
-```
-
-After `dep` is installed, please follow the instructions below:
+### Linux
 
 ```bash
-go get github.com/thrasher-/gocryptotrader
-cd $GOPATH/src/github.com/thrasher-/gocryptotrader
-make get
-make install
-cp $GOPATH/src/github.com/thrasher-/gocryptotrader/config_example.json $GOPATH/bin/config.json
+git clone https://github.com/thrasher-/gocryptotrader.git
+cd gocryptotrader
+go build
+mkdir ~/.config/gocryptotrader
+cp config_example.json ~/.config/gocryptotrader/config.json
+```
+
+### MacOS/OSX
+
+```bash
+git clone https://github.com/thrasher-/gocryptotrader.git
+cd gocryptotrader
+go build
+mkdir ~/Library/Preferences/gocryptotrader
+cp config_example.json ~/Library/Preferences/gocryptotrader/config.json
 ```
 
 ### Windows
 
 ```bash
-go get github.com/thrasher-/gocryptotrader
-cd %GOPATH%\src\github.com\thrasher-\gocryptotrader
-go install
-copy %GOPATH%\src\github.com\thrasher-\gocryptotrader\config_example.json %GOPATH%\bin\config.json
+git clone https://github.com/thrasher-/gocryptotrader.git
+cd gocryptotrader
+go build
+copy config_example.json %APPDATA%\GoCryptoTrader\config.json
 ```
 
 + Make any neccessary changes to the `config.json` file.

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"os"
+	"path"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -953,5 +956,30 @@ func TestTimeFromUnixTimestampFloat(t *testing.T) {
 	_, err = TimeFromUnixTimestampFloat(testString)
 	if err == nil {
 		t.Error("Test failed. Common TimeFromUnixTimestampFloat. Converted invalid syntax.")
+	}
+}
+
+func TestGetDefaultDataDir(t *testing.T) {
+	t.Parallel()
+	defaultDir, err := GetDefaultDataDir()
+	if err != nil {
+		t.Errorf("Test failed. Common GetDefaultDataDir returned error %s", err)
+	}
+	var dataDir string
+	switch env := runtime.GOOS; env {
+	case "windows":
+		dataDir = os.Getenv("APPDATA") + GetOSPathSlash() + "GoCryptoTrader"
+	case "darwin":
+		dataDir = path.Join(os.ExpandEnv("$HOME"), "/Library/Preferences/gocryptotrader")
+	case "linux":
+		configPath, pathIsSet := os.LookupEnv("XDG_CONFIG_HOME")
+		if !pathIsSet {
+			dataDir = path.Join(os.ExpandEnv("$HOME"), "/.config/gocryptotrader")
+			break
+		}
+		dataDir = path.Join(configPath, "gocryptotrader")
+	}
+	if defaultDir != dataDir {
+		t.Errorf("Test failed Common GetDefaultDataDir. returned wrong location expected: %s got: %s", dataDir, defaultDir)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -845,7 +844,8 @@ func GetFilePath(file string) (string, error) {
 	oldDir := exePath + common.GetOSPathSlash()
 	oldDirs := []string{oldDir + ConfigFile, oldDir + EncryptedConfigFile}
 
-	newDir := common.GetDefaultDataDir(runtime.GOOS) + common.GetOSPathSlash()
+	defaultDir, _ := common.GetDefaultDataDir()
+	newDir := defaultDir + common.GetOSPathSlash()
 	err = common.CheckDir(newDir, true)
 	if err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -21,13 +21,17 @@ func main() {
 		log.Fatal(err)
 	}
 
+	dataDir, err := common.GetDefaultDataDir()
+	if err != nil {
+		log.Fatal(err)
+	}
 	//Handle flags
 	var settings engine.Settings
 	versionFlag := flag.Bool("version", false, "retrieves current GoCryptoTrader version")
 
 	// Core settings
 	flag.StringVar(&settings.ConfigFile, "config", defaultPath, "config file to load")
-	flag.StringVar(&settings.DataDir, "datadir", common.GetDefaultDataDir(runtime.GOOS), "default data directory for GoCryptoTrader files")
+	flag.StringVar(&settings.DataDir, "datadir", dataDir, "default data directory for GoCryptoTrader files")
 	flag.IntVar(&settings.GoMaxProcs, "gomaxprocs", runtime.NumCPU(), "sets the runtime GOMAXPROCS value")
 	flag.BoolVar(&settings.EnableDryRun, "dryrun", false, "dry runs bot, doesn't save config file")
 	flag.BoolVar(&settings.EnableAllExchanges, "enableallexchanges", false, "enables all exchanges")


### PR DESCRIPTION
# Description

Currently GetDefaultDataDir just creates a .gocryptotrader folder in the users home path or appdata\roaming on windows this can lead to unwanted files in the user space

Following the "Don't Pollute User Space" guide this updates the location to current industry "best practice" locations

Windows: no changes
Linux: XDG_CONFIG_HOME location or if not set default back to ~/.config/gocryptotrader
OSX: ~/Library/Preferences/gocryptotrader

This will mean users have to move existing data folder from ~/.gocryptotrader to the updated path
 because of this i am flagging it as a breaking change

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Running go test ./... on machines running Ubuntu 18.04 & Windows 10
Running compiled binary both machines

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules