### PR TITLE
Fixes DNS rebinding vulnerability in router by explicitly passing Host parameter based off config listenaddress

### DIFF
--- a/engine/restful_server_test.go
+++ b/engine/restful_server_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
 )
 
@@ -47,5 +48,37 @@ func TestConfigAllJsonResponse(t *testing.T) {
 
 	if reflect.DeepEqual(responseConfig, cfg) {
 		t.Error("Test failed. Json not equal to config")
+	}
+}
+
+func TestInvalidHostRequest(t *testing.T) {
+	t.Parallel()
+	req, err := http.NewRequest("GET", "/config/all", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "invalidsite.com"
+
+	resp := httptest.NewRecorder()
+	NewRouter(true).ServeHTTP(resp, req)
+
+	if status := resp.Code; status != http.StatusNotFound {
+		t.Errorf("Test failed. Response returned wrong status code expected %v got %v", http.StatusNotFound, status)
+	}
+}
+
+func TestValidHostRequest(t *testing.T) {
+	t.Parallel()
+	req, err := http.NewRequest("GET", "/config/all", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = common.ExtractHost(Bot.Config.RESTServer.ListenAddress)
+
+	resp := httptest.NewRecorder()
+	NewRouter(true).ServeHTTP(resp, req)
+
+	if status := resp.Code; status != http.StatusOK {
+		t.Errorf("Test failed. Response returned wrong status code expected %v got %v", http.StatusOK, status)
 	}
 }


### PR DESCRIPTION
# Description

The current router setup by design accepts requests from any hosts making it vulnerable to [DNS rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Automated testing with unit tests:

Running go test ./...

Manual testing running

``
curl localhost:9050/config/all -H "Host: localhost" -verborse
``
``
curl localhost:9050/config/all -H "Host: superawesomeinvalidhost.com" -verborse
``

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
