### PR TITLE
Map exchange wrapper function "SubmitExchangeOrder" to exchange implementations

### DIFF
--- a/exchanges/alphapoint/alphapoint.go
+++ b/exchanges/alphapoint/alphapoint.go
@@ -359,17 +359,26 @@ func (a *Alphapoint) WithdrawCoins(symbol, product, address string, amount float
 	return nil
 }
 
+func (a *Alphapoint) convertOrderTypeToOrderTypeNumber(orderType string) (orderTypeNumber int64) {
+	if orderType == exchange.OrderTypeMarket().Format(a.Name) {
+		orderTypeNumber = 1
+	}
+
+	return orderTypeNumber
+}
+
 // CreateOrder creates a market or limit order
 // symbol - Instrument code (ex: “BTCUSD”)
 // side - “buy” or “sell”
 // orderType - “1” for market orders, “0” for limit orders
 // quantity - Quantity
 // price - Price in USD
-func (a *Alphapoint) CreateOrder(symbol, side string, orderType int, quantity, price float64) (int64, error) {
+func (a *Alphapoint) CreateOrder(symbol, side, orderType string, quantity, price float64) (int64, error) {
+	orderTypeNumber := a.convertOrderTypeToOrderTypeNumber(orderType)
 	request := make(map[string]interface{})
 	request["ins"] = symbol
 	request["side"] = side
-	request["orderType"] = orderType
+	request["orderType"] = orderTypeNumber
 	request["qty"] = strconv.FormatFloat(quantity, 'f', -1, 64)
 	request["px"] = strconv.FormatFloat(price, 'f', -1, 64)
 	response := Response{}

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -411,7 +411,7 @@ func TestCreateOrder(t *testing.T) {
 		return
 	}
 
-	_, err := a.CreateOrder("", "", 1, 0.01, 0)
+	_, err := a.CreateOrder("", "", exchange.OrderTypeMarket().Format(a.Name), 0.01, 0)
 	if err == nil {
 		t.Error("Test Failed - GetUserInfo() error")
 	}

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -106,8 +106,7 @@ func (a *Alphapoint) GetExchangeHistory(p pair.CurrencyPair, assetType string) (
 // SubmitExchangeOrder submits a new order and returns a true value when
 // successfully submitted
 func (a *Alphapoint) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
-	//return a.CreateOrder(p.Pair().String(), side, orderType, amount, price)
-	return 0, errors.New("not yet implemented")
+	return a.CreateOrder(p.Pair().String(), side.Format(a.Name), orderType.Format(a.Name), amount, price)
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -105,7 +105,7 @@ func (a *Alphapoint) GetExchangeHistory(p pair.CurrencyPair, assetType string) (
 
 // SubmitExchangeOrder submits a new order and returns a true value when
 // successfully submitted
-func (a *Alphapoint) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (a *Alphapoint) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return a.CreateOrder(p.Pair().String(), side.Format(a.Name), orderType.Format(a.Name), amount, price)
 }
 

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -2,6 +2,7 @@ package alphapoint
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/exchanges"
@@ -106,7 +107,8 @@ func (a *Alphapoint) GetExchangeHistory(p pair.CurrencyPair, assetType string) (
 // SubmitExchangeOrder submits a new order and returns a true value when
 // successfully submitted
 func (a *Alphapoint) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return a.CreateOrder(p.Pair().String(), side.Format(a.Name), orderType.Format(a.Name), amount, price)
+	response, err := a.CreateOrder(p.Pair().String(), side.Format(a.Name), orderType.Format(a.Name), amount, price)
+	return strconv.FormatInt(response, 64), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -2,7 +2,7 @@ package alphapoint
 
 import (
 	"errors"
-	"strconv"
+	"fmt"
 
 	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/exchanges"
@@ -108,7 +108,8 @@ func (a *Alphapoint) GetExchangeHistory(p pair.CurrencyPair, assetType string) (
 // successfully submitted
 func (a *Alphapoint) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	response, err := a.CreateOrder(p.Pair().String(), side.Format(a.Name), orderType.Format(a.Name), amount, price)
-	return strconv.FormatInt(response, 64), err
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -78,7 +78,7 @@ func (a *ANX) Setup(exch config.ExchangeConfig) {
 	} else {
 		a.Enabled = true
 		a.AuthenticatedAPISupport = exch.AuthenticatedAPISupport
-		a.SetAPIKeys(exch.APIKey, exch.APISecret, "", true)
+		a.SetAPIKeys(exch.APIKey, exch.APISecret, "", false)
 		a.SetHTTPClientTimeout(exch.HTTPTimeout)
 		a.SetHTTPClientUserAgent(exch.HTTPUserAgent)
 		a.RESTPollingDelay = exch.RESTPollingDelay
@@ -223,7 +223,7 @@ func (a *ANX) NewOrder(orderType string, buy bool, tradedCurrency string, traded
 
 	type OrderResponse struct {
 		OrderID    string `json:"orderId"`
-		Timestamp  int64  `json:"timestamp"`
+		Timestamp  int64  `json:"timestamp,string"`
 		ResultCode string `json:"resultCode"`
 	}
 	var response OrderResponse
@@ -234,7 +234,7 @@ func (a *ANX) NewOrder(orderType string, buy bool, tradedCurrency string, traded
 	}
 
 	if response.ResultCode != "OK" {
-		return "", errors.New("Response code is not OK: %s" + response.ResultCode)
+		return "", errors.New("Response code is not OK: " + response.ResultCode)
 	}
 	return response.OrderID, nil
 }

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -196,10 +196,10 @@ func (a *ANX) GetDataToken() (string, error) {
 }
 
 // NewOrder sends a new order request to the exchange.
-func (a *ANX) NewOrder(orderType string, buy bool, tradedCurrency, tradedCurrencyAmount, settlementCurrency, settlementCurrencyAmount, limitPriceSettlement string,
-	replace bool, replaceUUID string, replaceIfActive bool) error {
-	request := make(map[string]interface{})
+func (a *ANX) NewOrder(orderType string, buy bool, tradedCurrency string, tradedCurrencyAmount float64, settlementCurrency string, settlementCurrencyAmount float64, limitPriceSettlement float64,
+	replace bool, replaceUUID string, replaceIfActive bool) (string, error) {
 
+	request := make(map[string]interface{})
 	var order Order
 	order.OrderType = orderType
 	order.BuyTradedCurrency = buy
@@ -230,13 +230,13 @@ func (a *ANX) NewOrder(orderType string, buy bool, tradedCurrency, tradedCurrenc
 
 	err := a.SendAuthenticatedHTTPRequest(anxOrderNew, request, &response)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if response.ResultCode != "OK" {
-		return errors.New("Response code is not OK: %s" + response.ResultCode)
+		return "", errors.New("Response code is not OK: %s" + response.ResultCode)
 	}
-	return nil
+	return response.OrderID, nil
 }
 
 // OrderInfo returns information about a specific order

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -233,8 +233,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "_",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "USD",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USD,
 	}
 	response, err := a.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/anx/anx_types.go
+++ b/exchanges/anx/anx_types.go
@@ -99,15 +99,15 @@ type CurrenciesStaticResponse struct {
 
 // Order holds order information
 type Order struct {
-	OrderType                      string `json:"orderType"`
-	BuyTradedCurrency              bool   `json:"buyTradedCurrency"`
-	TradedCurrency                 string `json:"tradedCurrency"`
-	SettlementCurrency             string `json:"settlementCurrency"`
-	TradedCurrencyAmount           string `json:"tradedCurrencyAmount"`
-	SettlementCurrencyAmount       string `json:"settlementCurrencyAmount"`
-	LimitPriceInSettlementCurrency string `json:"limitPriceInSettlementCurrency"`
-	ReplaceExistingOrderUUID       string `json:"replaceExistingOrderUuid"`
-	ReplaceOnlyIfActive            bool   `json:"replaceOnlyIfActive"`
+	OrderType                      string  `json:"orderType"`
+	BuyTradedCurrency              bool    `json:"buyTradedCurrency"`
+	TradedCurrency                 string  `json:"tradedCurrency"`
+	SettlementCurrency             string  `json:"settlementCurrency"`
+	TradedCurrencyAmount           float64 `json:"tradedCurrencyAmount,string"`
+	SettlementCurrencyAmount       float64 `json:"settlementCurrencyAmount,string"`
+	LimitPriceInSettlementCurrency float64 `json:"limitPriceInSettlementCurrency,string"`
+	ReplaceExistingOrderUUID       string  `json:"replaceExistingOrderUuid"`
+	ReplaceOnlyIfActive            bool    `json:"replaceOnlyIfActive"`
 }
 
 // OrderResponse holds order response data

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -196,8 +196,16 @@ func (a *ANX) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]excha
 }
 
 // SubmitExchangeOrder submits a new order
-func (a *ANX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
-	return 0, errors.New("not yet implemented")
+func (a *ANX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
+	var isBuying bool
+	var limitPriceInSettlementCurrency float64
+	if side == exchange.Buy {
+		isBuying = true
+	}
+	if orderType == exchange.Limit {
+		limitPriceInSettlementCurrency = price
+	}
+	return a.NewOrder(orderType.Format(a.Name), isBuying, p.FirstCurrency.String(), amount, p.SecondCurrency.String(), amount, limitPriceInSettlementCurrency, false, "", false)
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -426,8 +426,12 @@ func (b *Binance) NewOrder(o NewOrderRequest) (NewOrderResponse, error) {
 	params.Set("side", string(o.Side))
 	params.Set("type", string(o.TradeType))
 	params.Set("quantity", strconv.FormatFloat(o.Quantity, 'f', -1, 64))
-	params.Set("price", strconv.FormatFloat(o.Price, 'f', -1, 64))
-	params.Set("timeInForce", string(o.TimeInForce))
+	if o.TradeType == "LIMIT" {
+		params.Set("price", strconv.FormatFloat(o.Price, 'f', -1, 64))
+	}
+	if o.TimeInForce != "" {
+		params.Set("timeInForce", string(o.TimeInForce))
+	}
 
 	if o.NewClientOrderID != "" {
 		params.Set("newClientOrderID", o.NewClientOrderID)

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -3,6 +3,7 @@ package binance
 import (
 	"testing"
 
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -11,8 +12,9 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey    = ""
-	testAPISecret = ""
+	testAPIKey     = ""
+	testAPISecret  = ""
+	canPlaceOrders = false
 )
 
 var b Binance
@@ -326,5 +328,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip()
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "LTC",
+		SecondCurrency: "BTC",
+	}
+	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned")
 	}
 }

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -344,8 +344,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "LTC",
-		SecondCurrency: "BTC",
+		FirstCurrency:  symbol.LTC,
+		SecondCurrency: symbol.BTC,
 	}
 	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -3,6 +3,7 @@ package binance
 import (
 	"errors"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -142,7 +143,17 @@ func (b *Binance) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 
 // SubmitExchangeOrder submits a new order
 func (b *Binance) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var orderRequest = NewOrderRequest{
+		Symbol:    p.FirstCurrency.String() + p.SecondCurrency.String(),
+		Side:      RequestParamsSideType(side.Format(b.Name)),
+		Price:     price,
+		Quantity:  amount,
+		TradeType: RequestParamsOrderType(orderType.Format(b.Name)),
+	}
+
+	response, err := b.NewOrder(orderRequest)
+
+	return strconv.FormatInt(response.OrderID, 64), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -141,7 +141,7 @@ func (b *Binance) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *Binance) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *Binance) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -2,8 +2,8 @@ package binance
 
 import (
 	"errors"
+	"fmt"
 	"log"
-	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -143,17 +143,30 @@ func (b *Binance) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 
 // SubmitExchangeOrder submits a new order
 func (b *Binance) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
+	var sideType RequestParamsSideType
+	if side == exchange.Buy {
+		sideType = BinanceRequestParamsSideBuy
+	} else {
+		sideType = BinanceRequestParamsSideSell
+	}
+
+	var orderTypeTypeType RequestParamsOrderType
+	if orderType == exchange.Market {
+		orderTypeTypeType = BinanceRequestParamsOrderMarket
+	} else if orderType == exchange.Limit {
+		orderTypeTypeType = BinanceRequestParamsOrderLimit
+	}
 	var orderRequest = NewOrderRequest{
 		Symbol:    p.FirstCurrency.String() + p.SecondCurrency.String(),
-		Side:      RequestParamsSideType(side.Format(b.Name)),
+		Side:      sideType,
 		Price:     price,
 		Quantity:  amount,
-		TradeType: RequestParamsOrderType(orderType.Format(b.Name)),
+		TradeType: orderTypeTypeType,
 	}
 
 	response, err := b.NewOrder(orderRequest)
 
-	return strconv.FormatInt(response.OrderID, 64), err
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -150,18 +150,18 @@ func (b *Binance) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSi
 		sideType = BinanceRequestParamsSideSell
 	}
 
-	var orderTypeTypeType RequestParamsOrderType
+	var requestParamsOrderType RequestParamsOrderType
 	if orderType == exchange.Market {
-		orderTypeTypeType = BinanceRequestParamsOrderMarket
+		requestParamsOrderType = BinanceRequestParamsOrderMarket
 	} else if orderType == exchange.Limit {
-		orderTypeTypeType = BinanceRequestParamsOrderLimit
+		requestParamsOrderType = BinanceRequestParamsOrderLimit
 	}
 	var orderRequest = NewOrderRequest{
 		Symbol:    p.FirstCurrency.String() + p.SecondCurrency.String(),
 		Side:      sideType,
 		Price:     price,
 		Quantity:  amount,
-		TradeType: orderTypeTypeType,
+		TradeType: requestParamsOrderType,
 	}
 
 	response, err := b.NewOrder(orderRequest)

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -8,14 +8,16 @@ import (
 
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
 
 // Please supply your own keys here to do better tests
 const (
-	testAPIKey    = ""
-	testAPISecret = ""
+	testAPIKey     = ""
+	testAPISecret  = ""
+	canPlaceOrders = false
 )
 
 var b Bitfinex
@@ -716,5 +718,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip()
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "LTC",
+		SecondCurrency: "BTC",
+	}
+	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned")
 	}
 }

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -734,8 +734,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "LTC",
-		SecondCurrency: "BTC",
+		FirstCurrency:  symbol.LTC,
+		SecondCurrency: symbol.BTC,
 	}
 	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"net/url"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -175,7 +176,14 @@ func (b *Bitfinex) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]
 
 // SubmitExchangeOrder submits a new order
 func (b *Bitfinex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var isBuying bool
+	if side == exchange.Buy {
+		isBuying = true
+	}
+
+	butts, err := b.NewOrder(p.Pair().String(), amount, price, isBuying, orderType.Format(b.Name), false)
+
+	return strconv.FormatInt(butts.OrderID, 64), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -174,7 +174,7 @@ func (b *Bitfinex) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *Bitfinex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *Bitfinex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -2,9 +2,9 @@ package bitfinex
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/url"
-	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -177,13 +177,14 @@ func (b *Bitfinex) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]
 // SubmitExchangeOrder submits a new order
 func (b *Bitfinex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	var isBuying bool
+
 	if side == exchange.Buy {
 		isBuying = true
 	}
 
-	butts, err := b.NewOrder(p.Pair().String(), amount, price, isBuying, orderType.Format(b.Name), false)
+	response, err := b.NewOrder(p.Pair().String(), amount, price, isBuying, orderType.Format(b.Name), false)
 
-	return strconv.FormatInt(butts.OrderID, 64), err
+	return fmt.Sprintf("%v", response.OrderID), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -13,8 +13,9 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey    = ""
-	testAPISecret = ""
+	testAPIKey     = ""
+	testAPISecret  = ""
+	canPlaceOrders = false
 )
 
 var b Bitflyer
@@ -244,5 +245,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip()
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "LTC",
+	}
+	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned")
 	}
 }

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -261,8 +261,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "LTC",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/bitflyer/bitflyer_types.go
+++ b/exchanges/bitflyer/bitflyer_types.go
@@ -278,3 +278,14 @@ type CollateralHistory struct {
 	Reason       string  `json:"reason_code"`
 	Date         string  `json:"date"`
 }
+
+// NewOrder to send a new order
+type NewOrder struct {
+	ProductCode    string  `json:"product_code"`
+	ChildOrderType string  `json:"child_order_type"`
+	Side           string  `json:"side"`
+	Price          float64 `json:"price"`
+	Size           float64 `json:"size"`
+	MinuteToExpire float64 `json:"minute_to_expire"`
+	TimeInForce    string  `json:"time_in_force"`
+}

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -153,7 +153,7 @@ func (b *Bitflyer) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *Bitflyer) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *Bitflyer) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -154,7 +154,7 @@ func (b *Bitflyer) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]
 
 // SubmitExchangeOrder submits a new order
 func (b *Bitflyer) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	return "", errors.New("not yet implemented")
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -4,14 +4,16 @@ import (
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey    = ""
-	testAPISecret = ""
+	testAPIKey     = ""
+	testAPISecret  = ""
+	canPlaceOrders = false
 )
 
 var b Bithumb
@@ -279,5 +281,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip()
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "LTC",
+	}
+	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned")
 	}
 }

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -297,8 +297,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "LTC",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -141,7 +141,15 @@ func (b *Bithumb) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 
 // SubmitExchangeOrder submits a new order
 func (b *Bithumb) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var err error
+	if side == exchange.Buy {
+		result, err := b.MarketBuyOrder(p.FirstCurrency.String(), amount)
+		return result.OrderID, err
+	} else if side == exchange.Sell {
+		result, err := b.MarketSellOrder(p.FirstCurrency.String(), amount)
+		return result.OrderID, err
+	}
+	return "", err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -140,7 +140,7 @@ func (b *Bithumb) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *Bithumb) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *Bithumb) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/bitmex/bitmex_parameters.go
+++ b/exchanges/bitmex/bitmex_parameters.go
@@ -286,7 +286,7 @@ type OrderNewParams struct {
 
 	// DisplayQty - [Optional] quantity to display in the book. Use 0 for a fully
 	// hidden order.
-	DisplayQty int32 `json:"displayQty,omitempty"`
+	DisplayQty float64 `json:"displayQty,omitempty"`
 
 	// ExecInst - [Optional] execution instructions. Valid options:
 	// ParticipateDoNotInitiate, AllOrNone, MarkPrice, IndexPrice, LastPrice,
@@ -303,7 +303,7 @@ type OrderNewParams struct {
 	OrdType string `json:"ordType,omitempty"`
 
 	//OrderQty Order quantity in units of the instrument (i.e. contracts).
-	OrderQty int32 `json:"orderQty,omitempty"`
+	OrderQty float64 `json:"orderQty,omitempty"`
 
 	// PegOffsetValue - [Optional] trailing offset from the current price for
 	// 'Stop', 'StopLimit', 'MarketIfTouched', and 'LimitIfTouched' orders; use a

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -6,14 +6,16 @@ import (
 	"time"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey    = ""
-	testAPISecret = ""
+	testAPIKey     = ""
+	testAPISecret  = ""
+	canPlaceOrders = false
 )
 
 var b Bitmex
@@ -459,5 +461,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip()
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "XBT",
+		SecondCurrency: "USD",
+	}
+	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned")
 	}
 }

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -477,8 +477,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "XBT",
-		SecondCurrency: "USD",
+		FirstCurrency:  symbol.XBT,
+		SecondCurrency: symbol.USD,
 	}
 	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -144,7 +144,7 @@ func (b *Bitmex) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *Bitmex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *Bitmex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -145,7 +145,19 @@ func (b *Bitmex) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 
 // SubmitExchangeOrder submits a new order
 func (b *Bitmex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var oderParams = OrderNewParams{
+		OrdType:  side.Format(b.Name),
+		Symbol:   p.Pair().String(),
+		OrderQty: amount,
+		Side:     side.Format(b.Name),
+	}
+
+	if orderType == exchange.Limit {
+		oderParams.Price = price
+	}
+
+	response, err := b.CreateOrder(oderParams)
+	return response.OrderID, err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -145,7 +145,7 @@ func (b *Bitmex) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 
 // SubmitExchangeOrder submits a new order
 func (b *Bitmex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	var oderParams = OrderNewParams{
+	var orderNewParams = OrderNewParams{
 		OrdType:  side.Format(b.Name),
 		Symbol:   p.Pair().String(),
 		OrderQty: amount,
@@ -153,10 +153,10 @@ func (b *Bitmex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSid
 	}
 
 	if orderType == exchange.Limit {
-		oderParams.Price = price
+		orderNewParams.Price = price
 	}
 
-	response, err := b.CreateOrder(oderParams)
+	response, err := b.CreateOrder(orderNewParams)
 	return response.OrderID, err
 }
 

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -100,6 +100,10 @@ func (b *Bitstamp) Setup(exch config.ExchangeConfig) {
 		b.BaseCurrencies = common.SplitStrings(exch.BaseCurrencies, ",")
 		b.AvailablePairs = common.SplitStrings(exch.AvailablePairs, ",")
 		b.EnabledPairs = common.SplitStrings(exch.EnabledPairs, ",")
+		b.APIKey = exch.APIKey
+		b.APISecret = exch.APISecret
+		b.SetAPIKeys(exch.APIKey, exch.APISecret, b.ClientID, false)
+		b.AuthenticatedAPISupport = true
 		err := b.SetCurrencyPairFormat()
 		if err != nil {
 			log.Fatal(err)
@@ -612,5 +616,7 @@ func (b *Bitstamp) SendAuthenticatedHTTPRequest(path string, v2 bool, values url
 	headers := make(map[string]string)
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-	return b.SendPayload("POST", path, headers, strings.NewReader(values.Encode()), result, true, b.Verbose)
+	butts := values.Encode()
+	buttsTwo := strings.NewReader(butts)
+	return b.SendPayload("POST", path, headers, buttsTwo, result, true, b.Verbose)
 }

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -616,7 +616,7 @@ func (b *Bitstamp) SendAuthenticatedHTTPRequest(path string, v2 bool, values url
 	headers := make(map[string]string)
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-	butts := values.Encode()
-	buttsTwo := strings.NewReader(butts)
-	return b.SendPayload("POST", path, headers, buttsTwo, result, true, b.Verbose)
+	encodedValues := values.Encode()
+	readerValues := strings.NewReader(encodedValues)
+	return b.SendPayload("POST", path, headers, readerValues, result, true, b.Verbose)
 }

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -252,7 +252,10 @@ func TestGetOpenOrders(t *testing.T) {
 
 func TestGetOrderStatus(t *testing.T) {
 	t.Parallel()
-
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" {
+		t.Skip()
+	}
 	_, err := b.GetOrderStatus(1337)
 	if err == nil {
 		t.Error("Test Failed - GetOpenOrders() error")
@@ -279,7 +282,10 @@ func TestCancelAllOrders(t *testing.T) {
 
 func TestPlaceOrder(t *testing.T) {
 	t.Parallel()
-
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" {
+		t.Skip()
+	}
 	_, err := b.PlaceOrder("btcusd", 0.01, 1, true, true)
 	if err == nil {
 		t.Error("Test Failed - PlaceOrder() error")
@@ -301,6 +307,10 @@ func TestGetWithdrawalRequests(t *testing.T) {
 
 func TestCryptoWithdrawal(t *testing.T) {
 	t.Parallel()
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" {
+		t.Skip()
+	}
 
 	_, err := b.CryptoWithdrawal(0, "bla", "btc", "", true)
 	if err == nil {
@@ -327,8 +337,12 @@ func TestGetUnconfirmedBitcoinDeposits(t *testing.T) {
 }
 
 func TestTransferAccountBalance(t *testing.T) {
-	t.Parallel()
 
+	t.Parallel()
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" {
+		t.Skip()
+	}
 	_, err := b.TransferAccountBalance(1, "", "", true)
 	if err == nil {
 		t.Error("Test Failed - TransferAccountBalance() error", err)

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	"github.com/thrasher-/gocryptotrader/exchanges"
 
@@ -13,9 +14,10 @@ import (
 
 // Please add your private keys and customerID for better tests
 const (
-	apiKey     = ""
-	apiSecret  = ""
-	customerID = ""
+	apiKey         = ""
+	apiSecret      = ""
+	customerID     = ""
+	canPlaceOrders = false
 )
 
 var b Bitstamp
@@ -47,9 +49,11 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Error("Test Failed - Bitstamp Setup() init error")
 	}
+	bConfig.APIKey = apiKey
+	bConfig.APISecret = apiSecret
 	b.Setup(bConfig)
 
-	if !b.IsEnabled() || b.AuthenticatedAPISupport || b.RESTPollingDelay != time.Duration(10) ||
+	if !b.IsEnabled() || b.RESTPollingDelay != time.Duration(10) ||
 		b.Verbose || b.Websocket.IsEnabled() || len(b.BaseCurrencies) < 1 ||
 		len(b.AvailablePairs) < 1 || len(b.EnabledPairs) < 1 {
 		t.Error("Test Failed - Bitstamp Setup values not set correctly")
@@ -344,5 +348,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip()
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "USD",
+	}
+	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned")
 	}
 }

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -378,8 +378,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "USD",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USD,
 	}
 	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -165,7 +165,7 @@ func (b *Bitstamp) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *Bitstamp) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *Bitstamp) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -3,6 +3,7 @@ package bitstamp
 import (
 	"errors"
 	"log"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -166,7 +167,11 @@ func (b *Bitstamp) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]
 
 // SubmitExchangeOrder submits a new order
 func (b *Bitstamp) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	buy := side == exchange.Buy
+	market := orderType == exchange.Market
+	order, err := b.PlaceOrder(p.Pair().String(), price, amount, buy, market)
+
+	return strconv.FormatInt(order.ID, 64), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -2,8 +2,8 @@ package bitstamp
 
 import (
 	"errors"
+	"fmt"
 	"log"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -171,7 +171,7 @@ func (b *Bitstamp) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderS
 	market := orderType == exchange.Market
 	order, err := b.PlaceOrder(p.Pair().String(), price, amount, buy, market)
 
-	return strconv.FormatInt(order.ID, 64), err
+	return fmt.Sprintf("%v", order.ID), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -346,8 +346,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "-",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "LTC",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/bittrex/bittrex_types.go
+++ b/exchanges/bittrex/bittrex_types.go
@@ -150,7 +150,7 @@ type DepositAddress struct {
 type UUID struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`
-	Result  []struct {
+	Result  struct {
 		ID string `json:"uuid"`
 	} `json:"result"`
 }

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -169,7 +169,7 @@ func (b *Bittrex) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *Bittrex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *Bittrex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -170,7 +170,21 @@ func (b *Bittrex) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 
 // SubmitExchangeOrder submits a new order
 func (b *Bittrex) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	buy := side == exchange.Buy
+	var response UUID
+	var err error
+
+	if orderType != exchange.Limit {
+		return "", errors.New("not supported on exchange")
+	}
+
+	if buy {
+		response, err = b.PlaceBuyLimit(p.Pair().String(), amount, price)
+	} else {
+		response, err = b.PlaceSellLimit(p.Pair().String(), amount, price)
+	}
+
+	return response.Result.ID, err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -151,7 +151,7 @@ func (b *BTCC) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exch
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *BTCC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *BTCC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -152,7 +152,7 @@ func (b *BTCC) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exch
 
 // SubmitExchangeOrder submits a new order
 func (b *BTCC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	return "", errors.New("not yet implemented")
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -14,8 +14,9 @@ var b BTCMarkets
 
 // Please supply your own keys here to do better tests
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -306,5 +307,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip()
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "-",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "LTC",
+	}
+	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned")
 	}
 }

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -323,8 +323,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "-",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "LTC",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -153,7 +153,7 @@ func (b *BTCMarkets) GetExchangeHistory(p pair.CurrencyPair, assetType string) (
 }
 
 // SubmitExchangeOrder submits a new order
-func (b *BTCMarkets) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (b *BTCMarkets) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return b.NewOrder(p.FirstCurrency.Upper().String(), p.SecondCurrency.Upper().String(), price, amount, side.Format(b.GetName()), orderType.Format(b.GetName()), clientID)
 }
 

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -2,6 +2,7 @@ package btcmarkets
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -154,7 +155,9 @@ func (b *BTCMarkets) GetExchangeHistory(p pair.CurrencyPair, assetType string) (
 
 // SubmitExchangeOrder submits a new order
 func (b *BTCMarkets) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return b.NewOrder(p.FirstCurrency.Upper().String(), p.SecondCurrency.Upper().String(), price, amount, side.Format(b.GetName()), orderType.Format(b.GetName()), clientID)
+	response, err := b.NewOrder(p.FirstCurrency.Upper().String(), p.SecondCurrency.Upper().String(), price, amount, side.Format(b.GetName()), orderType.Format(b.GetName()), clientID)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -1,10 +1,12 @@
 package coinbasepro
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -13,9 +15,10 @@ var c CoinbasePro
 
 // Please supply your APIKeys here for better testing
 const (
-	apiKey    = ""
-	apiSecret = ""
-	clientID  = "" //passphrase you made at API CREATION
+	apiKey         = ""
+	apiSecret      = ""
+	clientID       = "" //passphrase you made at API CREATION
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -30,7 +33,9 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Error("Test Failed - coinbasepro Setup() init error")
 	}
-
+	gdxConfig.APIKey = apiKey
+	gdxConfig.APISecret = apiSecret
+	gdxConfig.AuthenticatedAPISupport = true
 	c.Setup(gdxConfig)
 }
 
@@ -400,5 +405,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	c.SetDefaults()
+	TestSetup(t)
+
+	if c.APIKey == "" || c.APISecret == "" ||
+		c.APIKey == "Key" || c.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can Place others: %v", c.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "-",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "LTC",
+	}
+	response, err := c.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -421,8 +421,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "-",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "LTC",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.LTC,
 	}
 	response, err := c.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
 	if err != nil {

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -144,7 +144,7 @@ func (c *CoinbasePro) GetExchangeHistory(p pair.CurrencyPair, assetType string) 
 }
 
 // SubmitExchangeOrder submits a new order
-func (c *CoinbasePro) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (c *CoinbasePro) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -145,7 +145,18 @@ func (c *CoinbasePro) GetExchangeHistory(p pair.CurrencyPair, assetType string) 
 
 // SubmitExchangeOrder submits a new order
 func (c *CoinbasePro) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var response string
+	var err error
+	if orderType == exchange.Market {
+		response, err = c.PlaceMarginOrder("", amount, amount, side.Format(c.Name), p.Pair().String(), "")
+
+	} else if orderType == exchange.Limit {
+		response, err = c.PlaceLimitOrder("", price, amount, side.Format(c.Name), "", "", p.Pair().String(), "", false)
+	} else {
+		err = errors.New("not supported")
+	}
+
+	return response, err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -156,6 +156,10 @@ func (c *CoinbasePro) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.Ord
 		err = errors.New("not supported")
 	}
 
+	if response == "" {
+		err = errors.New("No orderId returned")
+	}
+
 	return response, err
 }
 

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -80,7 +80,7 @@ func (c *COINUT) Setup(exch config.ExchangeConfig) {
 	} else {
 		c.Enabled = true
 		c.AuthenticatedAPISupport = exch.AuthenticatedAPISupport
-		c.SetAPIKeys(exch.APIKey, exch.APISecret, exch.ClientID, true)
+		c.SetAPIKeys(exch.APIKey, exch.APISecret, exch.ClientID, false)
 		c.SetHTTPClientTimeout(exch.HTTPTimeout)
 		c.SetHTTPClientUserAgent(exch.HTTPUserAgent)
 		c.RESTPollingDelay = exch.RESTPollingDelay
@@ -172,9 +172,9 @@ func (c *COINUT) NewOrder(instrumentID int, quantity, price float64, buy bool, o
 	params := make(map[string]interface{})
 	params["inst_id"] = instrumentID
 	if price > 0 {
-		params["price"] = price
+		params["price"] = fmt.Sprintf("%v", price)
 	}
-	params["qty"] = quantity
+	params["qty"] = fmt.Sprintf("%v", quantity)
 	params["side"] = "BUY"
 	if !buy {
 		params["side"] = "SELL"
@@ -191,7 +191,7 @@ func (c *COINUT) NewOrder(instrumentID int, quantity, price float64, buy bool, o
 	if _, ok := result.(OrdersBase); ok {
 		return result.(OrdersBase), err
 	}
-	return result, errors.New("Could not handle response")
+	return result, err
 }
 
 // NewOrders places multiple orders on the exchange

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -1,10 +1,12 @@
 package coinut
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -13,8 +15,9 @@ var c COINUT
 
 // Please supply your own keys here to do better tests
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -28,10 +31,13 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Error("Test Failed - Coinut Setup() init error")
 	}
+	bConfig.AuthenticatedAPISupport = true
+	bConfig.APISecret = apiSecret
+	bConfig.Verbose = true
 	c.Setup(bConfig)
 
-	if !c.IsEnabled() || c.AuthenticatedAPISupport ||
-		c.RESTPollingDelay != time.Duration(10) || c.Verbose ||
+	if !c.IsEnabled() ||
+		c.RESTPollingDelay != time.Duration(10) ||
 		c.Websocket.IsEnabled() || len(c.BaseCurrencies) < 1 ||
 		len(c.AvailablePairs) < 1 || len(c.EnabledPairs) < 1 {
 		t.Error("Test Failed - Coinut Setup values not set correctly")
@@ -184,5 +190,31 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	c.SetDefaults()
+	TestSetup(t)
+	c.Verbose = true
+
+	if c.APISecret == "" ||
+		c.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", c.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "USD",
+	}
+	response, err := c.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 10, "1234234")
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -207,8 +207,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "USD",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USD,
 	}
 	response, err := c.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 10, "1234234")
 	if err != nil {

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -141,7 +141,7 @@ func (c *COINUT) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 }
 
 // SubmitExchangeOrder submits a new order
-func (c *COINUT) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (c *COINUT) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -147,7 +147,7 @@ func (c *COINUT) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSid
 	var err error
 	var APIresponse interface{}
 	var response string
-	buy := side == exchange.Buy
+	isBuyOrder := side == exchange.Buy
 	clientIDInt, err := strconv.ParseUint(clientID, 0, 32)
 	clientIDUint := uint32(clientIDInt)
 
@@ -155,18 +155,18 @@ func (c *COINUT) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSid
 		return "", err
 	}
 	// Need to get the ID of the currency sent
-	instrucments, err := c.GetInstruments()
+	instruments, err := c.GetInstruments()
 	if err != nil {
 		return "", err
 	}
 
-	currencyArray := instrucments.Instruments[p.Pair().String()]
+	currencyArray := instruments.Instruments[p.Pair().String()]
 	currencyID := currencyArray[0].InstID
 
 	if orderType == exchange.Limit {
-		APIresponse, err = c.NewOrder(currencyID, amount, price, buy, clientIDUint)
+		APIresponse, err = c.NewOrder(currencyID, amount, price, isBuyOrder, clientIDUint)
 	} else if orderType == exchange.Market {
-		APIresponse, err = c.NewOrder(currencyID, amount, 0, buy, clientIDUint)
+		APIresponse, err = c.NewOrder(currencyID, amount, 0, isBuyOrder, clientIDUint)
 	}
 	switch APIresponse.(type) {
 	case OrdersBase:

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -246,7 +246,7 @@ type IBotExchange interface {
 	SupportsWithdrawPermissions(permissions uint32) bool
 
 	GetExchangeFundTransferHistory() ([]FundHistory, error)
-	SubmitExchangeOrder(p pair.CurrencyPair, side OrderSide, orderType OrderType, amount, price float64, clientID string) (int64, error)
+	SubmitExchangeOrder(p pair.CurrencyPair, side OrderSide, orderType OrderType, amount, price float64, clientID string) (string, error)
 	ModifyExchangeOrder(orderID int64, modify ModifyOrder) (int64, error)
 	CancelExchangeOrder(orderID int64) error
 	CancelAllExchangeOrders() error

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -747,6 +747,12 @@ var formats = Formatting{
 // OrderType enforces a standard for Ordertypes across the code base
 type OrderType string
 
+// OrderType ...types
+const (
+	Limit  OrderType = "Limit"
+	Market OrderType = "Market"
+)
+
 // Format changes the ordertype to the exchange standard and returns a string
 func (o OrderType) Format(exchangeName string) string {
 	for _, format := range formats {
@@ -759,16 +765,22 @@ func (o OrderType) Format(exchangeName string) string {
 
 // OrderTypeLimit returns an OrderType limit order
 func OrderTypeLimit() OrderType {
-	return "Limit"
+	return Limit
 }
 
 // OrderTypeMarket returns an OrderType Market order
 func OrderTypeMarket() OrderType {
-	return "Market"
+	return Market
 }
 
 // OrderSide enforces a standard for OrderSides across the code base
 type OrderSide string
+
+// OrderSide types
+const (
+	Buy  OrderSide = "Buy"
+	Sell OrderSide = "Sell"
+)
 
 // Format changes the ordertype to the exchange standard and returns a string
 func (o OrderSide) Format(exchangeName string) string {
@@ -782,12 +794,12 @@ func (o OrderSide) Format(exchangeName string) string {
 
 // OrderSideBuy returns an OrderSide buy order
 func OrderSideBuy() OrderSide {
-	return "Buy"
+	return Buy
 }
 
 // OrderSideSell returns an OrderSide Sell order
 func OrderSideSell() OrderSide {
-	return "Sell"
+	return Sell
 }
 
 // SetAPIURL sets configuration API URL for an exchange

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -760,7 +760,8 @@ func (o OrderType) Format(exchangeName string) string {
 			return format.OrderType[string(o)]
 		}
 	}
-	return ""
+
+	return fmt.Sprintf("%v", o)
 }
 
 // OrderTypeLimit returns an OrderType limit order
@@ -789,7 +790,7 @@ func (o OrderSide) Format(exchangeName string) string {
 			return format.OrderSide[string(o)]
 		}
 	}
-	return ""
+	return fmt.Sprintf("%v", o)
 }
 
 // OrderSideBuy returns an OrderSide buy order

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -263,8 +263,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "_",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "USD",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USD,
 	}
 	response, err := e.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
 

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -1,15 +1,18 @@
 package exmo
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
 
 const (
-	APIKey    = ""
-	APISecret = ""
+	APIKey         = ""
+	APISecret      = ""
+	canPlaceOrders = false
 )
 
 var (
@@ -243,5 +246,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	e.SetDefaults()
+	TestSetup(t)
+	e.Verbose = true
+
+	if e.APISecret == "" ||
+		e.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", e.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "_",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "USD",
+	}
+	response, err := e.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -176,7 +176,7 @@ func (e *EXMO) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exch
 }
 
 // SubmitExchangeOrder submits a new order
-func (e *EXMO) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (e *EXMO) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -2,6 +2,7 @@ package exmo
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"strconv"
 	"sync"
@@ -177,7 +178,9 @@ func (e *EXMO) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exch
 
 // SubmitExchangeOrder submits a new order
 func (e *EXMO) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	response, err := e.CreateOrder(p.Pair().String(), orderType.Format(e.Name), price, amount)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -178,7 +178,18 @@ func (e *EXMO) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exch
 
 // SubmitExchangeOrder submits a new order
 func (e *EXMO) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	response, err := e.CreateOrder(p.Pair().String(), orderType.Format(e.Name), price, amount)
+	var oT string
+	if orderType == exchange.Limit {
+		return "", errors.New("Not supported")
+	} else if orderType == exchange.Market {
+		if side == exchange.Buy {
+			oT = "market_buy"
+		} else {
+			oT = "market_sell"
+		}
+	}
+
+	response, err := e.CreateOrder(p.Pair().String(), oT, price, amount)
 
 	return fmt.Sprintf("%v", response), err
 }

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -1,9 +1,11 @@
 package gateio
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -11,8 +13,9 @@ import (
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 var g Gateio
@@ -245,5 +248,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	g.SetDefaults()
+	TestSetup(t)
+	g.Verbose = true
+
+	if g.APIKey == "" || g.APISecret == "" ||
+		g.APIKey == "Key" || g.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", g.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "_",
+		FirstCurrency:  "LTC",
+		SecondCurrency: "BTC",
+	}
+	response, err := g.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -265,8 +265,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "_",
-		FirstCurrency:  "LTC",
-		SecondCurrency: "BTC",
+		FirstCurrency:  symbol.LTC,
+		SecondCurrency: symbol.BTC,
 	}
 	response, err := g.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
 

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -127,7 +127,7 @@ func (g *Gateio) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 }
 
 // SubmitExchangeOrder submits a new order
-func (g *Gateio) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (g *Gateio) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -2,6 +2,7 @@ package gateio
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -128,7 +129,24 @@ func (g *Gateio) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 
 // SubmitExchangeOrder submits a new order
 func (g *Gateio) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var orderTypeFormat SpotNewOrderRequestParamsType
+
+	if side == exchange.Buy {
+		orderTypeFormat = SpotNewOrderRequestParamsTypeBuy
+	} else {
+		orderTypeFormat = SpotNewOrderRequestParamsTypeSell
+
+	}
+
+	var spotNewOrderRequestParams = SpotNewOrderRequestParams{
+		Amount: amount,
+		Price:  price,
+		Symbol: p.Pair().String(),
+		Type:   orderTypeFormat,
+	}
+	response, err := g.SpotNewOrder(spotNewOrderRequestParams)
+
+	return fmt.Sprintf("%v", response.OrderNumber), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -135,7 +135,6 @@ func (g *Gateio) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSid
 		orderTypeFormat = SpotNewOrderRequestParamsTypeBuy
 	} else {
 		orderTypeFormat = SpotNewOrderRequestParamsTypeSell
-
 	}
 
 	var spotNewOrderRequestParams = SpotNewOrderRequestParams{
@@ -144,6 +143,7 @@ func (g *Gateio) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSid
 		Symbol: p.Pair().String(),
 		Type:   orderTypeFormat,
 	}
+
 	response, err := g.SpotNewOrder(spotNewOrderRequestParams)
 
 	return fmt.Sprintf("%v", response.OrderNumber), err

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -1,10 +1,12 @@
 package gemini
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -21,6 +23,8 @@ const (
 	apiSecret2        = ""
 	apiKeyRole2       = ""
 	sessionHeartBeat2 = false
+
+	canPlaceOrders = false
 )
 
 func TestAddSession(t *testing.T) {
@@ -318,5 +322,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	Session[1].SetDefaults()
+	TestSetup(t)
+	Session[1].Verbose = true
+
+	if Session[1].APIKey == "" || Session[1].APISecret == "" ||
+		Session[1].APIKey == "Key" || Session[1].APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", Session[1].APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "_",
+		FirstCurrency:  "LTC",
+		SecondCurrency: "BTC",
+	}
+	response, err := Session[1].SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -339,8 +339,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "_",
-		FirstCurrency:  "LTC",
-		SecondCurrency: "BTC",
+		FirstCurrency:  symbol.LTC,
+		SecondCurrency: symbol.BTC,
 	}
 	response, err := Session[1].SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
 

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -127,7 +127,7 @@ func (g *Gemini) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 }
 
 // SubmitExchangeOrder submits a new order
-func (g *Gemini) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (g *Gemini) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/url"
 	"sync"
@@ -128,7 +129,9 @@ func (g *Gemini) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 
 // SubmitExchangeOrder submits a new order
 func (g *Gemini) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	response, err := g.NewOrder(p.Pair().String(), amount, price, side.Format(g.Name), orderType.Format(g.Name))
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -37,7 +37,7 @@ const (
 	apiV2TradeHistory   = "api/2/history/trades"
 	apiV2FeeInfo        = "api/2/trading/fee"
 	orders              = "order"
-	orderBuy            = "buy"
+	orderBuy            = "api/2/order"
 	orderSell           = "sell"
 	orderCancel         = "cancelOrder"
 	orderMove           = "moveOrder"

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -1,9 +1,11 @@
 package hitbtc
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -13,8 +15,9 @@ var h HitBTC
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -170,5 +173,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	h.SetDefaults()
+	TestSetup(t)
+	h.Verbose = true
+
+	if h.APIKey == "" || h.APISecret == "" ||
+		h.APIKey == "Key" || h.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", h.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "LTC",
+		SecondCurrency: "BTC",
+	}
+	response, err := h.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -190,8 +190,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "LTC",
-		SecondCurrency: "BTC",
+		FirstCurrency:  symbol.LTC,
+		SecondCurrency: symbol.BTC,
 	}
 	response, err := h.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
 

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -155,7 +155,7 @@ func (h *HitBTC) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 }
 
 // SubmitExchangeOrder submits a new order
-func (h *HitBTC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (h *HitBTC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -2,6 +2,7 @@ package hitbtc
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -156,7 +157,11 @@ func (h *HitBTC) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 
 // SubmitExchangeOrder submits a new order
 func (h *HitBTC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	isImmediate := orderType == exchange.Market
+	isBuying := side == exchange.Buy
+	response, err := h.PlaceOrder(p.Pair().String(), price, amount, isImmediate, false, isBuying)
+
+	return fmt.Sprintf("%v", response.OrderNumber), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -20,8 +20,8 @@ import (
 
 // Please supply you own test keys here for due diligence testing.
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
 	canPlaceOrders = false
 )
 
@@ -411,8 +411,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "btc",
-		SecondCurrency: "usdt",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USDT,
 	}
 	accounts, err := h.GetAccounts()
 

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -20,6 +22,7 @@ import (
 const (
 	apiKey    = ""
 	apiSecret = ""
+	canPlaceOrders = false
 )
 
 var h HUOBI
@@ -201,7 +204,7 @@ func TestSpotNewOrder(t *testing.T) {
 
 	arg := SpotNewOrderRequestParams{
 		Symbol:    "btcusdt",
-		AccountID: 000000,
+		AccountID: 1,
 		Amount:    0.01,
 		Price:     10.1,
 		Type:      SpotNewOrderRequestTypeBuyLimit,
@@ -391,5 +394,34 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	h.SetDefaults()
+	TestSetup(t)
+	h.Verbose = true
+
+	if h.APIKey == "" || h.APISecret == "" ||
+		h.APIKey == "Key" || h.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", h.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "btc",
+		SecondCurrency: "usdt",
+	}
+	accounts, err := h.GetAccounts()
+
+	response, err := h.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 10, strconv.FormatInt(accounts[0].ID, 10))
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -196,12 +196,12 @@ type MarginAccountBalance struct {
 // SpotNewOrderRequestParams holds the params required to place
 // an order
 type SpotNewOrderRequestParams struct {
-	AccountID int                           `json:"account-id"` // Account ID, obtained using the accounts method. Curency trades use the accountid of the ‘spot’ account; for loan asset transactions, please use the accountid of the ‘margin’ account.
-	Amount    float64                       `json:"amount"`     // The limit price indicates the quantity of the order, the market price indicates how much to buy when the order is paid, and the market price indicates how much the coin is sold when the order is sold.
-	Price     float64                       `json:"price"`      // Order price, market price does not use  this parameter
-	Source    string                        `json:"source"`     // Order source, api: API call, margin-api: loan asset transaction
-	Symbol    string                        `json:"symbol"`     // The symbol to use; example btcusdt, bccbtc......
-	Type      SpotNewOrderRequestParamsType `json:"type"`       // 订单类型, buy-market: 市价买, sell-market: 市价卖, buy-limit: 限价买, sell-limit: 限价卖
+	AccountID int                           `json:"account-id,string"` // Account ID, obtained using the accounts method. Curency trades use the accountid of the ‘spot’ account; for loan asset transactions, please use the accountid of the ‘margin’ account.
+	Amount    float64                       `json:"amount"`            // The limit price indicates the quantity of the order, the market price indicates how much to buy when the order is paid, and the market price indicates how much the coin is sold when the order is sold.
+	Price     float64                       `json:"price"`             // Order price, market price does not use  this parameter
+	Source    string                        `json:"source"`            // Order source, api: API call, margin-api: loan asset transaction
+	Symbol    string                        `json:"symbol"`            // The symbol to use; example btcusdt, bccbtc......
+	Type      SpotNewOrderRequestParamsType `json:"type"`              // 订单类型, buy-market: 市价买, sell-market: 市价卖, buy-limit: 限价买, sell-limit: 限价卖
 }
 
 // SpotNewOrderRequestParamsType order type

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -170,7 +170,7 @@ func (h *HUOBI) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exc
 }
 
 // SubmitExchangeOrder submits a new order
-func (h *HUOBI) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (h *HUOBI) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -2,7 +2,9 @@ package huobi
 
 import (
 	"errors"
+	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -171,7 +173,34 @@ func (h *HUOBI) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exc
 
 // SubmitExchangeOrder submits a new order
 func (h *HUOBI) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	accountIDInt64, err := strconv.ParseInt(clientID, 0, 64)
+	var formattedType SpotNewOrderRequestParamsType
+
+	if err != nil {
+		return "", errors.New("Bad client ID sent")
+	}
+
+	if side == exchange.Buy && orderType == exchange.Market {
+		formattedType = SpotNewOrderRequestTypeBuyMarket
+	} else if side == exchange.Sell && orderType == exchange.Market {
+		formattedType = SpotNewOrderRequestTypeSellMarket
+	} else if side == exchange.Buy && orderType == exchange.Limit {
+		formattedType = SpotNewOrderRequestTypeBuyLimit
+	} else if side == exchange.Sell && orderType == exchange.Limit {
+		formattedType = SpotNewOrderRequestTypeSellLimit
+	}
+
+	var params = SpotNewOrderRequestParams{
+		AccountID: int(accountIDInt64),
+		Amount:    amount,
+		Price:     price,
+		Source:    "api",
+		Symbol:    p.Pair().String(),
+		Type:      formattedType,
+	}
+	response, err := h.SpotNewOrder(params)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -173,11 +173,13 @@ func (h *HUOBI) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exc
 
 // SubmitExchangeOrder submits a new order
 func (h *HUOBI) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	accountIDInt64, err := strconv.ParseInt(clientID, 0, 64)
+	accountID, err := strconv.ParseInt(clientID, 10, 64)
 	var formattedType SpotNewOrderRequestParamsType
-
-	if err != nil {
-		return "", errors.New("Bad client ID sent")
+	var params = SpotNewOrderRequestParams{
+		Amount:    amount,
+		Source:    "api",
+		Symbol:    common.StringToLower(p.Pair().String()),
+		AccountID: int(accountID),
 	}
 
 	if side == exchange.Buy && orderType == exchange.Market {
@@ -186,18 +188,15 @@ func (h *HUOBI) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide
 		formattedType = SpotNewOrderRequestTypeSellMarket
 	} else if side == exchange.Buy && orderType == exchange.Limit {
 		formattedType = SpotNewOrderRequestTypeBuyLimit
+		params.Price = price
 	} else if side == exchange.Sell && orderType == exchange.Limit {
 		formattedType = SpotNewOrderRequestTypeSellLimit
+		params.Price = price
+
 	}
 
-	var params = SpotNewOrderRequestParams{
-		AccountID: int(accountIDInt64),
-		Amount:    amount,
-		Price:     price,
-		Source:    "api",
-		Symbol:    p.Pair().String(),
-		Type:      formattedType,
-	}
+	params.Type = formattedType
+
 	response, err := h.SpotNewOrder(params)
 
 	return fmt.Sprintf("%v", response), err

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -389,8 +389,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "btc",
-		SecondCurrency: "usdt",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USDT,
 	}
 	accounts, err := h.GetAccounts()
 

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -13,8 +14,9 @@ import (
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 var h HUOBIHADAX
@@ -370,5 +372,34 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	h.SetDefaults()
+	TestSetup(t)
+	h.Verbose = true
+
+	if h.APIKey == "" || h.APISecret == "" ||
+		h.APIKey == "Key" || h.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", h.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "btc",
+		SecondCurrency: "usdt",
+	}
+	accounts, err := h.GetAccounts()
+
+	response, err := h.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 10, strconv.FormatInt(accounts[0].ID, 10))
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -135,7 +135,7 @@ func (h *HUOBIHADAX) GetExchangeHistory(p pair.CurrencyPair, assetType string) (
 }
 
 // SubmitExchangeOrder submits a new order
-func (h *HUOBIHADAX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (h *HUOBIHADAX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -2,7 +2,9 @@ package huobihadax
 
 import (
 	"errors"
+	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -136,7 +138,34 @@ func (h *HUOBIHADAX) GetExchangeHistory(p pair.CurrencyPair, assetType string) (
 
 // SubmitExchangeOrder submits a new order
 func (h *HUOBIHADAX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	accountIDInt64, err := strconv.ParseInt(clientID, 0, 64)
+	var formattedType SpotNewOrderRequestParamsType
+
+	if err != nil {
+		return "", errors.New("Bad client ID sent")
+	}
+
+	if side == exchange.Buy && orderType == exchange.Market {
+		formattedType = SpotNewOrderRequestTypeBuyMarket
+	} else if side == exchange.Sell && orderType == exchange.Market {
+		formattedType = SpotNewOrderRequestTypeSellMarket
+	} else if side == exchange.Buy && orderType == exchange.Limit {
+		formattedType = SpotNewOrderRequestTypeBuyLimit
+	} else if side == exchange.Sell && orderType == exchange.Limit {
+		formattedType = SpotNewOrderRequestTypeSellLimit
+	}
+
+	var params = SpotNewOrderRequestParams{
+		AccountID: int(accountIDInt64),
+		Amount:    amount,
+		Price:     price,
+		Source:    "api",
+		Symbol:    p.Pair().String(),
+		Type:      formattedType,
+	}
+	response, err := h.SpotNewOrder(params)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -259,8 +259,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "btc",
-		SecondCurrency: "usdt",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USDT,
 	}
 	response, err := i.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 10, "hi")
 

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -1,10 +1,12 @@
 package itbit
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -13,9 +15,10 @@ var i ItBit
 
 // Please provide your own keys to do proper testing
 const (
-	apiKey    = ""
-	apiSecret = ""
-	clientID  = ""
+	apiKey         = ""
+	apiSecret      = ""
+	clientID       = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -239,5 +242,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	i.SetDefaults()
+	TestSetup(t)
+	i.Verbose = true
+
+	if i.APIKey == "" || i.APISecret == "" ||
+		i.APIKey == "Key" || i.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", i.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "btc",
+		SecondCurrency: "usdt",
+	}
+	response, err := i.SubmitExchangeOrder(p, exchange.Buy, exchange.Limit, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -129,7 +129,7 @@ func (i *ItBit) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exc
 }
 
 // SubmitExchangeOrder submits a new order
-func (i *ItBit) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (i *ItBit) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -788,12 +788,12 @@ func (k *Kraken) GetTradeVolume(feeinfo bool, symbol ...string) (TradeVolumeResp
 func (k *Kraken) AddOrder(symbol, side, orderType string, volume, price, price2, leverage float64, args AddOrderOptions) (AddOrderResponse, error) {
 	params := url.Values{
 		"pair":      {symbol},
-		"type":      {side},
-		"ordertype": {orderType},
+		"type":      {common.StringToLower(side)},
+		"ordertype": {common.StringToLower(orderType)},
 		"volume":    {strconv.FormatFloat(volume, 'f', -1, 64)},
 	}
 
-	if price != 0 {
+	if orderType == "limit" || price > 0 {
 		params.Set("price", strconv.FormatFloat(price, 'f', -1, 64))
 	}
 

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1,9 +1,11 @@
 package kraken
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -12,9 +14,10 @@ var k Kraken
 
 // Please add your own APIkeys to do correct due diligence testing.
 const (
-	apiKey    = ""
-	apiSecret = ""
-	clientID  = ""
+	apiKey         = ""
+	apiSecret      = ""
+	clientID       = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -325,5 +328,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	k.SetDefaults()
+	TestSetup(t)
+	k.Verbose = true
+
+	if k.APIKey == "" || k.APISecret == "" ||
+		k.APIKey == "Key" || k.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", k.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "XBT",
+		SecondCurrency: "CAD",
+	}
+	response, err := k.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -345,8 +345,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "XBT",
-		SecondCurrency: "CAD",
+		FirstCurrency:  symbol.XBT,
+		SecondCurrency: symbol.CAD,
 	}
 	response, err := k.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -161,7 +161,7 @@ func (k *Kraken) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 }
 
 // SubmitExchangeOrder submits a new order
-func (k *Kraken) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (k *Kraken) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -3,6 +3,7 @@ package kraken
 import (
 	"errors"
 	"log"
+	"strings"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -162,7 +163,12 @@ func (k *Kraken) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 
 // SubmitExchangeOrder submits a new order
 func (k *Kraken) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var args = AddOrderOptions{}
+
+	response, err := k.AddOrder(p.Pair().String(), side.Format(k.Name), orderType.Format(k.Name), amount, price, 0, 0, args)
+	orderIds := strings.Join(response.TransactionIds, ",")
+
+	return orderIds, err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -219,11 +219,11 @@ func (l *LakeBTC) GetAccountInfo() (AccountInfo, error) {
 
 // Trade executes an order on the exchange and returns trade inforamtion or an
 // error
-func (l *LakeBTC) Trade(orderType int, amount, price float64, currency string) (Trade, error) {
+func (l *LakeBTC) Trade(isBuyOrder bool, amount, price float64, currency string) (Trade, error) {
 	resp := Trade{}
 	params := strconv.FormatFloat(price, 'f', -1, 64) + "," + strconv.FormatFloat(amount, 'f', -1, 64) + "," + currency
 
-	if orderType == 1 {
+	if isBuyOrder {
 		if err := l.SendAuthenticatedHTTPRequest(lakeBTCBuyOrder, params, &resp); err != nil {
 			return resp, err
 		}

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -72,7 +72,7 @@ func TestTrade(t *testing.T) {
 	if l.APIKey == "" || l.APISecret == "" {
 		t.Skip()
 	}
-	_, err := l.Trade(0, 0, 0, "USD")
+	_, err := l.Trade(false, 0, 0, "USD")
 	if err == nil {
 		t.Error("Test Failed - Trade() error", err)
 	}

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -1,9 +1,11 @@
 package lakebtc
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -12,8 +14,9 @@ var l LakeBTC
 
 // Please add your own APIkeys to do correct due diligence testing.
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -243,5 +246,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	l.SetDefaults()
+	TestSetup(t)
+	l.Verbose = true
+
+	if l.APIKey == "" || l.APISecret == "" ||
+		l.APIKey == "Key" || l.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", l.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "EUR",
+	}
+	response, err := l.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -263,8 +263,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "EUR",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.EUR,
 	}
 	response, err := l.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -139,7 +139,7 @@ func (l *LakeBTC) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 }
 
 // SubmitExchangeOrder submits a new order
-func (l *LakeBTC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (l *LakeBTC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -2,6 +2,7 @@ package lakebtc
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"strconv"
 	"sync"
@@ -140,7 +141,10 @@ func (l *LakeBTC) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 
 // SubmitExchangeOrder submits a new order
 func (l *LakeBTC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	isBuyOrder := side == exchange.Buy
+	response, err := l.Trade(isBuyOrder, amount, price, p.Pair().String())
+
+	return fmt.Sprintf("%v", response.ID), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -142,7 +142,7 @@ func (l *LakeBTC) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]e
 // SubmitExchangeOrder submits a new order
 func (l *LakeBTC) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	isBuyOrder := side == exchange.Buy
-	response, err := l.Trade(isBuyOrder, amount, price, p.Pair().String())
+	response, err := l.Trade(isBuyOrder, amount, price, common.StringToLower(p.Pair().String()))
 
 	return fmt.Sprintf("%v", response.ID), err
 }

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -248,8 +248,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "EUR",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.EUR,
 	}
 	response, err := l.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -1,6 +1,7 @@
 package liqui
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -13,8 +14,9 @@ import (
 var l Liqui
 
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -229,5 +231,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	l.SetDefaults()
+	TestSetup(t)
+	l.Verbose = true
+
+	if l.APIKey == "" || l.APISecret == "" ||
+		l.APIKey == "Key" || l.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", l.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "EUR",
+	}
+	response, err := l.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/liqui/liqui_wrapper.go
+++ b/exchanges/liqui/liqui_wrapper.go
@@ -148,7 +148,7 @@ func (l *Liqui) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exc
 }
 
 // SubmitExchangeOrder submits a new order
-func (l *Liqui) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (l *Liqui) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/liqui/liqui_wrapper.go
+++ b/exchanges/liqui/liqui_wrapper.go
@@ -2,6 +2,7 @@ package liqui
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -149,7 +150,9 @@ func (l *Liqui) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exc
 
 // SubmitExchangeOrder submits a new order
 func (l *Liqui) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	response, err := l.Trade(p.Pair().String(), fmt.Sprintf("%s", orderType), amount, price)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -120,7 +120,7 @@ func (l *LocalBitcoins) GetExchangeHistory(p pair.CurrencyPair, assetType string
 }
 
 // SubmitExchangeOrder submits a new order
-func (l *LocalBitcoins) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (l *LocalBitcoins) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -157,7 +157,7 @@ func (l *LocalBitcoins) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.O
 	// Now to figure out what ad we just submitted
 	// The only details we have are the params above
 	var adID string
-	ads, err := l.Getads("", "")
+	ads, err := l.Getads()
 	for _, i := range ads.AdList {
 		if i.Data.PriceEquation == params.PriceEquation &&
 			i.Data.Lat == float64(params.Latitude) &&

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -121,7 +121,7 @@ func (l *LocalBitcoins) GetExchangeHistory(p pair.CurrencyPair, assetType string
 
 // SubmitExchangeOrder submits a new order
 func (l *LocalBitcoins) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	return "", errors.New("not yet implemented")
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -1,9 +1,11 @@
 package okcoin
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -13,8 +15,9 @@ var o OKCoin
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -135,5 +138,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	o.SetDefaults()
+	TestSetup(t)
+	o.Verbose = true
+
+	if o.APIKey == "" || o.APISecret == "" ||
+		o.APIKey == "Key" || o.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", o.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "EUR",
+	}
+	response, err := o.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -155,8 +155,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "EUR",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.EUR,
 	}
 	response, err := o.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -186,7 +186,7 @@ func (o *OKCoin) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 }
 
 // SubmitExchangeOrder submits a new order
-func (o *OKCoin) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (o *OKCoin) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -2,6 +2,7 @@ package okcoin
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -187,7 +188,24 @@ func (o *OKCoin) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]ex
 
 // SubmitExchangeOrder submits a new order
 func (o *OKCoin) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var oT string
+	if orderType == exchange.Limit {
+		if side == exchange.Buy {
+			oT = "buy"
+		} else {
+			oT = "sell"
+		}
+	} else if orderType == exchange.Market {
+		if side == exchange.Buy {
+			oT = "buy_market"
+		} else {
+			oT = "sell_market"
+		}
+	}
+
+	response, err := o.Trade(amount, price, p.Pair().String(), oT)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -404,8 +404,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "EUR",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.EUR,
 	}
 	response, err := o.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1,9 +1,11 @@
 package okex
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -12,8 +14,9 @@ var o OKEX
 
 // Please supply you own test keys here for due diligence testing.
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -384,5 +387,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	o.SetDefaults()
+	TestSetup(t)
+	o.Verbose = true
+
+	if o.APIKey == "" || o.APISecret == "" ||
+		o.APIKey == "Key" || o.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", o.APIKey, canPlaceOrders))
+	}
+	var p = pair.CurrencyPair{
+		Delimiter:      "",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "EUR",
+	}
+	response, err := o.SubmitExchangeOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -152,7 +152,7 @@ func (o *OKEX) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exch
 }
 
 // SubmitExchangeOrder submits a new order
-func (o *OKEX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (o *OKEX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -2,6 +2,7 @@ package okex
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -153,7 +154,32 @@ func (o *OKEX) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exch
 
 // SubmitExchangeOrder submits a new order
 func (o *OKEX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var oT SpotNewOrderRequestType
+
+	if orderType == exchange.Limit {
+		if side == exchange.Buy {
+			oT = SpotNewOrderRequestTypeBuy
+		} else {
+			oT = SpotNewOrderRequestTypeSell
+		}
+	} else if orderType == exchange.Market {
+		if side == exchange.Buy {
+			oT = SpotNewOrderRequestTypeBuyMarket
+		} else {
+			oT = SpotNewOrderRequestTypeSellMarket
+		}
+	}
+
+	var params = SpotNewOrderRequestParams{
+		Amount: amount,
+		Price:  price,
+		Symbol: p.Pair().String(),
+		Type:   oT,
+	}
+
+	response, err := o.SpotNewOrder(params)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -208,8 +208,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var pair = pair.CurrencyPair{
 		Delimiter:      "_",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "LTC",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.LTC,
 	}
 	response, err := p.SubmitExchangeOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -1,9 +1,11 @@
 package poloniex
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -13,8 +15,9 @@ var p Poloniex
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -188,5 +191,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	p.SetDefaults()
+	TestSetup(t)
+	p.Verbose = true
+
+	if p.APIKey == "" || p.APISecret == "" ||
+		p.APIKey == "Key" || p.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", p.APIKey, canPlaceOrders))
+	}
+	var pair = pair.CurrencyPair{
+		Delimiter:      "_",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "LTC",
+	}
+	response, err := p.SubmitExchangeOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -2,6 +2,7 @@ package poloniex
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -155,8 +156,12 @@ func (p *Poloniex) GetExchangeHistory(currencyPair pair.CurrencyPair, assetType 
 }
 
 // SubmitExchangeOrder submits a new order
-func (p *Poloniex) SubmitExchangeOrder(currencyPair pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
-	return 0, errors.New("not yet implemented")
+func (p *Poloniex) SubmitExchangeOrder(currencyPair pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
+	fillOrKill := orderType == exchange.Market
+	isBuyOrder := side == exchange.Buy
+	response, err := p.PlaceOrder(currencyPair.Pair().String(), price, amount, false, fillOrKill, isBuyOrder)
+
+	return fmt.Sprintf("%v", response.OrderNumber), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -1,9 +1,11 @@
 package wex
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -12,8 +14,9 @@ var w WEX
 
 // Please supply your own keys for better unit testing
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -263,5 +266,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	w.SetDefaults()
+	TestSetup(t)
+	w.Verbose = true
+
+	if w.APIKey == "" || w.APISecret == "" ||
+		w.APIKey == "Key" || w.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", w.APIKey, canPlaceOrders))
+	}
+	var pair = pair.CurrencyPair{
+		Delimiter:      "_",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "USD",
+	}
+	response, err := w.SubmitExchangeOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -283,8 +283,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var pair = pair.CurrencyPair{
 		Delimiter:      "_",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "USD",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USD,
 	}
 	response, err := w.SubmitExchangeOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -158,7 +158,7 @@ func (w *WEX) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]excha
 }
 
 // SubmitExchangeOrder submits a new order
-func (w *WEX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (w *WEX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -2,6 +2,7 @@ package wex
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -159,7 +160,9 @@ func (w *WEX) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]excha
 
 // SubmitExchangeOrder submits a new order
 func (w *WEX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	response, err := w.Trade(p.Pair().String(), orderType.Format(w.Name), amount, price)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -160,7 +160,7 @@ func (w *WEX) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]excha
 
 // SubmitExchangeOrder submits a new order
 func (w *WEX) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	response, err := w.Trade(p.Pair().String(), orderType.Format(w.Name), amount, price)
+	response, err := w.Trade(common.StringToLower(p.Pair().String()), common.StringToLower(side.Format(w.Name)), amount, price)
 
 	return fmt.Sprintf("%v", response), err
 }

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -327,8 +327,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var pair = pair.CurrencyPair{
 		Delimiter:      "_",
-		FirstCurrency:  "BTC",
-		SecondCurrency: "USD",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.USD,
 	}
 	response, err := y.SubmitExchangeOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -1,9 +1,11 @@
 package yobit
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
@@ -12,8 +14,9 @@ var y Yobit
 
 // Please supply your own keys for better unit testing
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -307,5 +310,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	y.SetDefaults()
+	TestSetup(t)
+	y.Verbose = true
+
+	if y.APIKey == "" || y.APISecret == "" ||
+		y.APIKey == "Key" || y.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", y.APIKey, canPlaceOrders))
+	}
+	var pair = pair.CurrencyPair{
+		Delimiter:      "_",
+		FirstCurrency:  "BTC",
+		SecondCurrency: "USD",
+	}
+	response, err := y.SubmitExchangeOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -140,7 +140,7 @@ func (y *Yobit) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exc
 }
 
 // SubmitExchangeOrder submits a new order
-func (y *Yobit) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (y *Yobit) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -2,6 +2,7 @@ package yobit
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -141,7 +142,9 @@ func (y *Yobit) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exc
 
 // SubmitExchangeOrder submits a new order
 func (y *Yobit) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	response, err := y.Trade(p.Pair().String(), orderType.Format(y.Name), amount, price)
+
+	return fmt.Sprintf("%v", response), err
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -5,14 +5,16 @@ import (
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
 
 // Please supply you own test keys here for due diligence testing.
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey         = ""
+	apiSecret      = ""
+	canPlaceOrders = false
 )
 
 var z ZB
@@ -238,5 +240,32 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// This will really really use the API to place an order
+// If you're going to test this, make sure you're willing to place real orders on the exchange
+func TestSubmitOrder(t *testing.T) {
+	z.SetDefaults()
+	TestSetup(t)
+	z.Verbose = true
+
+	if z.APIKey == "" || z.APISecret == "" ||
+		z.APIKey == "Key" || z.APISecret == "Secret" ||
+		!canPlaceOrders {
+		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", z.APIKey, canPlaceOrders))
+	}
+	var pair = pair.CurrencyPair{
+		Delimiter:      "_",
+		FirstCurrency:  "QTUM",
+		SecondCurrency: "USDT",
+	}
+	response, err := z.SubmitExchangeOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
+
+	if err != nil {
+		t.Error("Something happened: ", err)
+	}
+	if response == "" {
+		t.Errorf("OrderId not returned.")
 	}
 }

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -257,8 +257,8 @@ func TestSubmitOrder(t *testing.T) {
 	}
 	var pair = pair.CurrencyPair{
 		Delimiter:      "_",
-		FirstCurrency:  "QTUM",
-		SecondCurrency: "USDT",
+		FirstCurrency:  symbol.QTUM,
+		SecondCurrency: symbol.USDT,
 	}
 	response, err := z.SubmitExchangeOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
 

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -136,7 +136,7 @@ func (z *ZB) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exchan
 }
 
 // SubmitExchangeOrder submits a new order
-func (z *ZB) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func (z *ZB) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -2,6 +2,7 @@ package zb
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -137,7 +138,24 @@ func (z *ZB) GetExchangeHistory(p pair.CurrencyPair, assetType string) ([]exchan
 
 // SubmitExchangeOrder submits a new order
 func (z *ZB) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	var oT SpotNewOrderRequestParamsType
+
+	if side == exchange.Buy {
+		oT = SpotNewOrderRequestParamsTypeBuy
+	} else {
+		oT = SpotNewOrderRequestParamsTypeSell
+	}
+
+	var params = SpotNewOrderRequestParams{
+		Amount: amount,
+		Price:  price,
+		Symbol: p.Pair().String(),
+		Type:   oT,
+	}
+	response, err := z.SpotNewOrder(params)
+
+	return fmt.Sprintf("%v", response), err
+
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -149,7 +149,7 @@ func (z *ZB) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, o
 	var params = SpotNewOrderRequestParams{
 		Amount: amount,
 		Price:  price,
-		Symbol: p.Pair().String(),
+		Symbol: common.StringToLower(p.Pair().String()),
 		Type:   oT,
 	}
 	response, err := z.SpotNewOrder(params)

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -385,7 +385,7 @@
    "restPollingDelay": 10,
    "httpTimeout": 15000000000,
    "httpUserAgent": "",
-   "authenticatedApiSupport": true,
+   "authenticatedApiSupport": false,
    "apiKey": "Key",
    "apiSecret": "Secret",
    "apiUrl": "NON_DEFAULT_HTTP_LINK_TO_EXCHANGE_API",

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -385,7 +385,7 @@
    "restPollingDelay": 10,
    "httpTimeout": 15000000000,
    "httpUserAgent": "",
-   "authenticatedApiSupport": false,
+   "authenticatedApiSupport": true,
    "apiKey": "Key",
    "apiSecret": "Secret",
    "apiUrl": "NON_DEFAULT_HTTP_LINK_TO_EXCHANGE_API",

--- a/tools/exchange_template/wrapper_file.tmpl
+++ b/tools/exchange_template/wrapper_file.tmpl
@@ -121,7 +121,7 @@ func ({{.Variable}} *{{.CapitalName}}) GetExchangeHistory(p pair.CurrencyPair, a
 }
 
 // SubmitExchangeOrder submits a new order
-func ({{.Variable}} *{{.CapitalName}}) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (int64, error) {
+func ({{.Variable}} *{{.CapitalName}}) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
 	return 0, errors.New("not yet implemented")
 }
 

--- a/tools/exchange_template/wrapper_file.tmpl
+++ b/tools/exchange_template/wrapper_file.tmpl
@@ -122,7 +122,7 @@ func ({{.Variable}} *{{.CapitalName}}) GetExchangeHistory(p pair.CurrencyPair, a
 
 // SubmitExchangeOrder submits a new order
 func ({{.Variable}} *{{.CapitalName}}) SubmitExchangeOrder(p pair.CurrencyPair, side exchange.OrderSide, orderType exchange.OrderType, amount, price float64, clientID string) (string, error) {
-	return 0, errors.New("not yet implemented")
+	return "", errors.New("not yet implemented")
 }
 
 // ModifyExchangeOrder will allow of changing orderbook placement and limit to


### PR DESCRIPTION
# Description
This PR updates the wrappers of each exchange to map to the actual implementation to submit an order on an exchange via the API.

This is part of a greater piece of work to allow the engine to interact with wrapper methods to perform tasks in a standard manner

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
I've added the test _TestSubmitOrder_ to each exchange test file. Provided you enable its use with a bool and api keys it will actually perform an API trade with the exchange. That's why I added the bool, to prevent people from losing real assets with testing

The following exchanges I encountered issues with testing and will be addressed in another PR if anything needs updating:
- Coinbase
- BTCC (frequently down)
- Coinut
- HitBTC
- Huobi/Hadax
- Itbit
- LakeBTC
- Liqui
- OKCoin/OKex
- Yobit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
![image](https://user-images.githubusercontent.com/9261323/48456202-42a58800-e812-11e8-9d3a-0b03781cbf89.png)
