### PR TITLE
Cancel order wrapper wrapup

### DIFF
--- a/exchanges/alphapoint/alphapoint.go
+++ b/exchanges/alphapoint/alphapoint.go
@@ -431,10 +431,10 @@ func (a *Alphapoint) ModifyExistingOrder(symbol string, OrderID, action int64) (
 // CancelExistingOrder cancels an order that has not been executed.
 // symbol - Instrument code (ex: “BTCUSD”)
 // OrderId - Order id (ex: 1000)
-func (a *Alphapoint) CancelExistingOrder(OrderID int64) (int64, error) {
+func (a *Alphapoint) CancelExistingOrder(OrderID int64, OMSID string) (int64, error) {
 	request := make(map[string]interface{})
 	request["OrderId"] = OrderID
-	request["serverOrderId"] = OrderID
+	request["OMSId"] = OMSID
 	response := Response{}
 
 	err := a.SendAuthenticatedHTTPRequest(

--- a/exchanges/alphapoint/alphapoint.go
+++ b/exchanges/alphapoint/alphapoint.go
@@ -431,9 +431,9 @@ func (a *Alphapoint) ModifyExistingOrder(symbol string, OrderID, action int64) (
 // CancelExistingOrder cancels an order that has not been executed.
 // symbol - Instrument code (ex: “BTCUSD”)
 // OrderId - Order id (ex: 1000)
-func (a *Alphapoint) CancelExistingOrder(symbol string, OrderID int64) (int64, error) {
+func (a *Alphapoint) CancelExistingOrder(OrderID int64) (int64, error) {
 	request := make(map[string]interface{})
-	request["ins"] = symbol
+	request["OrderId"] = OrderID
 	request["serverOrderId"] = OrderID
 	response := Response{}
 

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -434,21 +434,6 @@ func TestModifyExistingOrder(t *testing.T) {
 	}
 }
 
-func TestCancelExistingOrder(t *testing.T) {
-	a := &Alphapoint{}
-	a.SetDefaults()
-	testSetAPIKey(a)
-
-	if !testIsAPIKeysSet(a) {
-		return
-	}
-
-	_, err := a.CancelExistingOrder(1)
-	if err == nil {
-		t.Error("Test Failed - GetUserInfo() error")
-	}
-}
-
 func TestCancelAllExistingOrders(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -441,7 +441,7 @@ func TestCancelExistingOrder(t *testing.T) {
 		return
 	}
 
-	_, err := a.CancelExistingOrder("", 1)
+	_, err := a.CancelExistingOrder(1)
 	if err == nil {
 		t.Error("Test Failed - GetUserInfo() error")
 	}

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -533,7 +533,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	a.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.BTC, symbol.LTC)
-	currencyPair.Delimiter = "_"
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -542,10 +541,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 		CurrencyPair:  currencyPair,
 	}
 	// Act
-	wasOrderCancelled, err := a.CancelOrder(orderCancellation)
+	err := a.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Test Failed - ANX CancelOrder() error: %s", err)
 	}
 }

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -137,7 +137,7 @@ func (a *Alphapoint) CancelOrder(order exchange.OrderCancellation) (bool, error)
 		return false, err
 	}
 
-	_, err = a.CancelExistingOrder(orderIDInt)
+	_, err = a.CancelExistingOrder(orderIDInt, order.AccountID)
 
 	if err != nil {
 		return false, err

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -130,20 +130,16 @@ func (a *Alphapoint) ModifyOrder(orderID int64, action exchange.ModifyOrder) (in
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (a *Alphapoint) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (a *Alphapoint) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = a.CancelExistingOrder(orderIDInt, order.AccountID)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -3,6 +3,7 @@ package alphapoint
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/currency/pair"
@@ -129,9 +130,20 @@ func (a *Alphapoint) ModifyOrder(orderID int64, action exchange.ModifyOrder) (in
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (a *Alphapoint) CancelOrder(orderID int64) error {
-	// return a.CancelExistingOrder(p.Pair().String(), orderID)
-	return common.ErrNotYetImplemented
+func (a *Alphapoint) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = a.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -24,6 +24,7 @@ const (
 	anxCurrencies      = "currencyStatic"
 	anxDataToken       = "dataToken"
 	anxOrderNew        = "order/new"
+	anxCancel          = "order/cancel"
 	anxOrderInfo       = "order/info"
 	anxSend            = "send"
 	anxSubaccountNew   = "subaccount/new"
@@ -237,6 +238,26 @@ func (a *ANX) NewOrder(orderType string, buy bool, tradedCurrency string, traded
 		return "", errors.New("Response code is not OK: " + response.ResultCode)
 	}
 	return response.OrderID, nil
+}
+
+// CancelOrderByIDs cancels orders, requires already knowing order IDs
+// There is no existing API call to retrieve orderIds
+func (a *ANX) CancelOrderByIDs(orderIds []string) (err error) {
+	request := make(map[string]interface{})
+	request["orderIds"] = orderIds
+	type OrderCancelResponse struct {
+		Order      OrderResponse `json:"order"`
+		ResultCode string        `json:"resultCode"`
+		UUID       int64         `json:"uuid"`
+		ErrorCode  int64         `json:"errorCode"`
+	}
+	var response OrderCancelResponse
+	err = a.SendAuthenticatedHTTPRequest(anxCancel, request, &response)
+	if response.ResultCode != "OK" {
+		log.Printf("Response code is not OK: %s\n", response.ResultCode)
+		return errors.New(response.ResultCode)
+	}
+	return err
 }
 
 // OrderInfo returns information about a specific order

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -1,6 +1,7 @@
 package anx
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -249,5 +250,23 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := a.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	a.SetDefaults()
+	TestSetup(t)
+	a.APIKey = ""
+	a.APISecret = ""
+	a.AuthenticatedAPISupport = true
+	a.Verbose = true
+	butts, errrr := a.GetDataToken()
+	fmt.Sprintf("%v %v", butts, errrr)
+
+	var buttsMcgee exchange.OrderCancellation
+	_, err := a.CancelOrder(buttsMcgee)
+
+	if err != nil {
+		t.Error("Could not cancel order:", err)
 	}
 }

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -268,7 +268,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	a.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.BTC, symbol.LTC)
-	currencyPair.Delimiter = "_"
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -277,10 +276,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 		CurrencyPair:  currencyPair,
 	}
 	// Act
-	wasOrderCancelled, err := a.CancelOrder(orderCancellation)
+	err := a.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Test Failed - ANX CancelOrder() error: %s", err)
 	}
 }

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -1,7 +1,6 @@
 package anx
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -12,15 +11,12 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey    = ""
-	testAPISecret = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
+	canManipulateRealOrders = false
 )
 
 var a ANX
-
-const (
-	canPlaceOrders = false
-)
 
 func TestSetDefaults(t *testing.T) {
 	a.SetDefaults()
@@ -231,15 +227,23 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+
+func isRealOrderTestEnabled() bool {
+	if a.APIKey == "" || a.APISecret == "" ||
+		a.APIKey == "Key" || a.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	a.SetDefaults()
 	TestSetup(t)
 
-	if a.APIKey == "" || a.APISecret == "" ||
-		a.APIKey == "Key" || a.APISecret == "Secret" ||
-		!canPlaceOrders {
+	if !isRealOrderTestEnabled() {
 		t.Skip()
 	}
 	var p = pair.CurrencyPair{
@@ -254,19 +258,29 @@ func TestSubmitOrder(t *testing.T) {
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
 	a.SetDefaults()
 	TestSetup(t)
-	a.APIKey = ""
-	a.APISecret = ""
-	a.AuthenticatedAPISupport = true
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
 	a.Verbose = true
-	butts, errrr := a.GetDataToken()
-	fmt.Sprintf("%v %v", butts, errrr)
+	currencyPair := pair.NewCurrencyPair(symbol.BTC, symbol.LTC)
+	currencyPair.Delimiter = "_"
 
-	var buttsMcgee exchange.OrderCancellation
-	_, err := a.CancelOrder(buttsMcgee)
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+	// Act
+	wasOrderCancelled, err := a.CancelOrder(orderCancellation)
 
-	if err != nil {
-		t.Error("Could not cancel order:", err)
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Test Failed - ANX CancelOrder() error: %s", err)
 	}
 }

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -228,8 +228,15 @@ func (a *ANX) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, er
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (a *ANX) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (a *ANX) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDs := []string{order.OrderID}
+	err := a.CancelOrderByIDs(orderIDs)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -228,15 +228,9 @@ func (a *ANX) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, er
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (a *ANX) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (a *ANX) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDs := []string{order.OrderID}
-	err := a.CancelOrderByIDs(orderIDs)
-
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return a.CancelOrderByIDs(orderIDs)
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -419,21 +419,6 @@ func (b *Binance) GetBestPrice(symbol string) (BestPrice, error) {
 	return resp, b.SendHTTPRequest(path, &resp)
 }
 
-// NewOrderTest sends a new order
-func (b *Binance) NewOrderTest() (interface{}, error) {
-	var resp interface{}
-
-	path := fmt.Sprintf("%s%s", b.APIUrl, newOrderTest)
-
-	params := url.Values{}
-	params.Set("symbol", "BTCUSDT")
-	params.Set("side", "BUY")
-	params.Set("type", "MARKET")
-	params.Set("quantity", "0.1")
-
-	return resp, b.SendAuthHTTPRequest("POST", path, params, &resp)
-}
-
 // NewOrder sends a new order to Binance
 func (b *Binance) NewOrder(o NewOrderRequest) (NewOrderResponse, error) {
 	var resp NewOrderResponse

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -375,7 +375,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -385,10 +384,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
-	// Assert
-	if !wasOrderCancelled || err != nil {
+	// Assert 
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -138,14 +138,6 @@ func TestGetBestPrice(t *testing.T) {
 	}
 }
 
-func TestNewOrderTest(t *testing.T) {
-	t.Parallel()
-	_, err := b.NewOrderTest()
-	if err != nil {
-		t.Error("Test Failed - Binance NewOrderTest() error", err)
-	}
-}
-
 func TestNewOrder(t *testing.T) {
 	t.Parallel()
 

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -12,9 +12,9 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey     = ""
-	testAPISecret  = ""
-	canPlaceOrders = false
+	testAPIKey              = ""
+	testAPISecret           = ""
+	canManipulateRealOrders = false
 )
 
 var b Binance
@@ -339,17 +339,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// -----------------------------------------------------------------------------------------------------------------------------
+
+func isRealOrderTestEnabled() bool {
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canPlaceOrders {
+	if !isRealOrderTestEnabled() {
 		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.LTC,
@@ -358,5 +367,36 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	TestSetup(t)
+
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		t.Skip()
+	}
+
+	b.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -191,20 +191,16 @@ func (b *Binance) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Binance) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (b *Binance) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	_, err = b.CancelExistingOrder(order.CurrencyPair.Pair().String(), orderIDInt, order.AccountID)
+	_, err = b.CancelExistingOrder(exchange.FormatExchangeCurrency(b.Name, order.CurrencyPair).String(), orderIDInt, order.AccountID)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -190,8 +191,20 @@ func (b *Binance) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Binance) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (b *Binance) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = b.CancelExistingOrder(order.CurrencyPair.Pair().String(), orderIDInt, order.AccountID)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -916,6 +916,7 @@ func (b *Bitfinex) SendAuthenticatedHTTPRequest(method, path string, params map[
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -15,9 +15,9 @@ import (
 
 // Please supply your own keys here to do better tests
 const (
-	testAPIKey     = ""
-	testAPISecret  = ""
-	canPlaceOrders = false
+	testAPIKey              = ""
+	testAPISecret           = ""
+	canManipulateRealOrders = false
 )
 
 var b Bitfinex
@@ -721,15 +721,22 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canPlaceOrders {
+	if !isRealOrderTestEnabled() {
 		t.Skip()
 	}
 	var p = pair.CurrencyPair{
@@ -740,5 +747,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	b.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -761,7 +761,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -771,10 +770,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -203,20 +203,16 @@ func (b *Bitfinex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int6
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bitfinex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (b *Bitfinex) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = b.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -202,8 +203,20 @@ func (b *Bitfinex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int6
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bitfinex) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (b *Bitfinex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = b.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -288,7 +288,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -298,10 +297,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -13,9 +13,9 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey     = ""
-	testAPISecret  = ""
-	canPlaceOrders = false
+	testAPIKey              = ""
+	testAPISecret           = ""
+	canManipulateRealOrders = false
 )
 
 var b Bitflyer
@@ -248,24 +248,60 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canPlaceOrders {
+	if !isRealOrderTestEnabled() {
 		t.Skip()
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
-		FirstCurrency:  symbol.BTC,
-		SecondCurrency: symbol.LTC,
+		FirstCurrency:  symbol.LTC,
+		SecondCurrency: symbol.BTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	b.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -166,8 +166,8 @@ func (b *Bitflyer) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int6
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bitflyer) CancelOrder(order exchange.OrderCancellation) (bool, error) {
-	return false, common.ErrNotYetImplemented
+func (b *Bitflyer) CancelOrder(order exchange.OrderCancellation) error {
+	return common.ErrNotYetImplemented
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -166,8 +166,8 @@ func (b *Bitflyer) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int6
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bitflyer) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (b *Bitflyer) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	return false, common.ErrNotYetImplemented
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -11,9 +11,9 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey     = ""
-	testAPISecret  = ""
-	canPlaceOrders = false
+	testAPIKey              = ""
+	testAPISecret           = ""
+	canManipulateRealOrders = false
 )
 
 var b Bithumb
@@ -284,17 +284,25 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canPlaceOrders {
+	if !isRealOrderTestEnabled() {
 		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.BTC,
@@ -303,5 +311,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	b.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -325,7 +325,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -335,10 +334,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -173,8 +173,14 @@ func (b *Bithumb) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bithumb) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (b *Bithumb) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	_, err := b.CancelTrade(order.Side.ToString(), order.OrderID, order.CurrencyPair.FirstCurrency.String())
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -173,14 +173,9 @@ func (b *Bithumb) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bithumb) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (b *Bithumb) CancelOrder(order exchange.OrderCancellation) error {
 	_, err := b.CancelTrade(order.Side.ToString(), order.OrderID, order.CurrencyPair.FirstCurrency.String())
-
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -508,7 +508,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
-		OrderID:       "1",
+		OrderID:       "123456789012345678901234567890123456",
 		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
 		AccountID:     "1",
 		CurrencyPair:  currencyPair,

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -13,9 +13,9 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey     = ""
-	testAPISecret  = ""
-	canPlaceOrders = false
+	testAPIKey              = ""
+	testAPISecret           = ""
+	canManipulateRealOrders = false
 )
 
 var b Bitmex
@@ -464,17 +464,25 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canPlaceOrders {
+	if !isRealOrderTestEnabled() {
 		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.XBT,
@@ -483,5 +491,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	b.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -505,7 +505,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "123456789012345678901234567890123456",
@@ -515,10 +514,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -177,8 +177,18 @@ func (b *Bitmex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bitmex) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (b *Bitmex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	var params = OrderCancelParams{
+		ClOrdID: order.AccountID,
+		OrderID: order.OrderID,
+	}
+	_, err := b.CancelOrders(params)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -179,7 +179,6 @@ func (b *Bitmex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 // CancelOrder cancels an order by its corresponding ID number
 func (b *Bitmex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
 	var params = OrderCancelParams{
-		ClOrdID: order.AccountID,
 		OrderID: order.OrderID,
 	}
 	_, err := b.CancelOrders(params)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -177,17 +177,13 @@ func (b *Bitmex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bitmex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (b *Bitmex) CancelOrder(order exchange.OrderCancellation) error {
 	var params = OrderCancelParams{
 		OrderID: order.OrderID,
 	}
 	_, err := b.CancelOrders(params)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -51,6 +51,8 @@ func TestSetup(t *testing.T) {
 	}
 	bConfig.APIKey = apiKey
 	bConfig.APISecret = apiSecret
+	bConfig.ClientID = customerID
+
 	b.Setup(bConfig)
 
 	if !b.IsEnabled() || b.RESTPollingDelay != time.Duration(10) ||

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -14,10 +14,10 @@ import (
 
 // Please add your private keys and customerID for better tests
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	customerID     = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	customerID              = ""
+	canManipulateRealOrders = false
 )
 
 var b Bitstamp
@@ -365,17 +365,25 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canPlaceOrders {
+	if !isRealOrderTestEnabled() {
 		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.BTC,
@@ -384,5 +392,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	b.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -408,7 +408,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -418,10 +417,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -3,6 +3,7 @@ package bitstamp
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -189,8 +190,19 @@ func (b *Bitstamp) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int6
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bitstamp) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (b *Bitstamp) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+	_, err = b.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -190,19 +190,15 @@ func (b *Bitstamp) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int6
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bitstamp) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (b *Bitstamp) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 	_, err = b.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -374,7 +374,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -384,10 +383,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -12,9 +12,9 @@ import (
 
 // Please supply you own test keys here to run better tests.
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	canManipulateRealOrders = false
 )
 
 var b Bittrex
@@ -333,17 +333,25 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canPlaceOrders {
+	if !isRealOrderTestEnabled() {
 		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "-",
 		FirstCurrency:  symbol.BTC,
@@ -352,5 +360,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	b.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -203,8 +203,14 @@ func (b *Bittrex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bittrex) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (b *Bittrex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	_, err := b.CancelExistingOrder(order.OrderID)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -203,14 +203,10 @@ func (b *Bittrex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *Bittrex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (b *Bittrex) CancelOrder(order exchange.OrderCancellation) error {
 	_, err := b.CancelExistingOrder(order.OrderID)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -5,14 +5,16 @@ import (
 	"time"
 
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 )
 
 // Please supply your own APIkeys here to do better tests
 const (
-	apiKey    = ""
-	apiSecret = ""
+	apiKey                  = ""
+	apiSecret               = ""
+	canManipulateRealOrders = false
 )
 
 var b BTCC
@@ -166,5 +168,64 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	// Assert
 	if withdrawPermissions != expectedResult {
 		t.Errorf("Expected: %s, Recieved: %s", expectedResult, withdrawPermissions)
+	}
+}
+
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if b.APIKey == "" || b.APISecret == "" ||
+		b.APIKey == "Key" || b.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
+func TestSubmitOrder(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	var p = pair.CurrencyPair{
+		Delimiter:      "-",
+		FirstCurrency:  symbol.BTC,
+		SecondCurrency: symbol.LTC,
+	}
+	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
+	if err != nil || !response.IsOrderPlaced {
+		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	b.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	b.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -212,7 +212,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -222,10 +221,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -164,8 +164,8 @@ func (b *BTCC) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, e
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *BTCC) CancelOrder(order exchange.OrderCancellation) (bool, error) {
-	return false, common.ErrNotYetImplemented
+func (b *BTCC) CancelOrder(order exchange.OrderCancellation) error {
+	return common.ErrNotYetImplemented
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -164,8 +164,8 @@ func (b *BTCC) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, e
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *BTCC) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (b *BTCC) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	return false, common.ErrNotYetImplemented
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -161,7 +161,9 @@ func TestModifyOrder(t *testing.T) {
 }
 
 func TestCancelOrder(t *testing.T) {
-	err := b.CancelOrder(1337)
+
+	_, err := b.CancelExistingOrder([]int64{1337})
+
 	if err == nil {
 		t.Error("Test failed - CancelgOrder() error", err)
 	}

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -345,7 +345,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	b.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -355,10 +354,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := b.CancelOrder(orderCancellation)
+	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/btcmarkets/btcmarkets_types.go
+++ b/exchanges/btcmarkets/btcmarkets_types.go
@@ -75,7 +75,7 @@ type OrderToGo struct {
 
 // Order holds order information
 type Order struct {
-	ID              int64           `json:"id"`
+	ID              string          `json:"id"`
 	Currency        string          `json:"currency"`
 	Instrument      string          `json:"instrument"`
 	OrderSide       string          `json:"orderSide"`

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -176,12 +177,16 @@ func (b *BTCMarkets) ModifyOrder(orderID int64, action exchange.ModifyOrder) (in
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *BTCMarkets) CancelOrder(orderID int64) error {
-	_, err := b.CancelExistingOrder([]int64{orderID})
+func (b *BTCMarkets) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	_, err = b.CancelExistingOrder([]int64{orderIDInt})
+
 	if err != nil {
-		return err
+		return false, err
 	}
-	return nil
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair
@@ -193,7 +198,13 @@ func (b *BTCMarkets) CancelAllOrders() error {
 
 	var orderList []int64
 	for _, order := range orders {
-		orderList = append(orderList, order.ID)
+		orderIDInt, strconvErr := strconv.ParseInt(order.ID, 10, 64)
+
+		if strconvErr != nil {
+			return strconvErr
+		}
+
+		orderList = append(orderList, orderIDInt)
 	}
 
 	_, err = b.CancelExistingOrder(orderList)

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -177,16 +177,12 @@ func (b *BTCMarkets) ModifyOrder(orderID int64, action exchange.ModifyOrder) (in
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (b *BTCMarkets) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (b *BTCMarkets) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	_, err = b.CancelExistingOrder([]int64{orderIDInt})
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -1,7 +1,6 @@
 package coinbasepro
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -15,10 +14,10 @@ var c CoinbasePro
 
 // Please supply your APIKeys here for better testing
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	clientID       = "" //passphrase you made at API CREATION
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	clientID                = "" //passphrase you made at API CREATION
+	canManipulateRealOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -408,17 +407,25 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if c.APIKey == "" || c.APISecret == "" ||
+		c.APIKey == "Key" || c.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if c.APIKey == "" || c.APISecret == "" ||
-		c.APIKey == "Key" || c.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can Place others: %v", c.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "-",
 		FirstCurrency:  symbol.BTC,
@@ -427,5 +434,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := c.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	c.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	c.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := c.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -448,7 +448,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	c.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -458,10 +457,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := c.CancelOrder(orderCancellation)
+	err := c.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -175,14 +175,8 @@ func (c *CoinbasePro) ModifyOrder(orderID int64, action exchange.ModifyOrder) (i
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (c *CoinbasePro) CancelOrder(order exchange.OrderCancellation) (bool, error) {
-	err := c.CancelExistingOrder(order.OrderID)
-
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+func (c *CoinbasePro) CancelOrder(order exchange.OrderCancellation) error {
+	return c.CancelExistingOrder(order.OrderID)
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -175,8 +175,14 @@ func (c *CoinbasePro) ModifyOrder(orderID int64, action exchange.ModifyOrder) (i
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (c *CoinbasePro) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (c *CoinbasePro) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	err := c.CancelExistingOrder(order.OrderID)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -216,8 +216,18 @@ func (c *COINUT) GetOpenOrders(instrumentID int) ([]OrdersResponse, error) {
 func (c *COINUT) CancelExistingOrder(instrumentID, orderID int) (bool, error) {
 	var result GenericResponse
 	params := make(map[string]interface{})
-	params["inst_id"] = instrumentID
-	params["order_id"] = orderID
+	type Request struct {
+		InstrumentID int `json:"inst_id"`
+		OrderID      int `json:"order_id"`
+	}
+
+	var entry = Request{
+		InstrumentID: instrumentID,
+		OrderID:      orderID,
+	}
+
+	entries := []Request{entry}
+	params["entries"] = entries
 
 	err := c.SendHTTPRequest(coinutOrdersCancel, params, true, &result)
 	if err != nil {

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -234,7 +234,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	c.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -244,10 +243,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := c.CancelOrder(orderCancellation)
+	err := c.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -1,7 +1,6 @@
 package coinut
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -195,16 +194,24 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if c.APISecret == "" ||
+		c.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 	c.Verbose = true
 
-	if c.APISecret == "" ||
-		c.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", c.APIKey, canManipulateRealOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.BTC,

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -199,8 +199,29 @@ func (c *COINUT) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (c *COINUT) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (c *COINUT) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	// Need to get the ID of the currency sent
+	instruments, err := c.GetInstruments()
+
+	if err != nil {
+		return false, err
+	}
+
+	currencyArray := instruments.Instruments[order.CurrencyPair.Pair().String()]
+	currencyID := currencyArray[0].InstID
+	_, err = c.CancelExistingOrder(currencyID, int(orderIDInt))
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -199,29 +199,25 @@ func (c *COINUT) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (c *COINUT) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (c *COINUT) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	// Need to get the ID of the currency sent
 	instruments, err := c.GetInstruments()
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	currencyArray := instruments.Instruments[order.CurrencyPair.Pair().String()]
+	currencyArray := instruments.Instruments[exchange.FormatExchangeCurrency(c.Name, order.CurrencyPair).String()]
 	currencyID := currencyArray[0].InstID
 	_, err = c.CancelExistingOrder(currencyID, int(orderIDInt))
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -89,6 +89,15 @@ type FeeBuilder struct {
 	Amount        float64
 }
 
+// OrderCancellation type requred when requesting to cancel an order
+type OrderCancellation struct {
+	AccountID     string
+	OrderID       string
+	CurrencyPair  pair.CurrencyPair
+	WalletAddress string
+	Side          OrderSide
+}
+
 // Definitions for each type of withdrawal method for a given exchange
 const (
 	// No withdraw
@@ -161,7 +170,7 @@ type TradeHistory struct {
 // OrderDetail holds order detail data
 type OrderDetail struct {
 	Exchange      string
-	ID            int64
+	ID            string
 	BaseCurrency  string
 	QuoteCurrency string
 	OrderSide     string
@@ -254,7 +263,7 @@ type IBotExchange interface {
 	GetFundingHistory() ([]FundHistory, error)
 	SubmitOrder(p pair.CurrencyPair, side OrderSide, orderType OrderType, amount, price float64, clientID string) (SubmitOrderResponse, error)
 	ModifyOrder(orderID int64, modify ModifyOrder) (int64, error)
-	CancelOrder(orderID int64) error
+	CancelOrder(order OrderCancellation) (bool, error)
 	CancelAllOrders() error
 	GetOrderInfo(orderID int64) (OrderDetail, error)
 	GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error)

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -263,7 +263,7 @@ type IBotExchange interface {
 	GetFundingHistory() ([]FundHistory, error)
 	SubmitOrder(p pair.CurrencyPair, side OrderSide, orderType OrderType, amount, price float64, clientID string) (SubmitOrderResponse, error)
 	ModifyOrder(orderID int64, modify ModifyOrder) (int64, error)
-	CancelOrder(order OrderCancellation) (bool, error)
+	CancelOrder(order OrderCancellation) error
 	CancelAllOrders() error
 	GetOrderInfo(orderID int64) (OrderDetail, error)
 	GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error)

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -290,7 +290,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	e.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -300,10 +299,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := e.CancelOrder(orderCancellation)
+	err := e.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -1,7 +1,6 @@
 package exmo
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/currency/pair"
@@ -10,9 +9,9 @@ import (
 )
 
 const (
-	APIKey         = ""
-	APISecret      = ""
-	canPlaceOrders = false
+	APIKey                  = ""
+	APISecret               = ""
+	canManipulateRealOrders = false
 )
 
 var (
@@ -249,18 +248,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if e.APIKey == "" || e.APISecret == "" ||
+		e.APIKey == "Key" || e.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	e.SetDefaults()
 	TestSetup(t)
 	e.Verbose = true
 
-	if e.APISecret == "" ||
-		e.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", e.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "_",
 		FirstCurrency:  symbol.BTC,
@@ -269,5 +276,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := e.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	e.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	e.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := e.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -212,8 +212,20 @@ func (e *EXMO) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, e
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (e *EXMO) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (e *EXMO) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	e.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -212,20 +212,14 @@ func (e *EXMO) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, e
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (e *EXMO) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (e *EXMO) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	e.CancelExistingOrder(orderIDInt)
-
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return e.CancelExistingOrder(orderIDInt)
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -292,7 +292,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	g.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -302,10 +301,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := g.CancelOrder(orderCancellation)
+	err := g.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -166,19 +166,15 @@ func (g *Gateio) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (g *Gateio) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (g *Gateio) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
-	_, err = g.CancelExistingOrder(orderIDInt, order.CurrencyPair.Pair().String())
+	_, err = g.CancelExistingOrder(orderIDInt, exchange.FormatExchangeCurrency(g.Name, order.CurrencyPair).String())
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -165,8 +166,19 @@ func (g *Gateio) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (g *Gateio) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (g *Gateio) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+	_, err = g.CancelExistingOrder(orderIDInt, order.CurrencyPair.Pair().String())
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -1,7 +1,6 @@
 package gemini
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 
@@ -24,7 +23,7 @@ const (
 	apiKeyRole2       = ""
 	sessionHeartBeat2 = false
 
-	canPlaceOrders = false
+	canManipulateRealOrders = false
 )
 
 func TestAddSession(t *testing.T) {
@@ -325,18 +324,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if Session[1].APIKey == "" || Session[1].APISecret == "" ||
+		Session[1].APIKey == "Key" || Session[1].APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	Session[1].SetDefaults()
 	TestSetup(t)
 	Session[1].Verbose = true
 
-	if Session[1].APIKey == "" || Session[1].APISecret == "" ||
-		Session[1].APIKey == "Key" || Session[1].APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", Session[1].APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "_",
 		FirstCurrency:  symbol.LTC,
@@ -345,5 +352,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := Session[1].SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	Session[1].SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	Session[1].Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := Session[1].CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -366,7 +366,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	Session[1].Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -376,10 +375,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := Session[1].CancelOrder(orderCancellation)
+	err := Session[1].CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -150,8 +151,20 @@ func (g *Gemini) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (g *Gemini) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (g *Gemini) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = g.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -151,20 +151,16 @@ func (g *Gemini) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (g *Gemini) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (g *Gemini) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = g.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -39,7 +39,6 @@ const (
 	orders              = "order"
 	orderBuy            = "api/2/order"
 	orderSell           = "sell"
-	orderCancel         = "cancelOrder"
 	orderMove           = "moveOrder"
 	tradableBalances    = "returnTradableBalances"
 	transferBalance     = "transferBalance"
@@ -436,9 +435,8 @@ func (h *HitBTC) PlaceOrder(currency string, rate, amount float64, orderType, si
 func (h *HitBTC) CancelExistingOrder(orderID int64) (bool, error) {
 	result := GenericResponse{}
 	values := url.Values{}
-	values.Set("orderNumber", strconv.FormatInt(orderID, 10))
 
-	err := h.SendAuthenticatedHTTPRequest("POST", orderCancel, values, &result)
+	err := h.SendAuthenticatedHTTPRequest("DELETE", orderBuy+"/"+strconv.FormatInt(orderID, 10), values, &result)
 
 	if err != nil {
 		return false, err

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -1,7 +1,6 @@
 package hitbtc
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -15,9 +14,9 @@ var h HitBTC
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	canManipulateRealOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -176,18 +175,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if h.APIKey == "" || h.APISecret == "" ||
+		h.APIKey == "Key" || h.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 	h.Verbose = true
 
-	if h.APIKey == "" || h.APISecret == "" ||
-		h.APIKey == "Key" || h.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", h.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.DGD,
@@ -196,5 +203,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := h.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	h.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	h.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := h.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -217,7 +217,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	h.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -227,10 +226,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := h.CancelOrder(orderCancellation)
+	err := h.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -178,20 +178,16 @@ func (h *HitBTC) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (h *HitBTC) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (h *HitBTC) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = h.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -3,6 +3,7 @@ package hitbtc
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -177,8 +178,20 @@ func (h *HitBTC) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (h *HitBTC) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (h *HitBTC) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = h.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -440,7 +440,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	h.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -450,10 +449,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := h.CancelOrder(orderCancellation)
+	err := h.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -219,8 +219,20 @@ func (h *HUOBI) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (h *HUOBI) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (h *HUOBI) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = h.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -219,20 +219,16 @@ func (h *HUOBI) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (h *HUOBI) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (h *HUOBI) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = h.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -419,7 +419,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	h.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -429,10 +428,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := h.CancelOrder(orderCancellation)
+	err := h.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -14,9 +14,9 @@ import (
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	canManipulateRealOrders = false
 )
 
 var h HUOBIHADAX
@@ -375,18 +375,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if h.APIKey == "" || h.APISecret == "" ||
+		h.APIKey == "Key" || h.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 	h.Verbose = true
 
-	if h.APIKey == "" || h.APISecret == "" ||
-		h.APIKey == "Key" || h.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", h.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.BTC,
@@ -397,5 +405,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := h.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 10, strconv.FormatInt(accounts[0].ID, 10))
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	h.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	h.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := h.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -184,20 +184,16 @@ func (h *HUOBIHADAX) ModifyOrder(orderID int64, action exchange.ModifyOrder) (in
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (h *HUOBIHADAX) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (h *HUOBIHADAX) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = h.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -184,8 +184,20 @@ func (h *HUOBIHADAX) ModifyOrder(orderID int64, action exchange.ModifyOrder) (in
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (h *HUOBIHADAX) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (h *HUOBIHADAX) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = h.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -286,7 +286,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	i.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -296,10 +295,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := i.CancelOrder(orderCancellation)
+	err := i.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -172,8 +172,14 @@ func (i *ItBit) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (i *ItBit) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (i *ItBit) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	err := i.CancelExistingOrder(order.WalletAddress, order.OrderID)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -172,14 +172,8 @@ func (i *ItBit) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (i *ItBit) CancelOrder(order exchange.OrderCancellation) (bool, error) {
-	err := i.CancelExistingOrder(order.WalletAddress, order.OrderID)
-
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+func (i *ItBit) CancelOrder(order exchange.OrderCancellation) error {
+	return i.CancelExistingOrder(order.WalletAddress, order.OrderID)
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -372,7 +372,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	k.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -382,10 +381,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := k.CancelOrder(orderCancellation)
+	err := k.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1,7 +1,6 @@
 package kraken
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -14,10 +13,10 @@ var k Kraken
 
 // Please add your own APIkeys to do correct due diligence testing.
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	clientID       = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	clientID                = ""
+	canManipulateRealOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -331,18 +330,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if k.APIKey == "" || k.APISecret == "" ||
+		k.APIKey == "Key" || k.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
 	k.Verbose = true
 
-	if k.APIKey == "" || k.APISecret == "" ||
-		k.APIKey == "Key" || k.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", k.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.XBT,
@@ -351,5 +358,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := k.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	k.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	k.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := k.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -185,14 +185,10 @@ func (k *Kraken) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (k *Kraken) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (k *Kraken) CancelOrder(order exchange.OrderCancellation) error {
 	_, err := k.CancelExistingOrder(order.OrderID)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -185,8 +185,14 @@ func (k *Kraken) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (k *Kraken) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (k *Kraken) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	_, err := k.CancelExistingOrder(order.OrderID)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -27,7 +27,7 @@ const (
 	lakeBTCSellOrder           = "sellOrder"
 	lakeBTCOpenOrders          = "openOrders"
 	lakeBTCGetOrders           = "getOrders"
-	lakeBTCCancelOrder         = "cancelOrder"
+	lakeBTCCancelOrder         = "cancelOrders"
 	lakeBTCGetTrades           = "getTrades"
 	lakeBTCGetExternalAccounts = "getExternalAccounts"
 	lakeBTCCreateWithdraw      = "createWithdraw"

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -1,7 +1,6 @@
 package lakebtc
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -14,9 +13,9 @@ var l LakeBTC
 
 // Please add your own APIkeys to do correct due diligence testing.
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	canManipulateRealOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -249,18 +248,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if l.APIKey == "" || l.APISecret == "" ||
+		l.APIKey == "Key" || l.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 	l.Verbose = true
 
-	if l.APIKey == "" || l.APISecret == "" ||
-		l.APIKey == "Key" || l.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", l.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.BTC,
@@ -269,5 +276,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := l.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	l.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	l.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := l.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -290,7 +290,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	l.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -300,10 +299,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := l.CancelOrder(orderCancellation)
+	err := l.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -108,9 +108,9 @@ func TestCancelOrder(t *testing.T) {
 	if l.APIKey == "" || l.APISecret == "" {
 		t.Skip()
 	}
-	err := l.CancelOrder(1337)
+	err := l.CancelExistingOrder(1337)
 	if err == nil {
-		t.Error("Test Failed - CancelOrder() error", err)
+		t.Error("Test Failed - CancelExistingOrder() error", err)
 	}
 }
 

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -162,20 +162,14 @@ func (l *LakeBTC) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (l *LakeBTC) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (l *LakeBTC) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	err = l.CancelExistingOrder(orderIDInt)
-
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return l.CancelExistingOrder(orderIDInt)
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -162,8 +162,20 @@ func (l *LakeBTC) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (l *LakeBTC) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (l *LakeBTC) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	err = l.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -275,7 +275,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	l.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -285,10 +284,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := l.CancelOrder(orderCancellation)
+	err := l.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -1,7 +1,6 @@
 package liqui
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 
@@ -14,9 +13,9 @@ import (
 var l Liqui
 
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	canManipulateRealOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -234,18 +233,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if l.APIKey == "" || l.APISecret == "" ||
+		l.APIKey == "Key" || l.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 	l.Verbose = true
 
-	if l.APIKey == "" || l.APISecret == "" ||
-		l.APIKey == "Key" || l.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", l.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.BTC,
@@ -254,5 +261,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := l.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	l.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	l.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := l.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/liqui/liqui_wrapper.go
+++ b/exchanges/liqui/liqui_wrapper.go
@@ -171,20 +171,16 @@ func (l *Liqui) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (l *Liqui) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (l *Liqui) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = l.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/liqui/liqui_wrapper.go
+++ b/exchanges/liqui/liqui_wrapper.go
@@ -3,6 +3,7 @@ package liqui
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -170,8 +171,20 @@ func (l *Liqui) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (l *Liqui) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (l *Liqui) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = l.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -239,7 +239,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	l.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -249,10 +248,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := l.CancelOrder(orderCancellation)
+	err := l.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -213,14 +213,8 @@ func (l *LocalBitcoins) ModifyOrder(orderID int64, action exchange.ModifyOrder) 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (l *LocalBitcoins) CancelOrder(order exchange.OrderCancellation) (bool, error) {
-	err := l.DeleteAd(order.OrderID)
-	
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+func (l *LocalBitcoins) CancelOrder(order exchange.OrderCancellation) error {
+	return l.DeleteAd(order.OrderID)
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -213,8 +213,8 @@ func (l *LocalBitcoins) ModifyOrder(orderID int64, action exchange.ModifyOrder) 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (l *LocalBitcoins) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (l *LocalBitcoins) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	return false, common.ErrNotYetImplemented
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -214,7 +214,13 @@ func (l *LocalBitcoins) ModifyOrder(orderID int64, action exchange.ModifyOrder) 
 
 // CancelOrder cancels an order by its corresponding ID number
 func (l *LocalBitcoins) CancelOrder(order exchange.OrderCancellation) (bool, error) {
-	return false, common.ErrNotYetImplemented
+	err := l.DeleteAd(order.OrderID)
+	
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -1,7 +1,6 @@
 package okcoin
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -15,9 +14,9 @@ var o OKCoin
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	canManipulateRealOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -149,18 +148,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if o.APIKey == "" || o.APISecret == "" ||
+		o.APIKey == "Key" || o.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 	o.Verbose = true
 
-	if o.APIKey == "" || o.APISecret == "" ||
-		o.APIKey == "Key" || o.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", o.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.BTC,
@@ -169,5 +176,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := o.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	o.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	o.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := o.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -190,7 +190,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	o.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -200,10 +199,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := o.CancelOrder(orderCancellation)
+	err := o.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -232,21 +232,17 @@ func (o *OKCoin) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (o *OKCoin) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (o *OKCoin) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 	orders := []int64{orderIDInt}
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	_, err = o.CancelExistingOrder(orders, order.CurrencyPair.Pair().String())
+	_, err = o.CancelExistingOrder(orders, exchange.FormatExchangeCurrency(o.Name, order.CurrencyPair).String())
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -231,8 +232,21 @@ func (o *OKCoin) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64,
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (o *OKCoin) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (o *OKCoin) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+	orders := []int64{orderIDInt}
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = o.CancelExistingOrder(orders, order.CurrencyPair.Pair().String())
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -439,7 +439,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	o.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -449,10 +448,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := o.CancelOrder(orderCancellation)
+	err := o.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -216,8 +217,20 @@ func (o *OKEX) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, e
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (o *OKEX) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (o *OKEX) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = o.SpotCancelOrder(order.CurrencyPair.Pair().String(), orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -217,20 +217,16 @@ func (o *OKEX) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, e
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (o *OKEX) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (o *OKEX) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	_, err = o.SpotCancelOrder(order.CurrencyPair.Pair().String(), orderIDInt)
+	_, err = o.SpotCancelOrder(exchange.FormatExchangeCurrency(o.Name, order.CurrencyPair).String(), orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -1,7 +1,6 @@
 package poloniex
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -15,9 +14,9 @@ var p Poloniex
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey         = ""
-	apiSecret      = ""
-	canPlaceOrders = false
+	apiKey                  = ""
+	apiSecret               = ""
+	canManipulateRealOrders = false
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -194,18 +193,26 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
-// This will really really use the API to place an order
-// If you're going to test this, make sure you're willing to place real orders on the exchange
+// Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
+// ----------------------------------------------------------------------------------------------------------------------------
+func isRealOrderTestEnabled() bool {
+	if p.APIKey == "" || p.APISecret == "" ||
+		p.APIKey == "Key" || p.APISecret == "Secret" ||
+		!canManipulateRealOrders {
+		return false
+	}
+	return true
+}
+
 func TestSubmitOrder(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 	p.Verbose = true
 
-	if p.APIKey == "" || p.APISecret == "" ||
-		p.APIKey == "Key" || p.APISecret == "Secret" ||
-		!canPlaceOrders {
-		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", p.APIKey, canPlaceOrders))
+	if !isRealOrderTestEnabled() {
+		t.Skip()
 	}
+
 	var pair = pair.CurrencyPair{
 		Delimiter:      "_",
 		FirstCurrency:  symbol.BTC,
@@ -214,5 +221,34 @@ func TestSubmitOrder(t *testing.T) {
 	response, err := p.SubmitOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
 	if err != nil || !response.IsOrderPlaced {
 		t.Errorf("Order failed to be placed: %v", err)
+	}
+}
+
+func TestCancelExchangeOrder(t *testing.T) {
+	// Arrange
+	p.SetDefaults()
+	TestSetup(t)
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	p.Verbose = true
+	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
+	currencyPair.Delimiter = ""
+
+	var orderCancellation = exchange.OrderCancellation{
+		OrderID:       "1",
+		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		AccountID:     "1",
+		CurrencyPair:  currencyPair,
+	}
+
+	// Act
+	wasOrderCancelled, err := p.CancelOrder(orderCancellation)
+
+	// Assert
+	if !wasOrderCancelled || err != nil {
+		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -235,7 +235,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	p.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -245,10 +244,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := p.CancelOrder(orderCancellation)
+	err := p.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -3,6 +3,7 @@ package poloniex
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -179,8 +180,20 @@ func (p *Poloniex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int6
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (p *Poloniex) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (p *Poloniex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = p.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -180,20 +180,16 @@ func (p *Poloniex) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int6
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (p *Poloniex) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (p *Poloniex) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = p.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -291,8 +291,13 @@ func (r *Requester) DoRequest(req *http.Request, method, path string, headers ma
 			return err
 		}
 
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("Error: HTTP Status code %s. Body: %s", resp.Status, contents)
+		}
+
 		resp.Body.Close()
 		if verbose {
+			log.Printf("HTTP status: %s, Code: %v", resp.Status, resp.StatusCode)
 			log.Printf("%s exchange raw response: %s", r.Name, string(contents[:]))
 		}
 

--- a/exchanges/request/request.go
+++ b/exchanges/request/request.go
@@ -291,7 +291,7 @@ func (r *Requester) DoRequest(req *http.Request, method, path string, headers ma
 			return err
 		}
 
-		if resp.StatusCode != 200 {
+		if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202 {
 			return fmt.Errorf("Error: HTTP Status code %s. Body: %s", resp.Status, contents)
 		}
 

--- a/exchanges/request/request_test.go
+++ b/exchanges/request/request_test.go
@@ -274,7 +274,7 @@ func TestDoRequest(t *testing.T) {
 
 	headers := make(map[string]string)
 	headers["content-type"] = "content/text"
-	err = r.SendPayload("POST", "https://api.bitfinex.com", headers, nil, result, false, true)
+	err = r.SendPayload("POST", "https://bitfinex.com", headers, nil, result, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -371,7 +371,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	w.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -381,10 +380,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := w.CancelOrder(orderCancellation)
+	err := w.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -16,6 +16,7 @@ const (
 	apiKey                  = ""
 	apiSecret               = ""
 	canManipulateRealOrders = false
+	isWexEncounteringIssues = true
 )
 
 func TestSetDefaults(t *testing.T) {
@@ -37,6 +38,9 @@ func TestSetup(t *testing.T) {
 }
 
 func TestGetTradablePairs(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetTradablePairs()
 	if err != nil {
@@ -45,6 +49,9 @@ func TestGetTradablePairs(t *testing.T) {
 }
 
 func TestGetInfo(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetInfo()
 	if err != nil {
@@ -53,6 +60,9 @@ func TestGetInfo(t *testing.T) {
 }
 
 func TestGetTicker(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetTicker("btc_usd")
 	if err != nil {
@@ -61,6 +71,9 @@ func TestGetTicker(t *testing.T) {
 }
 
 func TestGetDepth(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetDepth("btc_usd")
 	if err != nil {
@@ -69,6 +82,9 @@ func TestGetDepth(t *testing.T) {
 }
 
 func TestGetTrades(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetTrades("btc_usd")
 	if err != nil {
@@ -77,6 +93,9 @@ func TestGetTrades(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetAccountInfo()
 	if err == nil {
@@ -85,6 +104,9 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestGetActiveOrders(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetActiveOrders("")
 	if err == nil {
@@ -93,6 +115,9 @@ func TestGetActiveOrders(t *testing.T) {
 }
 
 func TestGetOrderInfo(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetOrderInfo(6196974)
 	if err == nil {
@@ -101,6 +126,9 @@ func TestGetOrderInfo(t *testing.T) {
 }
 
 func TestCancelExistingOrder(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.CancelExistingOrder(1337)
 	if err == nil {
@@ -109,6 +137,9 @@ func TestCancelExistingOrder(t *testing.T) {
 }
 
 func TestTrade(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.Trade("", "buy", 0, 0)
 	if err == nil {
@@ -117,6 +148,9 @@ func TestTrade(t *testing.T) {
 }
 
 func TestGetTransactionHistory(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetTransactionHistory(0, 0, 0, "", "", "")
 	if err == nil {
@@ -125,6 +159,9 @@ func TestGetTransactionHistory(t *testing.T) {
 }
 
 func TestGetTradeHistory(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.GetTradeHistory(0, 0, 0, "", "", "", "")
 	if err == nil {
@@ -133,6 +170,9 @@ func TestGetTradeHistory(t *testing.T) {
 }
 
 func TestWithdrawCoins(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.WithdrawCoins("", 0, "")
 	if err == nil {
@@ -141,6 +181,9 @@ func TestWithdrawCoins(t *testing.T) {
 }
 
 func TestCoinDepositAddress(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.CoinDepositAddress("btc")
 	if err == nil {
@@ -149,6 +192,9 @@ func TestCoinDepositAddress(t *testing.T) {
 }
 
 func TestCreateCoupon(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.CreateCoupon("bla", 0)
 	if err == nil {
@@ -157,6 +203,9 @@ func TestCreateCoupon(t *testing.T) {
 }
 
 func TestRedeemCoupon(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	t.Parallel()
 	_, err := w.RedeemCoupon("bla")
 	if err == nil {
@@ -179,6 +228,9 @@ func setFeeBuilder() exchange.FeeBuilder {
 }
 
 func TestGetFee(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	w.SetDefaults()
 	TestSetup(t)
 	var feeBuilder = setFeeBuilder()
@@ -257,6 +309,9 @@ func TestGetFee(t *testing.T) {
 }
 
 func TestFormatWithdrawPermissions(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	// Arrange
 	w.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithAPIPermissionText
@@ -280,6 +335,9 @@ func isRealOrderTestEnabled() bool {
 }
 
 func TestSubmitOrder(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	w.SetDefaults()
 	TestSetup(t)
 	w.Verbose = true
@@ -300,6 +358,9 @@ func TestSubmitOrder(t *testing.T) {
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
+	if isWexEncounteringIssues {
+		t.Skip()
+	}
 	// Arrange
 	w.SetDefaults()
 	TestSetup(t)

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -181,20 +181,16 @@ func (w *WEX) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, er
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (w *WEX) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (w *WEX) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = w.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -3,6 +3,7 @@ package wex
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -180,8 +181,20 @@ func (w *WEX) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, er
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (w *WEX) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (w *WEX) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = w.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -354,7 +354,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	y.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -364,10 +363,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := y.CancelOrder(orderCancellation)
+	err := y.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -163,20 +163,16 @@ func (y *Yobit) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (y *Yobit) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (y *Yobit) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	_, err = y.CancelExistingOrder(orderIDInt)
 
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -3,6 +3,7 @@ package yobit
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -162,8 +163,20 @@ func (y *Yobit) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, 
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (y *Yobit) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (y *Yobit) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	_, err = y.CancelExistingOrder(orderIDInt)
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -284,7 +284,6 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	z.Verbose = true
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-	currencyPair.Delimiter = ""
 
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
@@ -294,10 +293,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 
 	// Act
-	wasOrderCancelled, err := z.CancelOrder(orderCancellation)
+	err := z.CancelOrder(orderCancellation)
 
 	// Assert
-	if !wasOrderCancelled || err != nil {
+	if err != nil {
 		t.Errorf("Could not cancel order: %s", err)
 	}
 }

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -174,20 +174,14 @@ func (z *ZB) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, err
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (z *ZB) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func (z *ZB) CancelOrder(order exchange.OrderCancellation) error {
 	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	err = z.CancelExistingOrder(orderIDInt, order.CurrencyPair.Pair().String())
-
-	if err != nil {
-		return false, err
-	}
-
-	return true, err
+	return z.CancelExistingOrder(orderIDInt, exchange.FormatExchangeCurrency(z.Name, order.CurrencyPair).String())
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/thrasher-/gocryptotrader/common"
@@ -173,8 +174,20 @@ func (z *ZB) ModifyOrder(orderID int64, action exchange.ModifyOrder) (int64, err
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func (z *ZB) CancelOrder(orderID int64) error {
-	return common.ErrNotYetImplemented
+func (z *ZB) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+	orderIDInt, err := strconv.ParseInt(order.OrderID, 10, 64)
+
+	if err != nil {
+		return false, err
+	}
+
+	err = z.CancelExistingOrder(orderIDInt, order.CurrencyPair.Pair().String())
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, err
 }
 
 // CancelAllOrders cancels all orders associated with a currency pair

--- a/tools/exchange_template/wrapper_file.tmpl
+++ b/tools/exchange_template/wrapper_file.tmpl
@@ -132,7 +132,7 @@ func ({{.Variable}} *{{.CapitalName}}) ModifyOrder(orderID int64, action exchang
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func ({{.Variable}} *{{.CapitalName}}) CancelOrder(orderID int64) error {
+func ({{.Variable}} *{{.CapitalName}}) CancelOrder(order exchange.OrderCancellation) (bool, error) {
 	return common.ErrNotYetImplemented
 }
 

--- a/tools/exchange_template/wrapper_file.tmpl
+++ b/tools/exchange_template/wrapper_file.tmpl
@@ -132,7 +132,7 @@ func ({{.Variable}} *{{.CapitalName}}) ModifyOrder(orderID int64, action exchang
 }
 
 // CancelOrder cancels an order by its corresponding ID number
-func ({{.Variable}} *{{.CapitalName}}) CancelOrder(order exchange.OrderCancellation) (bool, error) {
+func ({{.Variable}} *{{.CapitalName}}) CancelOrder(order exchange.OrderCancellation) error {
 	return common.ErrNotYetImplemented
 }
 


### PR DESCRIPTION
# Description

This PR maps each exchange's wrapper method _CancelOrder_ with the exchange implementation. It fixes up issues encountered via testing.
It introduces a type to handle the various requirements for each exchange. It also adds tests. 

Note: This does not cover _CancelAllOrders_ as it will be a future PR

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
The test _TestCancelExchangeOrder_ has been added to each exchange's test file.

All but the following exchanges have been tested:
- localbitcoins (requires more verification before API access is granted)
- BTCC (Cancelling orders it not implemented in the websocket yet)
- BitFlyer (Has shut down account creation so cannot verify)
- Liqui (Requires more verification before API access is granted)
- Alphapoint (no account)
- Bithumb (Does not send validation email to activate API)
- Wex (Is down)
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules