### PR TITLE
Fixes huobi hadax signature for authenticated methods

### DIFF
--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -763,7 +763,7 @@ func (h *HUOBIHADAX) SendAuthenticatedHTTPPostRequest(method, endpoint, postBody
 	signatureParams.Set("Timestamp", time.Now().UTC().Format("2006-01-02T15:04:05"))
 
 	endpoint = fmt.Sprintf("/v%s/%s", huobihadaxAPIVersion, endpoint)
-	payload := fmt.Sprintf("%s\napi.huobi.pro\n%s\n%s",
+	payload := fmt.Sprintf("%s\napi.hadax.com\n%s\n%s",
 		method, endpoint, signatureParams.Encode())
 
 	headers := make(map[string]string)
@@ -791,7 +791,7 @@ func (h *HUOBIHADAX) SendAuthenticatedHTTPRequest(method, endpoint string, value
 	values.Set("Timestamp", time.Now().UTC().Format("2006-01-02T15:04:05"))
 
 	endpoint = fmt.Sprintf("/v%s/%s", huobihadaxAPIVersion, endpoint)
-	payload := fmt.Sprintf("%s\napi.huobi.pro\n%s\n%s",
+	payload := fmt.Sprintf("%s\napi.hadax.com\n%s\n%s",
 		method, endpoint, values.Encode())
 
 	headers := make(map[string]string)


### PR DESCRIPTION
# Description

Hadax had the wrong URL in its signature generation so all authenticated requests were denied. This changes it to the correct URL

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've run authenticated endpoint tests such as TestCancelExchangeOrder and it is successful

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally and on Travis with my changes