### PR TITLE
Pre-Commit Githook

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,9 +1,9 @@
-This Git hook is designed to prevent you from commit your keys.
+This Git hook is designed to prevent you from commit your keys to the repo
 
-#To use:
-##Command method:
+# To use:
+## Command method:
 Run the following:
 `git config core.hooksPath .githooks`
 
-##Copy method:
+## Copy method:
 Copy pre-commit to .git/hooks

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,9 @@
+This Git hook is designed to prevent you from commit your keys.
+
+#To use:
+##Command method:
+Run the following:
+`git config core.hooksPath .githooks`
+
+##Copy method:
+Copy pre-commit to .git/hooks

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,9 +1,23 @@
-This Git hook is designed to prevent you from commit your keys to the repo
+This folder contains optional git hooks to use when commiting to GoCryptoTrader
 
 # To use:
 ## Command method:
 Run the following:
 `git config core.hooksPath .githooks`
+This will set the hook path to this folder
 
-## Copy method:
-Copy pre-commit to .git/hooks
+# Git Hooks:
+The following table details our git hooks and what they do
+
+<table>
+<thead>
+<tr>
+<th>Git Hook</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Pre-Commit</td>
+<td>Scans all test files and verifies that the testAPIKey, testAPISecret, clientID and canManipulateRealOrders fields will not comprimise you/the GoCryptoTrader repository. It will also perform the same checks against testconfig.json</td>
+</tr></tbody></table>

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+STAGED_GO_FILES=$(git diff --cached --name-only | grep "test.go$")
+
+if [[ "$STAGED_GO_FILES" = "" ]]; then
+  exit 0
+fi
+
+PASS=true
+
+for FILE in $STAGED_GO_FILES
+do
+EXCHANGE_DIRECTORY=$(echo  $FILE | rev | cut -d"/" -f2-  | rev)
+ROOT_PATH="./"
+TEST_PATH="$ROOT_PATH$EXCHANGE_DIRECTORY"
+  go test $TEST_PATH -run TestAreAPIKeysSet
+   if [[ $? == 1 ]]; then
+    printf "$TEST_PATH\033[0m \033[0;30m\033[41mFAILURE! Please ensure API Keys are not set and canManipulateRealOrders is not enabled\033[0m\n"
+    PASS=false
+  fi
+done
+
+if ! $PASS; then
+  printf "COMMIT FAILED\n"
+  exit 1
+else
+  printf "COMMIT SUCCEEDED\n"
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,10 @@
 #!/bin/sh
+  echo "Running git hook to look for API keys\n"
 
 STAGED_GO_FILES=$(git diff --cached --name-only | grep "test.go$")
 
 if [[ "$STAGED_GO_FILES" = "" ]]; then
+  echo "No staged files contain keys\n"
   exit 0
 fi
 
@@ -13,9 +15,10 @@ do
 EXCHANGE_DIRECTORY=$(echo  $FILE | rev | cut -d"/" -f2-  | rev)
 ROOT_PATH="./"
 TEST_PATH="$ROOT_PATH$EXCHANGE_DIRECTORY"
+  echo "Running test for staged file: $FILE"
   go test $TEST_PATH -run TestAreAPIKeysSet
    if [[ $? == 1 ]]; then
-    printf "$TEST_PATH\033[0m \033[0;30m\033[41mFAILURE! Please ensure API Keys are not set and canManipulateRealOrders is not enabled\033[0m\n"
+    echo "$TEST_PATH\033[0m \033[0;30m\033[41mFAILURE! Please ensure API Keys are not set and canManipulateRealOrders is not enabled\033[0m\n"
     PASS=false
   fi
 done

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -35,7 +35,25 @@ func testSetAPIKey(a *Alphapoint) {
 	a.AuthenticatedAPISupport = true
 }
 
-func testIsAPIKeysSet(a *Alphapoint) bool {
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
+}
+
+func testCanRunAuthenticatedEndpoint(a *Alphapoint) bool {
 	if testAPIKey != "" && testAPISecret != "" && a.AuthenticatedAPISupport {
 		return true
 	}
@@ -296,7 +314,7 @@ func TestCreateAccount(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -319,7 +337,7 @@ func TestGetUserInfo(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -334,7 +352,7 @@ func TestSetUserInfo(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -349,7 +367,7 @@ func TestGetAccountInfo(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -364,7 +382,7 @@ func TestGetAccountTrades(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -379,7 +397,7 @@ func TestGetDepositAddresses(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -394,7 +412,7 @@ func TestWithdrawCoins(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -409,7 +427,7 @@ func TestCreateOrder(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -424,7 +442,7 @@ func TestModifyExistingOrder(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -439,7 +457,7 @@ func TestCancelAllExistingOrders(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -454,7 +472,7 @@ func TestGetOrders(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 
@@ -469,7 +487,7 @@ func TestGetOrderFee(t *testing.T) {
 	a.SetDefaults()
 	testSetAPIKey(a)
 
-	if !testIsAPIKeysSet(a) {
+	if !testCanRunAuthenticatedEndpoint(a) {
 		return
 	}
 

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -83,6 +83,33 @@ func TestSetup(t *testing.T) {
 	}
 }
 
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	a.SetDefaults()
+	TestSetup(t)
+	if a.APIKey != "" && a.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if a.APISecret != "" && a.APISecret != "Secret" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
+}
+
 func TestGetCurrencies(t *testing.T) {
 	_, err := a.GetCurrencies()
 	if err != nil {

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -37,6 +37,33 @@ func TestSetup(t *testing.T) {
 	b.Setup(binanceConfig)
 }
 
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
+}
+
 func TestGetExchangeValidCurrencyPairs(t *testing.T) {
 	t.Parallel()
 	_, err := b.GetExchangeValidCurrencyPairs()

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -44,6 +44,33 @@ func TestSetup(t *testing.T) {
 	b.Requester.SetRateLimit(false, time.Millisecond*300, 1)
 }
 
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
+}
+
 func TestGetPlatformStatus(t *testing.T) {
 	t.Parallel()
 

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -39,6 +39,33 @@ func TestSetup(t *testing.T) {
 	b.Setup(bitflyerConfig)
 }
 
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
+}
+
 func TestGetLatestBlockCA(t *testing.T) {
 	t.Parallel()
 	_, err := b.GetLatestBlockCA()

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -37,6 +37,33 @@ func TestSetup(t *testing.T) {
 	b.Setup(bitConfig)
 }
 
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
+}
+
 func TestGetTradablePairs(t *testing.T) {
 	t.Parallel()
 	_, err := b.GetTradablePairs()

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -39,6 +39,33 @@ func TestSetup(t *testing.T) {
 	b.Setup(bitmexConfig)
 }
 
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
+}
+
 func TestStart(t *testing.T) {
 	var testWg sync.WaitGroup
 	b.Start(&testWg)

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -14,8 +14,8 @@ import (
 
 // Please add your private keys and customerID for better tests
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	customerID              = ""
 	canManipulateRealOrders = false
 )
@@ -49,8 +49,8 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Error("Test Failed - Bitstamp Setup() init error")
 	}
-	bConfig.APIKey = apiKey
-	bConfig.APISecret = apiSecret
+	bConfig.APIKey = testAPIKey
+	bConfig.APISecret = testAPISecret
 	bConfig.ClientID = customerID
 
 	b.Setup(bConfig)
@@ -60,6 +60,36 @@ func TestSetup(t *testing.T) {
 		b.Verbose || b.Websocket.IsEnabled() || len(b.BaseCurrencies) < 1 ||
 		len(b.AvailablePairs) < 1 || len(b.EnabledPairs) < 1 {
 		t.Error("Test Failed - Bitstamp Setup values not set correctly")
+	}
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if customerID != "" {
+		errMsg += "Cannot commit populated customerID. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
 	}
 }
 

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please supply you own test keys here to run better tests.
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -33,8 +33,8 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Error("Test Failed - Bittrex Setup() init error")
 	}
-	bConfig.APIKey = apiKey
-	bConfig.APISecret = apiSecret
+	bConfig.APIKey = testAPIKey
+	bConfig.APISecret = testAPISecret
 	bConfig.AuthenticatedAPISupport = true
 
 	b.Setup(bConfig)
@@ -44,6 +44,33 @@ func TestSetup(t *testing.T) {
 		b.Websocket.IsEnabled() || len(b.BaseCurrencies) < 1 ||
 		len(b.AvailablePairs) < 1 || len(b.EnabledPairs) < 1 {
 		t.Error("Test Failed - Bittrex Setup values not set correctly")
+	}
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
 	}
 }
 

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please supply your own APIkeys here to do better tests
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -37,6 +37,33 @@ func TestSetup(t *testing.T) {
 		b.Websocket.IsEnabled() || len(b.BaseCurrencies) < 1 ||
 		len(b.AvailablePairs) < 1 || len(b.EnabledPairs) < 1 {
 		t.Error("Test Failed - BTCC Setup values not set correctly")
+	}
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
 	}
 }
 

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -14,8 +14,8 @@ var b BTCMarkets
 
 // Please supply your own keys here to do better tests
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -31,13 +31,40 @@ func TestSetup(t *testing.T) {
 		t.Error("Test Failed - BTC Markets Setup() init error")
 	}
 
-	if apiKey != "" && apiSecret != "" {
-		bConfig.APIKey = apiKey
-		bConfig.APISecret = apiSecret
+	if testAPIKey != "" && testAPISecret != "" {
+		bConfig.APIKey = testAPIKey
+		bConfig.APISecret = testAPISecret
 		bConfig.AuthenticatedAPISupport = true
 	}
 
 	b.Setup(bConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	b.SetDefaults()
+	TestSetup(t)
+	if b.APIKey != "" && b.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if b.APISecret != "" && b.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetMarkets(t *testing.T) {
@@ -45,22 +72,6 @@ func TestGetMarkets(t *testing.T) {
 	_, err := b.GetMarkets()
 	if err != nil {
 		t.Error("Test failed - GetMarkets() error", err)
-	}
-}
-
-func TestAreAPIKeysSet(t *testing.T) {
-	var errMsg string
-	if apiKey != "" && apiKey != "Key" {
-		errMsg += "Cannot commit populated testAPIKey. "
-	}
-	if apiSecret != "" && apiSecret != "Secret" {
-		errMsg += "Cannot commit populated testAPISecret. "
-	}
-	if canManipulateRealOrders {
-		errMsg += "Cannot commit with canManipulateRealOrders enabled."
-	}
-	if len(errMsg) > 0 {
-		t.Error(errMsg)
 	}
 }
 
@@ -224,7 +235,7 @@ func TestGetFee(t *testing.T) {
 
 	var feeBuilder = setFeeBuilder()
 
-	if apiKey != "" || apiSecret != "" {
+	if testAPIKey != "" || testAPISecret != "" {
 		// CryptocurrencyTradeFee Fiat
 		feeBuilder = setFeeBuilder()
 		feeBuilder.SecondCurrency = symbol.USD

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -48,6 +48,22 @@ func TestGetMarkets(t *testing.T) {
 	}
 }
 
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	if apiKey != "" && apiKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if apiSecret != "" && apiSecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
+}
+
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
 	_, err := b.GetTicker("BTC", "AUD")

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -14,8 +14,8 @@ var c CoinbasePro
 
 // Please supply your APIKeys here for better testing
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	clientID                = "" //passphrase you made at API CREATION
 	canManipulateRealOrders = false
 )
@@ -32,10 +32,40 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Error("Test Failed - coinbasepro Setup() init error")
 	}
-	gdxConfig.APIKey = apiKey
-	gdxConfig.APISecret = apiSecret
+	gdxConfig.APIKey = testAPIKey
+	gdxConfig.APISecret = testAPISecret
 	gdxConfig.AuthenticatedAPISupport = true
 	c.Setup(gdxConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if clientID != "" {
+		errMsg += "Cannot commit populated clientID. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	c.SetDefaults()
+	TestSetup(t)
+	if c.APIKey != "" && c.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if c.APISecret != "" && c.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetProducts(t *testing.T) {
@@ -240,7 +270,7 @@ func TestGetFee(t *testing.T) {
 
 	var feeBuilder = setFeeBuilder()
 
-	if apiKey != "" || apiSecret != "" {
+	if testAPIKey != "" || testAPISecret != "" {
 		// CryptocurrencyTradeFee Basic
 		if resp, err := c.GetFee(feeBuilder); resp != float64(0.003) || err != nil {
 			t.Error(err)

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -14,7 +14,7 @@ var c COINUT
 
 // Please supply your own keys here to do better tests
 const (
-	apiKey                  = ""
+	testAPIKey              = ""
 	clientID                = ""
 	canManipulateRealOrders = false
 )
@@ -31,7 +31,7 @@ func TestSetup(t *testing.T) {
 		t.Error("Test Failed - Coinut Setup() init error")
 	}
 	bConfig.AuthenticatedAPISupport = true
-	bConfig.APIKey = apiKey
+	bConfig.APIKey = testAPIKey
 	c.Setup(bConfig)
 	c.ClientID = clientID
 
@@ -40,6 +40,30 @@ func TestSetup(t *testing.T) {
 		c.Websocket.IsEnabled() || len(c.BaseCurrencies) < 1 ||
 		len(c.AvailablePairs) < 1 || len(c.EnabledPairs) < 1 {
 		t.Error("Test Failed - Coinut Setup values not set correctly")
+	}
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if clientID != "" {
+		errMsg += "Cannot commit populated clientID. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	c.SetDefaults()
+	TestSetup(t)
+	if c.APIKey != "" && c.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
 	}
 }
 
@@ -282,7 +306,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if apiKey != "" || clientID != "" {
+	if testAPIKey != "" || clientID != "" {
 		_, err := c.GetAccountInfo()
 		if err != nil {
 			t.Error("Test Failed - GetAccountInfo() error", err)

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	APIKey                  = ""
-	APISecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -24,8 +24,35 @@ func TestDefault(t *testing.T) {
 
 func TestSetup(t *testing.T) {
 	e.AuthenticatedAPISupport = true
-	e.APIKey = APIKey
-	e.APISecret = APISecret
+	e.APIKey = testAPIKey
+	e.APISecret = testAPISecret
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	e.SetDefaults()
+	TestSetup(t)
+	if e.APIKey != "" && e.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if e.APISecret != "" && e.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetTrades(t *testing.T) {
@@ -70,7 +97,7 @@ func TestGetCurrency(t *testing.T) {
 
 func TestGetUserInfo(t *testing.T) {
 	t.Parallel()
-	if APIKey == "" || APISecret == "" {
+	if testAPIKey == "" || testAPISecret == "" {
 		t.Skip()
 	}
 	TestSetup(t)
@@ -82,7 +109,7 @@ func TestGetUserInfo(t *testing.T) {
 
 func TestGetRequiredAmount(t *testing.T) {
 	t.Parallel()
-	if APIKey == "" || APISecret == "" {
+	if testAPIKey == "" || testAPISecret == "" {
 		t.Skip()
 	}
 	TestSetup(t)
@@ -94,7 +121,7 @@ func TestGetRequiredAmount(t *testing.T) {
 
 func TestGetCryptoDepositAddress(t *testing.T) {
 	t.Parallel()
-	if APIKey == "" || APISecret == "" {
+	if testAPIKey == "" || testAPISecret == "" {
 		t.Skip()
 	}
 	TestSetup(t)

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -13,13 +13,13 @@ import (
 // Please enter sandbox API keys & assigned roles for better testing procedures
 
 const (
-	apiKey1           = ""
-	apiSecret1        = ""
+	testAPIKey1       = ""
+	testAPISecret1    = ""
 	apiKeyRole1       = ""
 	sessionHeartBeat1 = false
 
-	apiKey2           = ""
-	apiSecret2        = ""
+	testAPIKey2       = ""
+	testAPISecret2    = ""
 	apiKeyRole2       = ""
 	sessionHeartBeat2 = false
 
@@ -28,16 +28,16 @@ const (
 
 func TestAddSession(t *testing.T) {
 	var g1 Gemini
-	err := AddSession(&g1, 1, apiKey1, apiSecret1, apiKeyRole1, true, false)
+	err := AddSession(&g1, 1, testAPIKey1, testAPISecret1, apiKeyRole1, true, false)
 	if err != nil {
 		t.Error("Test failed - AddSession() error")
 	}
-	err = AddSession(&g1, 1, apiKey1, apiSecret1, apiKeyRole1, true, false)
+	err = AddSession(&g1, 1, testAPIKey1, testAPISecret1, apiKeyRole1, true, false)
 	if err == nil {
 		t.Error("Test failed - AddSession() error")
 	}
 	var g2 Gemini
-	err = AddSession(&g2, 2, apiKey2, apiSecret2, apiKeyRole2, false, true)
+	err = AddSession(&g2, 2, testAPIKey2, testAPISecret2, apiKeyRole2, false, true)
 	if err != nil {
 		t.Error("Test failed - AddSession() error")
 	}
@@ -61,6 +61,30 @@ func TestSetup(t *testing.T) {
 
 	Session[1].Setup(geminiConfig)
 	Session[2].Setup(geminiConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey1 != "" && testAPIKey1 != "Key" {
+		errMsg += "Cannot commit populated testAPIKey1. "
+	}
+	if testAPISecret1 != "" && testAPISecret1 != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret1. "
+	}
+	if testAPIKey2 != "" && testAPIKey2 != "Key" {
+		errMsg += "Cannot commit populated testAPIKey2. "
+	}
+	if testAPISecret2 != "" && testAPISecret2 != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret2. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetSymbols(t *testing.T) {
@@ -100,7 +124,7 @@ func TestGetTrades(t *testing.T) {
 }
 
 func TestGetNotionalVolume(t *testing.T) {
-	if apiKey2 != "" && apiSecret2 != "" {
+	if testAPIKey2 != "" && testAPISecret2 != "" {
 		t.Parallel()
 		_, err := Session[2].GetNotionalVolume()
 		if err != nil {
@@ -238,7 +262,7 @@ func setFeeBuilder() exchange.FeeBuilder {
 func TestGetFee(t *testing.T) {
 
 	var feeBuilder = setFeeBuilder()
-	if apiKey1 != "" && apiSecret1 != "" {
+	if testAPIKey1 != "" && testAPISecret1 != "" {
 		// CryptocurrencyTradeFee Basic
 		if resp, err := Session[1].GetFee(feeBuilder); resp != float64(0.01) || err != nil {
 			t.Error(err)

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -14,8 +14,8 @@ var h HitBTC
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -32,10 +32,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	hitbtcConfig.AuthenticatedAPISupport = true
-	hitbtcConfig.APIKey = apiKey
-	hitbtcConfig.APISecret = apiSecret
+	hitbtcConfig.APIKey = testAPIKey
+	hitbtcConfig.APISecret = testAPISecret
 
 	h.Setup(hitbtcConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	h.SetDefaults()
+	TestSetup(t)
+	if h.APIKey != "" && h.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if h.APISecret != "" && h.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetOrderbook(t *testing.T) {
@@ -85,7 +112,7 @@ func TestGetFee(t *testing.T) {
 	TestSetup(t)
 
 	var feeBuilder = setFeeBuilder()
-	if apiKey != "" && apiSecret != "" {
+	if testAPIKey != "" && testAPISecret != "" {
 		// CryptocurrencyTradeFee Basic
 		if resp, err := h.GetFee(feeBuilder); resp != float64(0.001) || err != nil {
 			t.Error(err)

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -19,8 +19,8 @@ import (
 
 // Please supply you own test keys here for due diligence testing.
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -68,10 +68,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	hConfig.AuthenticatedAPISupport = true
-	hConfig.APIKey = apiKey
-	hConfig.APISecret = apiSecret
+	hConfig.APIKey = testAPIKey
+	hConfig.APISecret = testAPISecret
 
 	h.Setup(hConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	h.SetDefaults()
+	TestSetup(t)
+	if h.APIKey != "" && h.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if h.APISecret != "" && h.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetSpotKline(t *testing.T) {
@@ -487,7 +514,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if apiKey == "" || apiSecret == "" {
+	if testAPIKey == "" || testAPISecret == "" {
 		_, err := h.GetAccountInfo()
 		if err == nil {
 			t.Error("Test Failed - GetAccountInfo() error")

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -14,8 +14,8 @@ import (
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -63,10 +63,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	hadaxConfig.AuthenticatedAPISupport = true
-	hadaxConfig.APIKey = apiKey
-	hadaxConfig.APISecret = apiSecret
+	hadaxConfig.APIKey = testAPIKey
+	hadaxConfig.APISecret = testAPISecret
 
 	h.Setup(hadaxConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	h.SetDefaults()
+	TestSetup(t)
+	if h.APIKey != "" && h.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if h.APISecret != "" && h.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetSpotKline(t *testing.T) {
@@ -466,7 +493,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if apiKey == "" || apiSecret == "" {
+	if testAPIKey == "" || testAPISecret == "" {
 		_, err := h.GetAccountInfo()
 		if err == nil {
 			t.Error("Test Failed - GetAccountInfo() error")

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -14,8 +14,8 @@ var i ItBit
 
 // Please provide your own keys to do proper testing
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	clientID                = ""
 	canManipulateRealOrders = false
 )
@@ -33,11 +33,41 @@ func TestSetup(t *testing.T) {
 	}
 
 	itbitConfig.AuthenticatedAPISupport = true
-	itbitConfig.APIKey = apiKey
-	itbitConfig.APISecret = apiSecret
+	itbitConfig.APIKey = testAPIKey
+	itbitConfig.APISecret = testAPISecret
 	itbitConfig.ClientID = clientID
 
 	i.Setup(itbitConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if clientID != "" {
+		errMsg += "Cannot commit populated clientID. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	i.SetDefaults()
+	TestSetup(t)
+	if i.APIKey != "" && i.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if i.APISecret != "" && i.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetTicker(t *testing.T) {
@@ -333,7 +363,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if apiKey != "" || apiSecret != "" || clientID != "" {
+	if testAPIKey != "" || testAPISecret != "" || clientID != "" {
 		_, err := i.GetAccountInfo()
 		if err == nil {
 			t.Error("Test Failed - GetAccountInfo() error")

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -13,8 +13,8 @@ var k Kraken
 
 // Please add your own APIkeys to do correct due diligence testing.
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	clientID                = ""
 	canManipulateRealOrders = false
 )
@@ -32,11 +32,41 @@ func TestSetup(t *testing.T) {
 	}
 
 	krakenConfig.AuthenticatedAPISupport = true
-	krakenConfig.APIKey = apiKey
-	krakenConfig.APISecret = apiSecret
+	krakenConfig.APIKey = testAPIKey
+	krakenConfig.APISecret = testAPISecret
 	krakenConfig.ClientID = clientID
 
 	k.Setup(krakenConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if clientID != "" {
+		errMsg += "Cannot commit populated clientID. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	k.SetDefaults()
+	TestSetup(t)
+	if k.APIKey != "" && k.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if k.APISecret != "" && k.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetServerTime(t *testing.T) {
@@ -241,7 +271,7 @@ func TestGetFee(t *testing.T) {
 	TestSetup(t)
 	var feeBuilder = setFeeBuilder()
 
-	if apiKey != "" && apiSecret != "" {
+	if testAPIKey != "" && testAPISecret != "" {
 		// CryptocurrencyTradeFee Basic
 		if resp, err := k.GetFee(feeBuilder); resp != float64(0.0026) || err != nil {
 			t.Error(err)
@@ -419,7 +449,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if apiKey != "" || apiSecret != "" || clientID != "" {
+	if testAPIKey != "" || testAPISecret != "" || clientID != "" {
 		_, err := k.GetAccountInfo()
 		if err != nil {
 			t.Error("Test Failed - GetAccountInfo() error", err)

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -13,8 +13,8 @@ var l LakeBTC
 
 // Please add your own APIkeys to do correct due diligence testing.
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -31,10 +31,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	lakebtcConfig.AuthenticatedAPISupport = true
-	lakebtcConfig.APIKey = apiKey
-	lakebtcConfig.APISecret = apiSecret
+	lakebtcConfig.APIKey = testAPIKey
+	lakebtcConfig.APISecret = testAPISecret
 
 	l.Setup(lakebtcConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	l.SetDefaults()
+	TestSetup(t)
+	if l.APIKey != "" && l.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if l.APISecret != "" && l.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetTradablePairs(t *testing.T) {

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -13,8 +13,8 @@ import (
 var l Liqui
 
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -31,10 +31,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	liquiConfig.AuthenticatedAPISupport = true
-	liquiConfig.APIKey = apiKey
-	liquiConfig.APISecret = apiSecret
+	liquiConfig.APIKey = testAPIKey
+	liquiConfig.APISecret = testAPISecret
 
 	l.Setup(liquiConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	l.SetDefaults()
+	TestSetup(t)
+	if l.APIKey != "" && l.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if l.APISecret != "" && l.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetAvailablePairs(t *testing.T) {

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -14,8 +14,8 @@ var l LocalBitcoins
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -32,10 +32,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	localbitcoinsConfig.AuthenticatedAPISupport = true
-	localbitcoinsConfig.APIKey = apiKey
-	localbitcoinsConfig.APISecret = apiSecret
+	localbitcoinsConfig.APIKey = testAPIKey
+	localbitcoinsConfig.APISecret = testAPISecret
 
 	l.Setup(localbitcoinsConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	l.SetDefaults()
+	TestSetup(t)
+	if l.APIKey != "" && l.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if l.APISecret != "" && l.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetTicker(t *testing.T) {

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -14,8 +14,8 @@ var o OKCoin
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -32,10 +32,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	okcoinConfig.AuthenticatedAPISupport = true
-	okcoinConfig.APIKey = apiKey
-	okcoinConfig.APISecret = apiSecret
+	okcoinConfig.APIKey = testAPIKey
+	okcoinConfig.APISecret = testAPISecret
 
 	o.Setup(okcoinConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	o.SetDefaults()
+	TestSetup(t)
+	if o.APIKey != "" && o.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if o.APISecret != "" && o.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func setFeeBuilder() exchange.FeeBuilder {

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -13,8 +13,8 @@ var o OKEX
 
 // Please supply you own test keys here for due diligence testing.
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -34,10 +34,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	okexConfig.AuthenticatedAPISupport = true
-	okexConfig.APIKey = apiKey
-	okexConfig.APISecret = apiSecret
+	okexConfig.APIKey = testAPIKey
+	okexConfig.APISecret = testAPISecret
 
 	o.Setup(okexConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	o.SetDefaults()
+	TestSetup(t)
+	if o.APIKey != "" && o.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if o.APISecret != "" && o.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetSpotInstruments(t *testing.T) {
@@ -486,7 +513,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if apiKey != "" || apiSecret != "" {
+	if testAPIKey != "" || testAPISecret != "" {
 		_, err := o.GetAccountInfo()
 		if err != nil {
 			t.Error("Test Failed - GetAccountInfo() error", err)

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -14,8 +14,8 @@ var p Poloniex
 // Please supply your own APIKEYS here for due diligence testing
 
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -32,10 +32,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	poloniexConfig.AuthenticatedAPISupport = true
-	poloniexConfig.APIKey = apiKey
-	poloniexConfig.APISecret = apiSecret
+	poloniexConfig.APIKey = testAPIKey
+	poloniexConfig.APISecret = testAPISecret
 
 	p.Setup(poloniexConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	p.SetDefaults()
+	TestSetup(t)
+	if p.APIKey != "" && p.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if p.APISecret != "" && p.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetTicker(t *testing.T) {
@@ -106,7 +133,7 @@ func TestGetFee(t *testing.T) {
 	TestSetup(t)
 	var feeBuilder = setFeeBuilder()
 
-	if apiKey != "" && apiSecret != "" {
+	if testAPIKey != "" && testAPISecret != "" {
 		// CryptocurrencyTradeFee Basic
 		if resp, err := p.GetFee(feeBuilder); resp != float64(0.002) || err != nil {
 			t.Error(err)

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -13,8 +13,8 @@ var w WEX
 
 // Please supply your own keys for better unit testing
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 	isWexEncounteringIssues = true
 )
@@ -30,11 +30,38 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Error("Test Failed - WEX init error")
 	}
-	conf.APIKey = apiKey
-	conf.APISecret = apiSecret
+	conf.APIKey = testAPIKey
+	conf.APISecret = testAPISecret
 	conf.AuthenticatedAPISupport = true
 
 	w.Setup(conf)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	w.SetDefaults()
+	TestSetup(t)
+	if w.APIKey != "" && w.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if w.APISecret != "" && w.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetTradablePairs(t *testing.T) {

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -13,8 +13,8 @@ var y Yobit
 
 // Please supply your own keys for better unit testing
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -29,11 +29,38 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Error("Test Failed - Yobit init error")
 	}
-	conf.APIKey = apiKey
-	conf.APISecret = apiSecret
+	conf.APIKey = testAPIKey
+	conf.APISecret = testAPISecret
 	conf.AuthenticatedAPISupport = true
 
 	y.Setup(conf)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	y.SetDefaults()
+	TestSetup(t)
+	if y.APIKey != "" && y.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if y.APISecret != "" && y.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestGetInfo(t *testing.T) {

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please supply you own test keys here for due diligence testing.
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	testAPIKey              = ""
+	testAPISecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -32,10 +32,37 @@ func TestSetup(t *testing.T) {
 	}
 
 	zbConfig.AuthenticatedAPISupport = true
-	zbConfig.APIKey = apiKey
-	zbConfig.APISecret = apiSecret
+	zbConfig.APIKey = testAPIKey
+	zbConfig.APISecret = testAPISecret
 
 	z.Setup(zbConfig)
+}
+
+// TestAreAPIKeysSet is part of a pre-commit hook to prevent commiting your API keys
+func TestAreAPIKeysSet(t *testing.T) {
+	var errMsg string
+	// Local keys
+	if testAPIKey != "" && testAPIKey != "Key" {
+		errMsg += "Cannot commit populated testAPIKey. "
+	}
+	if testAPISecret != "" && testAPISecret != "Secret" {
+		errMsg += "Cannot commit populated testAPISecret. "
+	}
+	if canManipulateRealOrders {
+		errMsg += "Cannot commit with canManipulateRealOrders enabled."
+	}
+	//configtest.json keys
+	z.SetDefaults()
+	TestSetup(t)
+	if z.APIKey != "" && z.APIKey != "Key" {
+		errMsg += "API key present in testconfig.json"
+	}
+	if z.APISecret != "" && z.APISecret != "Key" {
+		errMsg += "API secret key present in testconfig.json"
+	}
+	if len(errMsg) > 0 {
+		t.Error(errMsg)
+	}
 }
 
 func TestSpotNewOrder(t *testing.T) {
@@ -318,7 +345,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if apiKey != "" || apiSecret != "" {
+	if testAPIKey != "" || testAPISecret != "" {
 		_, err := z.GetAccountInfo()
 		if err != nil {
 			t.Error("Test Failed - GetAccountInfo() error", err)


### PR DESCRIPTION
# Description

This change adds a pre-commit git hook to prevent the committing of API keys/customerIDs in test files/test config

The githook looks for each exchange test file committed, then runs only the test _TestAreAPIKeysSet_. If it is not found, no errors are thrown, allowing changes in other test files.

The test _TestAreAPIKeysSet_ looks at the value of the _testAPIKey_ and _testAPISecret_ key both in the file and the configtest.json file.

The readme documents how to install the githook. It is entirely optional.

Finally, it makes the naming for _testAPIKey_ and _testAPISecret_ consistent across exchange test files.

Please check to see if you find it alright to use and if the speed is acceptable

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Yes...
Here is an output in a scenario where a user changes every single test file:

> Running git hook to look for API keys
> Running test for staged file: exchanges/alphapoint/alphapoint_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/alphapoint	(cached)
> Running test for staged file: exchanges/anx/anx_test.go--- FAIL: TestAreAPIKeysSet (0.00s)
>     anx_test.go:109: API secret key present in testconfig.json
> FAIL
> FAIL	github.com/thrasher-/gocryptotrader/exchanges/anx	0.621s
> ./exchanges/anx FAILURE! Please ensure API Keys are not set and canManipulateRealOrders is not enabled
> Running test for staged file: exchanges/binance/binance_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/binance	(cached)
> Running test for staged file: exchanges/bitfinex/bitfinex_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/bitfinex	(cached)
> Running test for staged file: exchanges/bitflyer/bitflyer_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/bitflyer	(cached)
> Running test for staged file: exchanges/bithumb/bithumb_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/bithumb	(cached)
> Running test for staged file: exchanges/bitmex/bitmex_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/bitmex	(cached)
> Running test for staged file: exchanges/bitstamp/bitstamp_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/bitstamp	(cached)
> Running test for staged file: exchanges/bittrex/bittrex_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/bittrex	(cached)
> Running test for staged file: exchanges/btcc/btcc_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/btcc	(cached)
> Running test for staged file: exchanges/btcmarkets/btcmarkets_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/btcmarkets	(cached)
> Running test for staged file: exchanges/coinbasepro/coinbasepro_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/coinbasepro	(cached)
> Running test for staged file: exchanges/coinut/coinut_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/coinut	(cached)
> Running test for staged file: exchanges/exmo/exmo_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/exmo	(cached)
> Running test for staged file: exchanges/gemini/gemini_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/gemini	(cached)
> Running test for staged file: exchanges/hitbtc/hitbtc_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/hitbtc	(cached)
> Running test for staged file: exchanges/huobi/huobi_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/huobi	(cached)
> Running test for staged file: exchanges/huobihadax/huobihadax_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/huobihadax	(cached)
> Running test for staged file: exchanges/itbit/itbit_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/itbit	(cached)
> Running test for staged file: exchanges/kraken/kraken_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/kraken	(cached)
> Running test for staged file: exchanges/lakebtc/lakebtc_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/lakebtc	(cached)
> Running test for staged file: exchanges/liqui/liqui_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/liqui	(cached)
> Running test for staged file: exchanges/localbitcoins/localbitcoins_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/localbitcoins	(cached)
> Running test for staged file: exchanges/okcoin/okcoin_test.go--- FAIL: TestAreAPIKeysSet (0.00s)
>     okcoin_test.go:64: Cannot commit populated testAPISecret. API secret key present in testconfig.json
> FAIL
> FAIL	github.com/thrasher-/gocryptotrader/exchanges/okcoin	0.576s
> ./exchanges/okcoin FAILURE! Please ensure API Keys are not set and canManipulateRealOrders is not enabled
> Running test for staged file: exchanges/okex/okex_test.go--- FAIL: TestAreAPIKeysSet (0.00s)
>     okex_test.go:66: Cannot commit with canManipulateRealOrders enabled.
> FAIL
> FAIL	github.com/thrasher-/gocryptotrader/exchanges/okex	0.693s
> ./exchanges/okex FAILURE! Please ensure API Keys are not set and canManipulateRealOrders is not enabled
> Running test for staged file: exchanges/poloniex/poloniex_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/poloniex	(cached)
> Running test for staged file: exchanges/wex/wex_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/wex	(cached)
> Running test for staged file: exchanges/yobit/yobit_test.gook  	github.com/thrasher-/gocryptotrader/exchanges/yobit	0.692s
> Running test for staged file: exchanges/zb/zb_test.go--- FAIL: TestAreAPIKeysSet (0.00s)
>     zb_test.go:64: Cannot commit populated testAPIKey. API key present in testconfig.json
> FAIL
> FAIL	github.com/thrasher-/gocryptotrader/exchanges/zb	1.068s
> ./exchanges/zb FAILURE! Please ensure API Keys are not set and canManipulateRealOrders is not enabled
> COMMIT FAILED
> git did not exit cleanly (exit code 1) (35844 ms @ 18/12/2018 2:43:51 PM)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules