### PR TITLE
Withdraw Crypto wrapper mapping

### DIFF
--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -612,7 +612,7 @@ func TestWithdraw(t *testing.T) {
 	}
 
 	_, err := a.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if err != common.ErrFunctionNotSupported {
-		t.Errorf("Expected 'Not supported', recieved %v", err)
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not implemented', recieved %v", err)
 	}
 }

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -495,21 +495,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 
-func isRealOrderTestEnabled(a *Alphapoint) bool {
-	if a.APIKey == "" || a.APISecret == "" ||
-		a.APIKey == "Key" || a.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+func isAuthenticatedRequest(a *Alphapoint) bool {
+	if (a.APIKey != "" && a.APIKey != "Key" &&
+		a.APISecret != "" && a.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest(a *Alphapoint) bool {
+	if (a.APIKey != "" && a.APIKey != "Key" &&
+		a.APISecret != "" && a.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
 
-	if !isRealOrderTestEnabled(a) {
-		t.Skip()
+	if skipRealOrderTest(a) {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "_",
@@ -517,8 +526,15 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := a.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
-		t.Errorf("Order failed to be placed: %v", err)
+	if !isAuthenticatedRequest(a) && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest(a) && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
+
+		if !response.IsOrderPlaced {
+			t.Errorf("Order failed to be placed: %v", err)
+		}
 	}
 }
 
@@ -527,8 +543,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
 
-	if !isRealOrderTestEnabled(a) {
-		t.Skip()
+	if skipRealOrderTest(a) {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.BTC, symbol.LTC)
@@ -543,8 +559,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := a.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Test Failed - ANX CancelOrder() error: %s", err)
+	if !isAuthenticatedRequest(a) && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest(a) && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }
 
@@ -553,8 +572,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
 
-	if !isRealOrderTestEnabled(a) {
-		t.Skip()
+	if skipRealOrderTest(a) {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.BTC, symbol.LTC)
@@ -569,8 +588,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := a.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest(a) && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest(a) && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {
@@ -585,5 +607,26 @@ func TestModifyOrder(t *testing.T) {
 	_, err := a.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	a := &Alphapoint{}
+	a.SetDefaults()
+	a.Verbose = true
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:                   100,
+		Currency:                 symbol.BTC,
+		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:              "WITHDRAW IT ALL",
+		AddressTag:               "0123456789",
+	}
+
+	_, err := a.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !isAuthenticatedRequest(a) && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest(a) && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -495,19 +495,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 
-func isAuthenticatedRequest(a *Alphapoint) bool {
-	if (a.APIKey != "" && a.APIKey != "Key" &&
-		a.APISecret != "" && a.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest(a *Alphapoint) bool {
-	if (a.APIKey != "" && a.APIKey != "Key" &&
-		a.APISecret != "" && a.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet(a *Alphapoint) bool {
+	if a.APIKey != "" && a.APIKey != "Key" &&
+		a.APISecret != "" && a.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -517,7 +507,7 @@ func TestSubmitOrder(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
 
-	if skipRealOrderTest(a) {
+	if areTestAPIKeysSet(a) && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 	var p = pair.CurrencyPair{
@@ -526,10 +516,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := a.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if !isAuthenticatedRequest(a) && err == nil {
+	if !areTestAPIKeysSet(a) && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest(a) && err != nil {
+	if areTestAPIKeysSet(a) && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 
 		if !response.IsOrderPlaced {
@@ -543,7 +533,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
 
-	if skipRealOrderTest(a) {
+	if areTestAPIKeysSet(a) && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -559,10 +549,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := a.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest(a) && err == nil {
+	if !areTestAPIKeysSet(a) && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest(a) && err != nil {
+	if areTestAPIKeysSet(a) && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }
@@ -572,7 +562,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
 
-	if skipRealOrderTest(a) {
+	if areTestAPIKeysSet(a) && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -588,10 +578,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := a.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest(a) && err == nil {
+	if !areTestAPIKeysSet(a) && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest(a) && err != nil {
+	if areTestAPIKeysSet(a) && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 
@@ -614,18 +604,18 @@ func TestWithdraw(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.BTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
-		AddressTag:               "0123456789",
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+		AddressTag:  "0123456789",
 	}
 
 	_, err := a.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest(a) && err == nil {
+	if !areTestAPIKeysSet(a) && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest(a) && err != nil {
+	if areTestAPIKeysSet(a) && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -612,10 +612,7 @@ func TestWithdraw(t *testing.T) {
 	}
 
 	_, err := a.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !areTestAPIKeysSet(a) && err == nil {
-		t.Errorf("Expecting an error when no keys are set: %v", err)
-	}
-	if areTestAPIKeysSet(a) && err != nil {
-		t.Errorf("Withdraw failed to be placed: %v", err)
+	if err != common.ErrFunctionNotSupported {
+		t.Errorf("Expected 'Not supported', recieved %v", err)
 	}
 }

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -613,7 +613,6 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
-	a.Verbose = true
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
 		Amount:                   100,
 		Currency:                 symbol.BTC,

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -181,7 +181,6 @@ func (a *Alphapoint) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *Alphapoint) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -181,18 +181,19 @@ func (a *Alphapoint) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *Alphapoint) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrFunctionNotSupported
+
+	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is submitted
 func (a *Alphapoint) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrFunctionNotSupported
+	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *Alphapoint) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrFunctionNotSupported
+	return "", common.ErrNotYetImplemented
 }
 
 // GetWebsocket returns a pointer to the exchange websocket

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -181,12 +181,18 @@ func (a *Alphapoint) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *Alphapoint) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is submitted
 func (a *Alphapoint) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
+}
+
+// WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a withdrawal is
+// submitted
+func (a *Alphapoint) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
+	return "", common.ErrFunctionNotSupported
 }
 
 // GetWebsocket returns a pointer to the exchange websocket

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -180,12 +180,12 @@ func (a *Alphapoint) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (a *Alphapoint) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (a *Alphapoint) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is submitted
-func (a *Alphapoint) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (a *Alphapoint) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -262,8 +262,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := a.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -288,8 +290,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := a.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Test Failed - ANX CancelOrder() error: %s", err)
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel order: %s", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
 }
 
@@ -349,7 +353,6 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	a.SetDefaults()
 	TestSetup(t)
-	a.Verbose = true
 
 	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -231,19 +231,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 
-func isAuthenticatedRequest() bool {
-	if (a.APIKey != "" && a.APIKey != "Key" &&
-		a.APISecret != "" && a.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (a.APIKey != "" && a.APIKey != "Key" &&
-		a.APISecret != "" && a.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if a.APIKey != "" && a.APIKey != "Key" &&
+		a.APISecret != "" && a.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -253,7 +243,7 @@ func TestSubmitOrder(t *testing.T) {
 	a.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 	var p = pair.CurrencyPair{
@@ -262,9 +252,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := a.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -274,7 +264,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	a.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -290,9 +280,9 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := a.CancelOrder(orderCancellation)
 
 	// Assert
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel order: %s", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
 }
@@ -302,7 +292,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	a.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -318,9 +308,9 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := a.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel order: %s", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
 
@@ -354,22 +344,22 @@ func TestWithdraw(t *testing.T) {
 	a.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.BTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
-		AddressTag:               "0123456789",
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+		AddressTag:  "0123456789",
 	}
 
 	_, err := a.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 	fmt.Printf(err.Error())

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -1,7 +1,6 @@
 package anx
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/thrasher-/gocryptotrader/config"
@@ -362,5 +361,4 @@ func TestWithdraw(t *testing.T) {
 	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
-	fmt.Printf(err.Error())
 }

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -312,7 +312,7 @@ func (a *ANX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *ANX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return a.Send(withdrawRequest.Currency.String(), withdrawRequest.DestinationWalletAddress, "", fmt.Sprintf("%v", withdrawRequest.Amount))
+	return a.Send(withdrawRequest.Currency.String(), withdrawRequest.Address, "", fmt.Sprintf("%v", withdrawRequest.Amount))
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -312,7 +312,7 @@ func (a *ANX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *ANX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return a.Send(cryptocurrency.String(), address, "", fmt.Sprintf("%v", amount))
+	return a.Send(withdrawRequest.Currency.String(), withdrawRequest.DestinationWalletAddress, "", fmt.Sprintf("%v", withdrawRequest.Amount))
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -1,6 +1,7 @@
 package anx
 
 import (
+	"fmt"
 	"log"
 	"strconv"
 	"sync"
@@ -311,18 +312,20 @@ func (a *ANX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *ANX) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return a.Send(cryptocurrency.String(), address, "", fmt.Sprintf("%v", amount))
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *ANX) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+	// Fiat withdawals available via website
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *ANX) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+	// Fiat withdawals available via website
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -311,20 +311,20 @@ func (a *ANX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (a *ANX) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (a *ANX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return a.Send(cryptocurrency.String(), address, "", fmt.Sprintf("%v", amount))
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (a *ANX) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (a *ANX) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	// Fiat withdawals available via website
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a withdrawal is
 // submitted
-func (a *ANX) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (a *ANX) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	// Fiat withdawals available via website
 	return "", common.ErrNotYetImplemented
 }

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -318,14 +318,14 @@ func (a *ANX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawReque
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *ANX) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	// Fiat withdawals available via website
+	// Fiat withdrawals available via website
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a withdrawal is
 // submitted
 func (a *ANX) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	// Fiat withdawals available via website
+	// Fiat withdrawals available via website
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -740,3 +740,18 @@ func (b *Binance) WithdrawCrypto(asset, address, addressTag, name, amount string
 
 	return resp.ID, nil
 }
+
+
+//GetDepositAddressForCurrency retrieves the wallet address for a given currency
+func (b *Binance) GetDepositAddressForCurrency(currency string) error {
+	path := fmt.Sprintf("%s%s", b.APIUrl, depositAddress)
+	var resp interface{}
+	params := url.Values{}
+	params.Set("asset", currency)
+
+	if err := b.SendAuthHTTPRequest("GET", path, params, &resp); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -51,6 +51,17 @@ const (
 	openOrders   = "/api/v3/openOrders"
 	allOrders    = "/api/v3/allOrders"
 
+	// Withdraw API endpoints
+	withdraw          = "/wapi/v3/withdraw.html"
+	depositHistory    = "/wapi/v3/depositHistory.html"
+	withdrawalHistory = "/wapi/v3/withdrawHistory.html"
+	depositAddress    = "/wapi/v3/depositAddress.html"
+	accountStatus     = "/wapi/v3/accountStatus.html"
+	systemStatus      = "/wapi/v3/systemStatus.html"
+	dustLog           = "/wapi/v3/userAssetDribbletLog.html"
+	tradeFee          = "/wapi/v3/tradeFee.html"
+	assetDetail       = "/wapi/v3/assetDetail.html"
+
 	// binance authenticated and unauthenticated limit rates
 	// to-do
 	binanceAuthRate   = 0
@@ -701,4 +712,31 @@ func calculateTradingFee(purchasePrice, amount, multiplier float64) float64 {
 // getCryptocurrencyWithdrawalFee returns the fee for withdrawing from the exchange
 func getCryptocurrencyWithdrawalFee(currency string, purchasePrice, amount float64) float64 {
 	return WithdrawalFees[currency]
+}
+
+// WithdrawCrypto sends cryptocurrency to the address of your choosing
+func (b *Binance) WithdrawCrypto(asset, address, addressTag, name, amount string) (int64, error) {
+	var resp WithdrawResponse
+	path := fmt.Sprintf("%s%s", b.APIUrl, withdraw)
+
+	params := url.Values{}
+	params.Set("asset", asset)
+	params.Set("address", string(address))
+	params.Set("amount", string(amount))
+	if len(name) > 0 {
+		params.Set("name", string(name))
+	}
+	if len(addressTag) > 0 {
+		params.Set("addressTag", string(addressTag))
+	}
+
+	if err := b.SendAuthHTTPRequest("POST", path, params, &resp); err != nil {
+		return -1, err
+	}
+
+	if !resp.Success {
+		return resp.ID, errors.New(resp.Msg)
+	}
+
+	return resp.ID, nil
 }

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -334,19 +334,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // -----------------------------------------------------------------------------------------------------------------------------
 
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -362,9 +352,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.BTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -387,10 +377,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -413,10 +403,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel order: %v", err)
 	}
 
@@ -449,22 +439,22 @@ func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.BTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -437,3 +437,18 @@ func TestModifyOrder(t *testing.T) {
 		t.Error("Test failed - ModifyOrder() error")
 	}
 }
+
+func TestWithdraw(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+	b.Verbose = true
+
+	if !isRealOrderTestEnabled() {
+		t.Skip()
+	}
+
+	response, err := b.WithdrawCryptocurrencyFunds("1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB", pair.CurrencyItem(symbol.BTC), 100)
+	if err != nil || len(response) <= 2 {
+		t.Errorf("Withdraw failed to be placed: %v", err)
+	}
+}

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -362,8 +362,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.BTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -385,8 +387,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -423,7 +428,6 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 func TestGetAccountInfo(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	if testAPIKey == "" || testAPISecret == "" {
 		t.Skip()
 	}

--- a/exchanges/binance/binance_types.go
+++ b/exchanges/binance/binance_types.go
@@ -616,3 +616,10 @@ var WithdrawalFees = map[string]float64{
 	symbol.APPC:    12.4,
 	symbol.PIVX:    0.02,
 }
+
+// WithdrawResponse contains status of withdrawal request
+type WithdrawResponse struct {
+	Success bool   `json:"success"`
+	Msg     string `json:"msg"`
+	ID      int64  `json:"id"`
+}

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -271,8 +271,8 @@ func (b *Binance) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Binance) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	amountStr := strconv.FormatFloat(amount, 'f', -1, 64)
-	id, err := b.WithdrawCrypto(cryptocurrency.String(), address, "", "", amountStr)
+	amountStr := strconv.FormatFloat(withdrawRequest.Amount, 'f', -1, 64)
+	id, err := b.WithdrawCrypto(withdrawRequest.Currency.String(), withdrawRequest.DestinationWalletAddress, withdrawRequest.AddressTag, withdrawRequest.Description, amountStr)
 
 	return strconv.FormatInt(id, 10), err
 }

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -271,7 +271,10 @@ func (b *Binance) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Binance) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
-	return "", common.ErrNotYetImplemented
+	amountStr := strconv.FormatFloat(amount, 'f', -1, 64)
+	id, err := b.WithdrawCrypto(cryptocurrency.String(), address, "", "", amountStr)
+
+	return strconv.FormatInt(id, 10), err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -272,7 +272,7 @@ func (b *Binance) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 // submitted
 func (b *Binance) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	amountStr := strconv.FormatFloat(withdrawRequest.Amount, 'f', -1, 64)
-	id, err := b.WithdrawCrypto(withdrawRequest.Currency.String(), withdrawRequest.DestinationWalletAddress, withdrawRequest.AddressTag, withdrawRequest.Description, amountStr)
+	id, err := b.WithdrawCrypto(withdrawRequest.Currency.String(), withdrawRequest.Address, withdrawRequest.AddressTag, withdrawRequest.Description, amountStr)
 
 	return strconv.FormatInt(id, 10), err
 }

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -270,7 +270,7 @@ func (b *Binance) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *Binance) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Binance) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	amountStr := strconv.FormatFloat(amount, 'f', -1, 64)
 	id, err := b.WithdrawCrypto(cryptocurrency.String(), address, "", "", amountStr)
 
@@ -279,13 +279,13 @@ func (b *Binance) WithdrawCryptocurrencyFunds(address string, cryptocurrency pai
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Binance) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Binance) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Binance) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Binance) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 	"github.com/thrasher-/gocryptotrader/exchanges/request"
 	"github.com/thrasher-/gocryptotrader/exchanges/ticker"
@@ -582,15 +583,18 @@ func (b *Bitfinex) WalletTransfer(amount float64, currency, walletFrom, walletTo
 		b.SendAuthenticatedHTTPRequest("POST", bitfinexTransfer, request, &response)
 }
 
-// Withdrawal requests a withdrawal from one of your wallets.
-// Major Upgrade needed on this function to include all query params
-func (b *Bitfinex) Withdrawal(withdrawType, wallet, address string, amount float64) ([]Withdrawal, error) {
+// WithdrawCryptocurrency requests a withdrawal from one of your wallets.
+// For FIAT, use WithdrawFIAT
+func (b *Bitfinex) WithdrawCryptocurrency(withdrawType, wallet, address, currency, paymentID string, amount float64) ([]Withdrawal, error) {
 	response := []Withdrawal{}
 	request := make(map[string]interface{})
 	request["withdrawal_type"] = withdrawType
 	request["walletselected"] = wallet
 	request["amount"] = strconv.FormatFloat(amount, 'f', -1, 64)
 	request["address"] = address
+	if currency == symbol.XMR {
+		request["paymend_id"] = paymentID
+	}
 
 	return response,
 		b.SendAuthenticatedHTTPRequest("POST", bitfinexWithdrawal, request, &response)
@@ -998,4 +1002,52 @@ func (b *Bitfinex) CalculateTradingFee(accountInfos []AccountInfo, purchasePrice
 		}
 	}
 	return (fee / 100) * purchasePrice * amount, err
+}
+
+// ConvertSymbolToWithdrawalType You need to have specific withdrawal types to withdraw from Bitfinex
+func (b *Bitfinex) ConvertSymbolToWithdrawalType(currency string) string {
+	switch currency {
+	case symbol.BTC:
+		return "bitcoin"
+	case symbol.LTC:
+		return "litecoin"
+	case symbol.ETH:
+		return "ethereum"
+	case symbol.ETC:
+		return "ethereumc"
+	case symbol.USDT:
+		return "tetheruso"
+	case "Wire":
+		return "wire"
+	case symbol.ZEC:
+		return "zcash"
+	case symbol.XMR:
+		return "monero"
+	case symbol.DSH:
+		return "dash"
+	case symbol.XRP:
+		return "ripple"
+	case symbol.SAN:
+		return "santiment"
+	case symbol.OMG:
+		return "omisego"
+	case symbol.BCH:
+		return "bcash"
+	case symbol.ETP:
+		return "metaverse"
+	case symbol.AVT:
+		return "aventus"
+	case symbol.EDO:
+		return "eidoo"
+	case symbol.BTG:
+		return "bgold"
+	case symbol.DATA:
+		return "datacoin"
+	case symbol.GNT:
+		return "golem"
+	case symbol.SNT:
+		return "status"
+	default:
+		return common.StringToLower(currency)
+	}
 }

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -588,7 +588,7 @@ func (b *Bitfinex) WalletTransfer(amount float64, currency, walletFrom, walletTo
 func (b *Bitfinex) WithdrawCryptocurrency(withdrawType, wallet, address, currency, paymentID string, amount float64) ([]Withdrawal, error) {
 	response := []Withdrawal{}
 	request := make(map[string]interface{})
-	request["withdrawal_type"] = withdrawType
+	request["withdraw_type"] = withdrawType
 	request["walletselected"] = wallet
 	request["amount"] = strconv.FormatFloat(amount, 'f', -1, 64)
 	request["address"] = address

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -741,8 +741,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.BTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -768,8 +770,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -795,8 +800,11 @@ func TestCancelAllExchangeOrdera(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {
@@ -814,7 +822,6 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -336,18 +336,6 @@ func TestWalletTransfer(t *testing.T) {
 	}
 }
 
-func TestWithdrawal(t *testing.T) {
-	if b.APIKey == "" || b.APISecret == "" {
-		t.SkipNow()
-	}
-	t.Parallel()
-
-	_, err := b.Withdrawal("LITECOIN", "deposit", "1000", 0.01)
-	if err == nil {
-		t.Error("Test Failed - Withdrawal() error")
-	}
-}
-
 func TestNewOrder(t *testing.T) {
 	if b.APIKey == "" || b.APISecret == "" {
 		t.SkipNow()

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -710,19 +710,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -732,7 +722,7 @@ func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 	var p = pair.CurrencyPair{
@@ -741,9 +731,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.BTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -753,7 +743,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -770,10 +760,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -783,7 +773,7 @@ func TestCancelAllExchangeOrdera(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -800,10 +790,10 @@ func TestCancelAllExchangeOrdera(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -822,22 +812,22 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.BTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -710,21 +710,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+func isAuthenticatedRequest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
@@ -742,8 +751,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -769,8 +778,8 @@ func TestCancelAllExchangeOrdera(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -799,5 +808,29 @@ func TestModifyOrder(t *testing.T) {
 	_, err := b.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+	b.Verbose = true
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:                   100,
+		Currency:                 symbol.BTC,
+		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:              "WITHDRAW IT ALL",
+	}
+
+	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -240,7 +240,7 @@ func (b *Bitfinex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.Withdraw
 	// As this is for trading, I've made the wrapper default 'exchange'
 	// TODO: Discover an automated way to make the decision for wallet type to withdraw from
 	walletType := "exchange"
-	resp, err := b.WithdrawCryptocurrency(withdrawalType, walletType, withdrawRequest.DestinationWalletAddress, withdrawRequest.Currency.String(), withdrawRequest.Description, withdrawRequest.Amount)
+	resp, err := b.WithdrawCryptocurrency(withdrawalType, walletType, withdrawRequest.Address, withdrawRequest.Currency.String(), withdrawRequest.Description, withdrawRequest.Amount)
 	if err != nil {
 		return "", err
 	}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -233,19 +233,21 @@ func (b *Bitfinex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, 
 }
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is submitted
-func (b *Bitfinex) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitfinex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
+	//withdrawalType := b.ConvertSymbolToWithdrawalType(fmt.Sprintf("%v", withdrawRequest.Currency))
+	//resp, err := b.WithdrawCryptocurrency(withdrawalType)
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bitfinex) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitfinex) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bitfinex) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitfinex) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -251,19 +251,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -273,7 +263,7 @@ func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -293,7 +283,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -318,7 +308,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -342,13 +332,13 @@ func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.BTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	"github.com/thrasher-/gocryptotrader/exchanges"
 
@@ -250,30 +251,40 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+func isAuthenticatedRequest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
+
 	var p = pair.CurrencyPair{
 		Delimiter:      "",
 		FirstCurrency:  symbol.LTC,
 		SecondCurrency: symbol.BTC,
 	}
-	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
-		t.Errorf("Order failed to be placed: %v", err)
+	_, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
 	}
 }
 
@@ -282,12 +293,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
 		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
@@ -297,10 +307,9 @@ func TestCancelExchangeOrder(t *testing.T) {
 
 	// Act
 	err := b.CancelOrder(orderCancellation)
-
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
 	}
 }
 
@@ -309,12 +318,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
-
 	var orderCancellation = exchange.OrderCancellation{
 		OrderID:       "1",
 		WalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
@@ -323,15 +331,31 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	}
 
 	// Act
-	resp, err := b.CancelAllOrders(orderCancellation)
-
+	_, err := b.CancelAllOrders(orderCancellation)
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+	b.Verbose = true
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:                   100,
+		Currency:                 symbol.BTC,
+		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:              "WITHDRAW IT ALL",
 	}
 
-	if len(resp.OrderStatus) > 0 {
-		t.Errorf("%v orders failed to cancel", len(resp.OrderStatus))
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
 	}
 }
 

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -341,7 +341,6 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
 		Amount:                   100,
 		Currency:                 symbol.BTC,

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -190,19 +190,19 @@ func (b *Bitflyer) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, 
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *Bitflyer) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitflyer) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bitflyer) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitflyer) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bitflyer) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitflyer) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -447,7 +447,9 @@ func (b *Bithumb) WithdrawCrypto(address, destination, currency string, units fl
 
 	params := url.Values{}
 	params.Set("address", address)
-	params.Set("destination", destination)
+	if len(destination) > 0 {
+		params.Set("destination", destination)
+	}
 	params.Set("currency", common.StringToUpper(currency))
 	params.Set("units", strconv.FormatFloat(units, 'f', -1, 64))
 

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -289,19 +289,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -311,7 +301,7 @@ func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -321,9 +311,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -333,7 +323,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -350,10 +340,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel order: %v", err)
 	}
 }
@@ -363,7 +353,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -380,10 +370,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel order: %v", err)
 	}
 
@@ -422,22 +412,22 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.BTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -321,8 +321,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -420,7 +422,6 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -251,7 +251,7 @@ func (b *Bithumb) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Bithumb) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	_, err := b.WithdrawCrypto(withdrawRequest.OriginWalletAddress, withdrawRequest.DestinationWalletAddress, withdrawRequest.Currency.String(), withdrawRequest.Amount)
+	_, err := b.WithdrawCrypto(withdrawRequest.Address, withdrawRequest.AddressTag, withdrawRequest.Currency.String(), withdrawRequest.Amount)
 	return "", err
 }
 

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -251,7 +251,8 @@ func (b *Bithumb) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Bithumb) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	_, err := b.WithdrawCrypto(withdrawRequest.OriginWalletAddress, withdrawRequest.DestinationWalletAddress, withdrawRequest.Currency.String(), withdrawRequest.Amount)
+	return "", err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -250,19 +250,19 @@ func (b *Bithumb) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *Bithumb) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bithumb) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bithumb) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bithumb) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bithumb) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bithumb) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/bitmex/bitmex_parameters.go
+++ b/exchanges/bitmex/bitmex_parameters.go
@@ -1089,7 +1089,7 @@ type UserRequestWithdrawalParams struct {
 	Address string `json:"address,omitempty"`
 
 	// Amount - Amount of withdrawal currency.
-	Amount int64 `json:"amount,omitempty"`
+	Amount float64 `json:"amount,omitempty"`
 
 	// Currency - Currency you're withdrawing. Options: `XBt`
 	Currency string `json:"currency,omitempty"`
@@ -1100,7 +1100,7 @@ type UserRequestWithdrawalParams struct {
 	Fee float64 `json:"fee,omitempty"`
 
 	// OtpToken - 2FA token. Required if 2FA is enabled on your account.
-	OtpToken string `json:"otpToken,omitempty"`
+	OtpToken int64 `json:"otpToken,omitempty"`
 }
 
 // VerifyData verifies outgoing data sets

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -467,19 +467,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -489,7 +479,7 @@ func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -499,9 +489,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -511,7 +501,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -528,10 +518,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -541,7 +531,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -558,10 +548,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -595,22 +585,22 @@ func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 "XBt",
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
-		OneTimePassword:          000000,
+		Amount:          100,
+		Currency:        "XBt",
+		Address:         "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:     "WITHDRAW IT ALL",
+		OneTimePassword: 000000,
 	}
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -499,8 +499,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -526,8 +528,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -553,8 +558,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {
@@ -586,7 +594,6 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
 		Amount:                   100,
 		Currency:                 "XBt",

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -258,7 +258,7 @@ func (b *Bitmex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 // submitted
 func (b *Bitmex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	var request = UserRequestWithdrawalParams{
-		Address:  withdrawRequest.DestinationWalletAddress,
+		Address:  withdrawRequest.Address,
 		Amount:   withdrawRequest.Amount,
 		Currency: withdrawRequest.Currency.String(),
 		OtpToken: withdrawRequest.OneTimePassword,

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -257,7 +257,22 @@ func (b *Bitmex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Bitmex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	var request = UserRequestWithdrawalParams{
+		Address:  withdrawRequest.DestinationWalletAddress,
+		Amount:   withdrawRequest.Amount,
+		Currency: withdrawRequest.Currency.String(),
+		OtpToken: withdrawRequest.OneTimePassword,
+	}
+	if withdrawRequest.FeeAmount > 0 {
+		request.Fee = withdrawRequest.FeeAmount
+	}
+
+	resp, err := b.UserRequestWithdrawal(request)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.TransactID, nil
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -281,9 +281,9 @@ func (b *Bitmex) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (st
 	return "", common.ErrNotYetImplemented
 }
 
-// WithdrawExchangeFiatFundsToInternationalBank returns a withdrawal ID when a withdrawal is
+// WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *Bitmex) WithdrawExchangeFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitmex) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -256,13 +256,13 @@ func (b *Bitmex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *Bitmex) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitmex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *Bitmex) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitmex) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -483,15 +483,12 @@ func (b *Bitstamp) GetWithdrawalRequests(timedelta int64) ([]WithdrawalRequests,
 // symbol - the type of crypto ie "ltc", "btc", "eth"
 // destTag - only for XRP  default to ""
 // instant - only for bitcoins
-func (b *Bitstamp) CryptoWithdrawal(amount float64, address, symbol, destTag string, instant bool) (string, error) {
+func (b *Bitstamp) CryptoWithdrawal(amount float64, address, symbol, destTag string, instant bool) (CryptoWithdrawalResponse, error) {
 	var req = url.Values{}
 	req.Add("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 	req.Add("address", address)
-
-	type response struct {
-		ID string `json:"id"`
-	}
-	resp := response{}
+	resp := CryptoWithdrawalResponse{}
+	var endpoint string
 
 	switch common.StringToLower(symbol) {
 	case "btc":
@@ -500,23 +497,21 @@ func (b *Bitstamp) CryptoWithdrawal(amount float64, address, symbol, destTag str
 		} else {
 			req.Add("instant", "0")
 		}
-		return resp.ID,
-			b.SendAuthenticatedHTTPRequest(bitstampAPIBitcoinWithdrawal, false, req, &resp)
+		endpoint = bitstampAPIBitcoinWithdrawal
 	case "ltc":
-		return resp.ID,
-			b.SendAuthenticatedHTTPRequest(bitstampAPILTCWithdrawal, true, req, &resp)
+		endpoint = bitstampAPILTCWithdrawal
 	case "eth":
-		return resp.ID,
-			b.SendAuthenticatedHTTPRequest(bitstampAPIETHWithdrawal, true, req, &resp)
+		endpoint = bitstampAPIETHWithdrawal
 	case "xrp":
 		if destTag != "" {
 			req.Add("destination_tag", destTag)
 		}
-		return resp.ID,
-			b.SendAuthenticatedHTTPRequest(bitstampAPIXrpWithdrawal, true, req, &resp)
+		endpoint = bitstampAPIXrpWithdrawal
+	default:
+		return resp, errors.New("incorrect symbol")
 	}
-	return resp.ID,
-		errors.New("incorrect symbol")
+
+	return resp, b.SendAuthenticatedHTTPRequest(endpoint, false, req, &resp)
 }
 
 // GetCryptoDepositAddress returns a depositing address by crypto

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -370,19 +370,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -392,7 +382,7 @@ func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -402,9 +392,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -414,7 +404,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -431,10 +421,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -444,7 +434,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -461,10 +451,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -484,21 +474,21 @@ func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.BTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -402,8 +402,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -429,8 +431,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -456,8 +461,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {
@@ -475,7 +483,6 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
 		Amount:                   100,
 		Currency:                 symbol.BTC,

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -370,21 +370,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+func isAuthenticatedRequest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -403,8 +412,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -430,8 +439,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -460,5 +469,29 @@ func TestModifyOrder(t *testing.T) {
 	_, err := b.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+	b.Verbose = true
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:                   100,
+		Currency:                 symbol.BTC,
+		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:              "WITHDRAW IT ALL",
+	}
+
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/bitstamp/bitstamp_types.go
+++ b/exchanges/bitstamp/bitstamp_types.go
@@ -122,6 +122,11 @@ type WithdrawalRequests struct {
 	TransactionID string `json:"transaction_id"` // Bitcoin withdrawals only
 }
 
+type CryptoWithdrawalResponse struct {
+	ID    string `json:"id"`
+	Error string `json:"error"`
+}
+
 // UnconfirmedBTCTransactions holds address information about unconfirmed
 // transactions
 type UnconfirmedBTCTransactions struct {

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -226,7 +226,7 @@ func (b *Bitstamp) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Bitstamp) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return b.CryptoWithdrawal(withdrawRequest.Amount, withdrawRequest.DestinationWalletAddress, withdrawRequest.Currency.String(), withdrawRequest.AddressTag, true)
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -225,19 +225,19 @@ func (b *Bitstamp) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, 
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *Bitstamp) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitstamp) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bitstamp) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitstamp) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bitstamp) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bitstamp) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -226,7 +226,7 @@ func (b *Bitstamp) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Bitstamp) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	resp, err := b.CryptoWithdrawal(withdrawRequest.Amount, withdrawRequest.DestinationWalletAddress, withdrawRequest.Currency.String(), withdrawRequest.AddressTag, true)
+	resp, err := b.CryptoWithdrawal(withdrawRequest.Amount, withdrawRequest.Address, withdrawRequest.Currency.String(), withdrawRequest.AddressTag, true)
 	if err != nil {
 		return "", err
 	}

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -226,7 +226,15 @@ func (b *Bitstamp) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Bitstamp) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return b.CryptoWithdrawal(withdrawRequest.Amount, withdrawRequest.DestinationWalletAddress, withdrawRequest.Currency.String(), withdrawRequest.AddressTag, true)
+	resp, err := b.CryptoWithdrawal(withdrawRequest.Amount, withdrawRequest.DestinationWalletAddress, withdrawRequest.Currency.String(), withdrawRequest.AddressTag, true)
+	if err != nil {
+		return "", err
+	}
+	if resp.Error != "" {
+		return "", errors.New(resp.Error)
+	}
+
+	return resp.ID, nil
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -390,7 +390,7 @@ func (b *Bittrex) Withdraw(currency, paymentID, address string, quantity float64
 	var id UUID
 	values := url.Values{}
 	values.Set("currency", currency)
-	values.Set("quantity", strconv.FormatFloat(quantity, 'E', -1, 64))
+	values.Set("quantity", fmt.Sprintf("%v", quantity))
 	values.Set("address", address)
 	path := fmt.Sprintf("%s/%s", b.APIUrl, bittrexAPIWithdraw)
 

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -176,15 +176,6 @@ func TestGetDepositAddress(t *testing.T) {
 	}
 }
 
-func TestWithdraw(t *testing.T) {
-	t.Parallel()
-
-	_, err := b.Withdraw("btc", "something", "someplace", 1)
-	if err == nil {
-		t.Error("Test Failed - Bittrex - Withdraw() error")
-	}
-}
-
 func TestGetOrder(t *testing.T) {
 	t.Parallel()
 
@@ -335,21 +326,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+func isAuthenticatedRequest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -368,8 +368,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -395,8 +395,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -425,5 +425,29 @@ func TestModifyOrder(t *testing.T) {
 	_, err := b.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+	b.Verbose = true
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:                   100,
+		Currency:                 symbol.LTC,
+		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:              "WITHDRAW IT ALL",
+	}
+
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -358,8 +358,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -385,8 +387,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -412,8 +417,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {
@@ -431,7 +439,6 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
 		Amount:                   100,
 		Currency:                 symbol.LTC,

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -326,19 +326,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -348,7 +338,7 @@ func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -358,9 +348,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -370,7 +360,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -387,10 +377,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -400,7 +390,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -417,10 +407,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -440,21 +430,21 @@ func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.LTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -2,6 +2,7 @@ package bittrex
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 
@@ -243,7 +244,8 @@ func (b *Bittrex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Bittrex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	uuid, err := b.Withdraw(withdrawRequest.Currency.String(), withdrawRequest.AddressTag, withdrawRequest.DestinationWalletAddress, withdrawRequest.Amount)
+	return fmt.Sprintf("%v", uuid), err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -242,19 +242,19 @@ func (b *Bittrex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *Bittrex) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bittrex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bittrex) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bittrex) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *Bittrex) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *Bittrex) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -244,7 +244,7 @@ func (b *Bittrex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (b *Bittrex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	uuid, err := b.Withdraw(withdrawRequest.Currency.String(), withdrawRequest.AddressTag, withdrawRequest.DestinationWalletAddress, withdrawRequest.Amount)
+	uuid, err := b.Withdraw(withdrawRequest.Currency.String(), withdrawRequest.AddressTag, withdrawRequest.Address, withdrawRequest.Amount)
 	return fmt.Sprintf("%v", uuid), err
 }
 

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -268,7 +268,6 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
 		Amount:                   100,
 		Currency:                 symbol.LTC,

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
 	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
@@ -173,21 +174,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
-	if b.APIKey == "" || b.APISecret == "" ||
-		b.APIKey == "Key" || b.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+func isAuthenticatedRequest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -195,9 +205,9 @@ func TestSubmitOrder(t *testing.T) {
 		FirstCurrency:  symbol.BTC,
 		SecondCurrency: symbol.LTC,
 	}
-	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
-		t.Errorf("Order failed to be placed: %v", err)
+	_, err := b.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
 	}
 }
 
@@ -206,8 +216,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -223,8 +233,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
 	}
 }
 
@@ -233,8 +243,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -247,15 +257,32 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	}
 
 	// Act
-	resp, err := b.CancelAllOrders(orderCancellation)
+	_, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	b.SetDefaults()
+	TestSetup(t)
+	b.Verbose = true
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:                   100,
+		Currency:                 symbol.LTC,
+		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:              "WITHDRAW IT ALL",
 	}
 
-	if len(resp.OrderStatus) > 0 {
-		t.Errorf("%v orders failed to cancel", len(resp.OrderStatus))
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if err != common.ErrNotYetImplemented {
+		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
 	}
 }
 

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -174,19 +174,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -196,7 +186,7 @@ func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -216,7 +206,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -243,7 +233,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -269,13 +259,13 @@ func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.LTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -186,19 +186,19 @@ func (b *BTCC) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, erro
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (b *BTCC) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *BTCC) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *BTCC) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *BTCC) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *BTCC) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *BTCC) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -278,19 +278,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (b.APIKey != "" && b.APIKey != "Key" &&
-		b.APISecret != "" && b.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if b.APIKey != "" && b.APIKey != "Key" &&
+		b.APISecret != "" && b.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -300,7 +290,7 @@ func TestSubmitOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -310,9 +300,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -322,7 +312,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -339,10 +329,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -352,7 +342,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -369,10 +359,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -392,21 +382,21 @@ func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.LTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	_, err := b.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -310,8 +310,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := b.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -337,8 +339,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := b.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -364,8 +369,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := b.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {
@@ -383,7 +391,6 @@ func TestModifyOrder(t *testing.T) {
 func TestWithdraw(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	b.Verbose = true
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
 		Amount:                   100,
 		Currency:                 symbol.LTC,

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -260,7 +260,7 @@ func (b *BTCMarkets) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is submitted
 func (b *BTCMarkets) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return b.WithdrawCrypto(withdrawRequest.Amount, withdrawRequest.Currency.String(), withdrawRequest.DestinationWalletAddress)
+	return b.WithdrawCrypto(withdrawRequest.Amount, withdrawRequest.Currency.String(), withdrawRequest.Address)
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -259,13 +259,13 @@ func (b *BTCMarkets) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 }
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is submitted
-func (b *BTCMarkets) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (b *BTCMarkets) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return b.WithdrawCrypto(amount, cryptocurrency.String(), address)
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *BTCMarkets) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *BTCMarkets) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	bd, err := b.GetClientBankAccounts(b.Name, currency.Upper().String())
 	if err != nil {
 		return "", err
@@ -275,7 +275,7 @@ func (b *BTCMarkets) WithdrawFiatFunds(currency pair.CurrencyItem, amount float6
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (b *BTCMarkets) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (b *BTCMarkets) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -260,17 +260,17 @@ func (b *BTCMarkets) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is submitted
 func (b *BTCMarkets) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return b.WithdrawCrypto(amount, cryptocurrency.String(), address)
+	return b.WithdrawCrypto(withdrawRequest.Amount, withdrawRequest.Currency.String(), withdrawRequest.DestinationWalletAddress)
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
 func (b *BTCMarkets) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	bd, err := b.GetClientBankAccounts(b.Name, currency.Upper().String())
+	bd, err := b.GetClientBankAccounts(b.Name, withdrawRequest.Currency.Upper().String())
 	if err != nil {
 		return "", err
 	}
-	return b.WithdrawAUD(bd.AccountName, bd.AccountNumber, bd.BankName, bd.BSBNumber, amount)
+	return b.WithdrawAUD(bd.AccountName, bd.AccountNumber, bd.BankName, bd.BSBNumber, withdrawRequest.Amount)
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -409,21 +409,30 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
-	if c.APIKey == "" || c.APISecret == "" ||
-		c.APIKey == "Key" || c.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+func isAuthenticatedRequest() bool {
+	if (c.APIKey != "" && c.APIKey != "Key" &&
+		c.APISecret != "" && c.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (c.APIKey != "" && c.APIKey != "Key" &&
+		c.APISecret != "" && c.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -442,8 +451,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -469,8 +478,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -499,5 +508,29 @@ func TestModifyOrder(t *testing.T) {
 	_, err := c.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	c.SetDefaults()
+	TestSetup(t)
+	c.Verbose = true
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:                   100,
+		Currency:                 symbol.LTC,
+		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:              "WITHDRAW IT ALL",
+	}
+
+	if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := c.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -409,19 +409,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (c.APIKey != "" && c.APIKey != "Key" &&
-		c.APISecret != "" && c.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (c.APIKey != "" && c.APIKey != "Key" &&
-		c.APISecret != "" && c.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if c.APIKey != "" && c.APIKey != "Key" &&
+		c.APISecret != "" && c.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -431,7 +421,7 @@ func TestSubmitOrder(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -441,9 +431,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := c.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 1, "clientId")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -453,7 +443,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -470,10 +460,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := c.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -483,7 +473,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -500,10 +490,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := c.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -523,21 +513,21 @@ func TestWithdraw(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.LTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	_, err := c.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -200,7 +200,7 @@ func (c *CoinbasePro) GetDepositAddress(cryptocurrency pair.CurrencyItem) (strin
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (c *CoinbasePro) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	resp, err := c.WithdrawCrypto(withdrawRequest.Amount, withdrawRequest.Currency.String(), withdrawRequest.DestinationWalletAddress)
+	resp, err := c.WithdrawCrypto(withdrawRequest.Amount, withdrawRequest.Currency.String(), withdrawRequest.Address)
 	return resp.ID, err
 }
 

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -210,6 +210,12 @@ func (c *CoinbasePro) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest
 	return "", common.ErrNotYetImplemented
 }
 
+// WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
+// withdrawal is submitted
+func (c *CoinbasePro) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
+	return "", common.ErrNotYetImplemented
+}
+
 // GetWebsocket returns a pointer to the exchange websocket
 func (c *CoinbasePro) GetWebsocket() (*exchange.Websocket, error) {
 	return c.Websocket, nil

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -206,7 +206,7 @@ func (c *CoinbasePro) WithdrawCryptocurrencyFunds(withdrawRequest exchange.Withd
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (c *CoinbasePro) WithdrawFiatFunds(cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (c *CoinbasePro) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -200,7 +200,8 @@ func (c *CoinbasePro) GetDepositAddress(cryptocurrency pair.CurrencyItem) (strin
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (c *CoinbasePro) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := c.WithdrawCrypto(withdrawRequest.Amount, withdrawRequest.Currency.String(), withdrawRequest.DestinationWalletAddress)
+	return resp.ID, err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -199,7 +199,7 @@ func (c *CoinbasePro) GetDepositAddress(cryptocurrency pair.CurrencyItem) (strin
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (c *CoinbasePro) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (c *CoinbasePro) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -195,19 +195,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (c.APIKey != "" && c.APIKey != "Key" &&
-		c.APISecret != "" && c.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (c.APIKey != "" && c.APIKey != "Key" &&
-		c.APISecret != "" && c.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if c.APIKey != "" && c.APIKey != "Key" &&
+		c.APISecret != "" && c.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -217,7 +207,7 @@ func TestSubmitOrder(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -227,9 +217,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := c.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 10, "1234234")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -239,7 +229,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -256,10 +246,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := c.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -269,7 +259,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -286,10 +276,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := c.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -323,18 +313,18 @@ func TestWithdraw(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:                   100,
-		Currency:                 symbol.LTC,
-		DestinationWalletAddress: "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description:              "WITHDRAW IT ALL",
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
 	}
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	_, err := c.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
-	if err != common.ErrNotYetImplemented {
-		t.Errorf("Expected 'Not Yet Implemented', recieved %v", err)
+	if err != common.ErrFunctionNotSupported {
+		t.Errorf("Expected 'Not supported', recieved %v", err)
 	}
 }

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -353,19 +353,19 @@ func (c *COINUT) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (c *COINUT) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
 func (c *COINUT) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
 func (c *COINUT) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // GetWebsocket returns a pointer to the exchange websocket

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -352,19 +352,19 @@ func (c *COINUT) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (c *COINUT) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (c *COINUT) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (c *COINUT) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (c *COINUT) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (c *COINUT) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (c *COINUT) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -100,15 +100,18 @@ type OrderCancellation struct {
 
 // WithdrawRequest used for wrapper crypto and FIAT withdraw methods
 type WithdrawRequest struct {
+	// Exchange related information
 	Description     string
 	OneTimePassword int64
+	AccountID       string
+	PIN             int64
+	TradePassword   string
 	// Crypto related information
-	Currency                 pair.CurrencyItem
-	OriginWalletAddress      string
-	DestinationWalletAddress string
-	AddressTag               string
-	Amount                   float64
-	FeeAmount                float64
+	Currency   pair.CurrencyItem
+	Address    string
+	AddressTag string
+	Amount     float64
+	FeeAmount  float64
 	// FIAT related information
 	BankName     string
 	BankAddress  string

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -100,10 +100,15 @@ type OrderCancellation struct {
 
 // WithdrawRequest used for wrapper crypto and FIAT withdraw methods
 type WithdrawRequest struct {
+	Description     string
+	OneTimePassword int64
 	// Crypto related information
-	Currency      pair.CurrencyItem
-	WalletAddress string
-	Amount        float64
+	Currency                 pair.CurrencyItem
+	OriginWalletAddress      string
+	DestinationWalletAddress string
+	AddressTag               string
+	Amount                   float64
+	FeeAmount                float64
 	// FIAT related information
 	BankName     string
 	BankAddress  string

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -293,6 +293,7 @@ type IBotExchange interface {
 
 	WithdrawCryptocurrencyFunds(wtihdrawRequest WithdrawRequest) (string, error)
 	WithdrawFiatFunds(wtihdrawRequest WithdrawRequest) (string, error)
+	WithdrawFiatFundsToInternationalBank(wtihdrawRequest WithdrawRequest) (string, error)
 
 	GetWebsocket() (*Websocket, error)
 }

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -98,6 +98,21 @@ type OrderCancellation struct {
 	Side          OrderSide
 }
 
+// WithdrawRequest used for wrapper crypto and FIAT withdraw methods
+type WithdrawRequest struct {
+	// Crypto related information
+	Currency      pair.CurrencyItem
+	WalletAddress string
+	Amount        float64
+	// FIAT related information
+	BankName     string
+	BankAddress  string
+	BankCity     string
+	BankCountry  string
+	SwiftCode    string
+	WireCurrency string
+}
+
 // Definitions for each type of withdrawal method for a given exchange
 const (
 	// No withdraw
@@ -268,8 +283,8 @@ type IBotExchange interface {
 	GetOrderInfo(orderID int64) (OrderDetail, error)
 	GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error)
 
-	WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error)
-	WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error)
+	WithdrawCryptocurrencyFunds(wtihdrawRequest WithdrawRequest) (string, error)
+	WithdrawFiatFunds(wtihdrawRequest WithdrawRequest) (string, error)
 
 	GetWebsocket() (*Websocket, error)
 }

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -250,7 +250,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if e.APIKey == "" || e.APISecret == "" ||
 		e.APIKey == "Key" || e.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -263,8 +263,8 @@ func TestSubmitOrder(t *testing.T) {
 	e.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -283,8 +283,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	e.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -310,8 +310,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	e.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -256,7 +256,9 @@ func (e *EXMO) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, erro
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (e *EXMO) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := e.WithdrawCryptocurrency(withdrawRequest.Currency.String(), withdrawRequest.Address, withdrawRequest.AddressTag, withdrawRequest.Amount)
+
+	return fmt.Sprintf("%v", resp), err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -255,19 +255,19 @@ func (e *EXMO) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, erro
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (e *EXMO) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (e *EXMO) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (e *EXMO) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (e *EXMO) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (e *EXMO) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (e *EXMO) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -28,6 +28,7 @@ const (
 	gateioBalances        = "private/balances"
 	gateioCancelOrder     = "private/cancelOrder"
 	gateioCancelAllOrders = "private/cancelAllOrders"
+	gateioWithdraw        = "private/withdraw"
 	gateioOpenOrders      = "private/openOrders"
 	gateioTicker          = "ticker"
 	gateioTickers         = "tickers"
@@ -507,4 +508,29 @@ func calculateTradingFee(feeForPair, purchasePrice, amount float64) float64 {
 
 func getCryptocurrencyWithdrawalFee(currency string) float64 {
 	return WithdrawalFees[currency]
+}
+
+// WithdrawCrypto deposits cryptocurrency to your selected wallet
+func (g *Gateio) WithdrawCrypto(currency, address string, amount float64) (string, error) {
+	type response struct {
+		Result  bool   `json:"result"`
+		Message string `json:"message"`
+		Code    int    `json:"code"`
+	}
+
+	var result response
+	params := fmt.Sprintf("currency=%v&amount=%v&address=%v",
+		currency,
+		address,
+		amount,
+	)
+	err := g.SendAuthenticatedHTTPRequest("POST", gateioWithdraw, params, &result)
+	if err != nil {
+		return "", err
+	}
+	if !result.Result {
+		return "", fmt.Errorf("code:%d message:%s", result.Code, result.Message)
+	}
+
+	return "", nil
 }

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -510,7 +510,7 @@ func getCryptocurrencyWithdrawalFee(currency string) float64 {
 	return WithdrawalFees[currency]
 }
 
-// WithdrawCrypto deposits cryptocurrency to your selected wallet
+// WithdrawCrypto withdraws cryptocurrency to your selected wallet
 func (g *Gateio) WithdrawCrypto(currency, address string, amount float64) (string, error) {
 	type response struct {
 		Result  bool   `json:"result"`

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -253,12 +253,21 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 func isAuthenticatedRequest() bool {
-	if g.APIKey == "" || g.APISecret == "" ||
-		g.APIKey == "Key" || g.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+	if (g.APIKey != "" && g.APIKey != "Key" &&
+		g.APISecret != "" && g.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (g.APIKey != "" && g.APIKey != "Key" &&
+		g.APISecret != "" && g.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
@@ -275,8 +284,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.BTC,
 	}
 	response, err := g.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -302,8 +313,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := g.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -329,8 +343,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := g.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -252,7 +252,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if g.APIKey == "" || g.APISecret == "" ||
 		g.APIKey == "Key" || g.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -265,7 +265,7 @@ func TestSubmitOrder(t *testing.T) {
 	g.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
+	if !isAuthenticatedRequest() {
 		t.Skip()
 	}
 
@@ -285,7 +285,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	g.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
+	if !isAuthenticatedRequest() {
 		t.Skip()
 	}
 
@@ -312,7 +312,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	g.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
+	if !isAuthenticatedRequest() {
 		t.Skip()
 	}
 

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -268,19 +268,19 @@ func (g *Gateio) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (g *Gateio) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (g *Gateio) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (g *Gateio) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (g *Gateio) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (g *Gateio) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (g *Gateio) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -269,7 +269,7 @@ func (g *Gateio) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (g *Gateio) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return g.WithdrawCrypto(withdrawRequest.Currency.String(), withdrawRequest.Address, withdrawRequest.Amount)
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -436,7 +436,7 @@ func (g *Gemini) WithdrawCrypto(address, currency string, amount float64) (Withd
 	request["address"] = address
 	request["amount"] = strconv.FormatFloat(amount, 'f', -1, 64)
 
-	err := g.SendAuthenticatedHTTPRequest("POST", geminiWithdraw+currency, nil, &response)
+	err := g.SendAuthenticatedHTTPRequest("POST", geminiWithdraw+common.StringToLower(currency), request, &response)
 	if err != nil {
 		return response, err
 	}

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -326,7 +326,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if Session[1].APIKey == "" || Session[1].APISecret == "" ||
 		Session[1].APIKey == "Key" || Session[1].APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -339,8 +339,8 @@ func TestSubmitOrder(t *testing.T) {
 	Session[1].SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -359,8 +359,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	Session[1].SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -386,8 +386,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	Session[1].SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/gemini/gemini_types.go
+++ b/exchanges/gemini/gemini_types.go
@@ -179,6 +179,8 @@ type WithdrawalAddress struct {
 	Amount  float64 `json:"amount"`
 	TXHash  string  `json:"txHash"`
 	Message string  `json:"message"`
+	Result  string  `json:"result"`
+	Reason  string  `json:"reason"`
 }
 
 // ErrorCapture is a generlized error response from the server

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -191,19 +191,19 @@ func (g *Gemini) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (g *Gemini) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (g *Gemini) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (g *Gemini) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (g *Gemini) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (g *Gemini) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (g *Gemini) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -192,7 +193,15 @@ func (g *Gemini) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (g *Gemini) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := g.WithdrawCrypto(withdrawRequest.Address, withdrawRequest.Currency.String(), withdrawRequest.Amount)
+	if err != nil {
+		return "", err
+	}
+	if resp.Result == "error" {
+		return "", errors.New(resp.Message)
+	}
+
+	return resp.TXHash, err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -177,7 +177,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if h.APIKey == "" || h.APISecret == "" ||
 		h.APIKey == "Key" || h.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -190,8 +190,8 @@ func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -210,8 +210,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -237,8 +237,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -177,19 +177,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (h.APIKey != "" && h.APIKey != "Key" &&
-		h.APISecret != "" && h.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (h.APIKey != "" && h.APIKey != "Key" &&
-		h.APISecret != "" && h.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if h.APIKey != "" && h.APIKey != "Key" &&
+		h.APISecret != "" && h.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -199,7 +189,7 @@ func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -209,9 +199,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.BTC,
 	}
 	response, err := h.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -221,7 +211,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -238,10 +228,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := h.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -251,7 +241,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -268,10 +258,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := h.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -284,5 +274,28 @@ func TestModifyOrder(t *testing.T) {
 	_, err := h.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	h.SetDefaults()
+	TestSetup(t)
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+	}
+
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := h.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !areTestAPIKeysSet() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -178,19 +178,28 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 func isAuthenticatedRequest() bool {
-	if h.APIKey == "" || h.APISecret == "" ||
-		h.APIKey == "Key" || h.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+	if (h.APIKey != "" && h.APIKey != "Key" &&
+		h.APISecret != "" && h.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (h.APIKey != "" && h.APIKey != "Key" &&
+		h.APISecret != "" && h.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -200,8 +209,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.BTC,
 	}
 	response, err := h.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "1234234")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -210,7 +221,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -227,8 +238,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := h.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -237,7 +251,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -254,8 +268,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := h.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -220,19 +220,19 @@ func (h *HitBTC) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (h *HitBTC) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HitBTC) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (h *HitBTC) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HitBTC) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (h *HitBTC) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HitBTC) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -221,7 +221,9 @@ func (h *HitBTC) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (h *HitBTC) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	_, err := h.Withdraw(withdrawRequest.Currency.String(), withdrawRequest.Address, withdrawRequest.Amount)
+
+	return "", err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 	"github.com/thrasher-/gocryptotrader/exchanges/request"
 	"github.com/thrasher-/gocryptotrader/exchanges/ticker"
@@ -778,19 +779,19 @@ func (h *HUOBI) Withdraw(address, currency, addrTag string, amount, fee float64)
 		Address  string `json:"address"`
 		Amount   string `json:"amount"`
 		Currency string `json:"currency"`
-		Fee      string `json:"fee"`
-		AddrTag  string `json:"addr-tag"`
+		Fee      string `json:"fee,omitempty"`
+		AddrTag  string `json:"addr-tag,omitempty"`
 	}{
 		Address:  address,
 		Currency: currency,
 		Amount:   strconv.FormatFloat(amount, 'f', -1, 64),
 	}
 
-	if fee != 0 {
+	if fee > 0 {
 		data.Fee = strconv.FormatFloat(fee, 'f', -1, 64)
 	}
 
-	if currency == "XRP" {
+	if currency == symbol.XRP {
 		data.AddrTag = addrTag
 	}
 

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -398,7 +398,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if h.APIKey == "" || h.APISecret == "" ||
 		h.APIKey == "Key" || h.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -411,8 +411,8 @@ func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -433,8 +433,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -460,8 +460,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -398,28 +398,19 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (h.APIKey != "" && h.APIKey != "Key" &&
-		h.APISecret != "" && h.APISecret != "Secret") &&
-		canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if h.APIKey != "" && h.APIKey != "Key" &&
+		h.APISecret != "" && h.APISecret != "Secret" {
 		return true
 	}
 	return false
 }
 
-func skipRealOrderTest() bool {
-	if (h.APIKey != "" && h.APIKey != "Key" &&
-		h.APISecret != "" && h.APISecret != "Secret") &&
-		!canManipulateRealOrders {
-		return true
-	}
-	return false
-}
 func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -437,9 +428,9 @@ func TestSubmitOrder(t *testing.T) {
 	accounts, err := h.GetAccounts()
 
 	response, err := h.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 10, strconv.FormatInt(accounts[0].ID, 10))
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -449,7 +440,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -466,10 +457,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := h.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -478,7 +469,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	// Arrange
 	h.SetDefaults()
 	TestSetup(t)
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -493,10 +484,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	// Act
 	resp, err := h.CancelAllOrders(orderCancellation)
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -523,5 +514,28 @@ func TestModifyOrder(t *testing.T) {
 	_, err := h.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	h.SetDefaults()
+	TestSetup(t)
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+	}
+
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := h.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !areTestAPIKeysSet() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -28,7 +28,8 @@ type CancelOpenOrdersBatch struct {
 		NextID       int `json:"next-id"`
 		SuccessCount int `json:"success-count"`
 	} `json:"data"`
-	Status string `json:"status"`
+	Status       string `json:"status"`
+	ErrorMessage string `json:"err-msg"`
 }
 
 // DetailMerged stores the ticker detail merged data

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -333,7 +333,8 @@ func (h *HUOBI) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, err
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (h *HUOBI) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := h.Withdraw(withdrawRequest.Address, withdrawRequest.Currency.Lower().String(), withdrawRequest.AddressTag, withdrawRequest.Amount, withdrawRequest.FeeAmount)
+	return fmt.Sprintf("%v", resp), err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -310,6 +310,10 @@ func (h *HUOBI) CancelAllOrders(orderCancellation exchange.OrderCancellation) (e
 		if resp.Data.FailedCount > 0 {
 			return cancelAllOrdersResponse, fmt.Errorf("%v orders failed to cancel", resp.Data.FailedCount)
 		}
+
+		if resp.Status == "error" {
+			return cancelAllOrdersResponse, errors.New(resp.ErrorMessage)
+		}
 	}
 
 	return cancelAllOrdersResponse, nil

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -328,19 +328,19 @@ func (h *HUOBI) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, err
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (h *HUOBI) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HUOBI) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (h *HUOBI) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HUOBI) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (h *HUOBI) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HUOBI) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
+	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	"github.com/thrasher-/gocryptotrader/exchanges"
 	"github.com/thrasher-/gocryptotrader/exchanges/request"
 	"github.com/thrasher-/gocryptotrader/exchanges/ticker"
@@ -755,22 +756,30 @@ func (h *HUOBIHADAX) Withdraw(address, currency, addrTag string, amount, fee flo
 		Response
 		WithdrawID int64 `json:"data"`
 	}
-
-	vals := url.Values{}
-	vals.Set("address", address)
-	vals.Set("currency", currency)
-	vals.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
-
-	if fee != 0 {
-		vals.Set("fee", strconv.FormatFloat(fee, 'f', -1, 64))
+	data := struct {
+		Address  string `json:"address"`
+		Amount   string `json:"amount"`
+		Currency string `json:"currency"`
+		Fee      string `json:"fee,omitempty"`
+		AddrTag  string `json:"addr-tag,omitempty"`
+	}{
+		Address:  address,
+		Currency: currency,
+		Amount:   strconv.FormatFloat(amount, 'f', -1, 64),
 	}
 
-	if currency == "XRP" {
-		vals.Set("addr-tag", addrTag)
+	if fee > 0 {
+		data.Fee = strconv.FormatFloat(fee, 'f', -1, 64)
+	}
+
+	if currency == symbol.XRP {
+		data.AddrTag = addrTag
 	}
 
 	var result response
-	err := h.SendAuthenticatedHTTPRequest("POST", huobihadaxWithdrawCreate, vals, &result)
+	bytesParams, _ := common.JSONEncode(data)
+	postBodyParams := string(bytesParams)
+	err := h.SendAuthenticatedHTTPPostRequest("POST", huobihadaxWithdrawCreate, postBodyParams, &result)
 
 	if result.ErrorMessage != "" {
 		return 0, errors.New(result.ErrorMessage)

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -377,7 +377,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if h.APIKey == "" || h.APISecret == "" ||
 		h.APIKey == "Key" || h.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -390,8 +390,8 @@ func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -412,8 +412,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -439,8 +439,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -377,28 +377,19 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (h.APIKey != "" && h.APIKey != "Key" &&
-		h.APISecret != "" && h.APISecret != "Secret") &&
-		canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if h.APIKey != "" && h.APIKey != "Key" &&
+		h.APISecret != "" && h.APISecret != "Secret" {
 		return true
 	}
 	return false
 }
 
-func skipRealOrderTest() bool {
-	if (h.APIKey != "" && h.APIKey != "Key" &&
-		h.APISecret != "" && h.APISecret != "Secret") &&
-		!canManipulateRealOrders {
-		return true
-	}
-	return false
-}
 func TestSubmitOrder(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -415,19 +406,20 @@ func TestSubmitOrder(t *testing.T) {
 	accounts, err := h.GetAccounts()
 
 	response, err := h.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 10, strconv.FormatInt(accounts[0].ID, 10))
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
 
 func TestCancelExchangeOrder(t *testing.T) {
 	// Arrange
+
 	h.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -444,10 +436,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := h.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -457,7 +449,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -474,10 +466,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := h.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -504,5 +496,28 @@ func TestModifyOrder(t *testing.T) {
 	_, err := h.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	h.SetDefaults()
+	TestSetup(t)
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:      100,
+		Currency:    symbol.BTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+	}
+
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := h.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !areTestAPIKeysSet() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/huobihadax/huobihadax_types.go
+++ b/exchanges/huobihadax/huobihadax_types.go
@@ -53,7 +53,8 @@ type CancelOpenOrdersBatch struct {
 		NextID       int `json:"next-id"`
 		SuccessCount int `json:"success-count"`
 	} `json:"data"`
-	Status string `json:"status"`
+	Status       string `json:"status"`
+	ErrorMessage string `json:"err-msg"`
 }
 
 // TradeHistory stores the the trade history data

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -275,6 +275,10 @@ func (h *HUOBIHADAX) CancelAllOrders(orderCancellation exchange.OrderCancellatio
 		if resp.Data.FailedCount > 0 {
 			return cancelAllOrdersResponse, fmt.Errorf("%v orders failed to cancel", resp.Data.FailedCount)
 		}
+
+		if resp.Status == "error" {
+			return cancelAllOrdersResponse, errors.New(resp.ErrorMessage)
+		}
 	}
 
 	return cancelAllOrdersResponse, nil

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -293,19 +293,19 @@ func (h *HUOBIHADAX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (h *HUOBIHADAX) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HUOBIHADAX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (h *HUOBIHADAX) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HUOBIHADAX) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (h *HUOBIHADAX) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (h *HUOBIHADAX) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -298,7 +298,8 @@ func (h *HUOBIHADAX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (h *HUOBIHADAX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := h.Withdraw(withdrawRequest.Address, withdrawRequest.Currency.Lower().String(), withdrawRequest.AddressTag, withdrawRequest.Amount, withdrawRequest.FeeAmount)
+	return fmt.Sprintf("%v", resp), err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -246,7 +246,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if i.APIKey == "" || i.APISecret == "" ||
 		i.APIKey == "Key" || i.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -259,8 +259,8 @@ func TestSubmitOrder(t *testing.T) {
 	i.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -279,8 +279,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	i.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -306,8 +306,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	i.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
 	"github.com/thrasher-/gocryptotrader/currency/pair"
 	"github.com/thrasher-/gocryptotrader/currency/symbol"
@@ -246,19 +247,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (i.APIKey != "" && i.APIKey != "Key" &&
-		i.APISecret != "" && i.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (i.APIKey != "" && i.APIKey != "Key" &&
-		i.APISecret != "" && i.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if i.APIKey != "" && i.APIKey != "Key" &&
+		i.APISecret != "" && i.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -267,7 +258,7 @@ func skipRealOrderTest() bool {
 func TestSubmitOrder(t *testing.T) {
 	i.SetDefaults()
 	TestSetup(t)
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -277,9 +268,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USDT,
 	}
 	response, err := i.SubmitOrder(p, exchange.Buy, exchange.Limit, 1, 10, "hi")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -289,7 +280,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	i.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -306,10 +297,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := i.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -319,7 +310,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	i.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -336,10 +327,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := i.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -361,5 +352,25 @@ func TestModifyOrder(t *testing.T) {
 	_, err := i.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	i.SetDefaults()
+	TestSetup(t)
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+	}
+
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := i.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if err != common.ErrFunctionNotSupported {
+		t.Errorf("Expected 'Not supported', recieved %v", err)
 	}
 }

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -168,7 +168,7 @@ func (i *ItBit) SubmitOrder(p pair.CurrencyPair, side exchange.OrderSide, orderT
 	var submitOrderResponse exchange.SubmitOrderResponse
 	var wallet string
 
-	wallets, err := i.GetWallets(nil)
+	wallets, err := i.GetWallets(url.Values{})
 	if err != nil {
 		return submitOrderResponse, err
 	}

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -243,19 +243,19 @@ func (i *ItBit) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, err
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (i *ItBit) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (i *ItBit) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (i *ItBit) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (i *ItBit) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (i *ItBit) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (i *ItBit) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -244,19 +244,19 @@ func (i *ItBit) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, err
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (i *ItBit) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
 func (i *ItBit) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
 func (i *ItBit) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // GetWebsocket returns a pointer to the exchange websocket

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -40,6 +40,7 @@ const (
 	krakenOrderCancel    = "CancelOrder"
 	krakenOrderPlace     = "AddOrder"
 	krakenWithdrawInfo   = "WithdrawInfo"
+	krakenWithdraw       = "Withdraw"
 	krakenDepositMethods = "DepositMethods"
 
 	krakenAuthRate   = 0
@@ -467,6 +468,24 @@ func (k *Kraken) GetWithdrawInfo(currency string, amount float64) (WithdrawInfor
 	}
 
 	return response.Result, GetError(response.Error)
+}
+
+// Withdraw withdraws funds
+func (k *Kraken) Withdraw(asset, key string, amount float64) (string, error) {
+	var response struct {
+		Error       []string `json:"error"`
+		ReferenceID string   `json:"refid"`
+	}
+	params := url.Values{}
+	params.Set("asset", asset)
+	params.Set("key", key)
+	params.Set("amount", fmt.Sprintf("%f", amount))
+
+	if err := k.SendAuthenticatedHTTPRequest(krakenWithdraw, params, &response); err != nil {
+		return response.ReferenceID, err
+	}
+
+	return response.ReferenceID, GetError(response.Error)
 }
 
 // GetDepositMethods gets withdrawal fees

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -450,10 +450,11 @@ func TestWithdraw(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
 	var withdrawCryptoRequest = exchange.WithdrawRequest{
-		Amount:      100,
-		Currency:    symbol.XXBT,
-		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
-		Description: "donation",
+		Amount:        100,
+		Currency:      symbol.XXBT,
+		Address:       "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:   "donation",
+		TradePassword: "Key",
 	}
 
 	if areTestAPIKeysSet() && !canManipulateRealOrders {

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -332,7 +332,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if k.APIKey == "" || k.APISecret == "" ||
 		k.APIKey == "Key" || k.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -345,8 +345,8 @@ func TestSubmitOrder(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -365,8 +365,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -392,8 +392,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -241,9 +241,9 @@ func (k *Kraken) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 }
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal
-// Populate exchange.WithdrawRequest.Description with withdrawal key name, as set up on your account
+// Populate exchange.WithdrawRequest.TradePassword with withdrawal key name, as set up on your account
 func (k *Kraken) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return k.Withdraw(withdrawRequest.Currency.String(), withdrawRequest.Description, withdrawRequest.Amount)
+	return k.Withdraw(withdrawRequest.Currency.String(), withdrawRequest.TradePassword, withdrawRequest.Amount)
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -240,10 +240,10 @@ func (k *Kraken) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 	return "", common.ErrNotYetImplemented
 }
 
-// WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
-// submitted
+// WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal
+// Populate exchange.WithdrawRequest.Description with withdrawal key name, as set up on your account
 func (k *Kraken) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return k.Withdraw(withdrawRequest.Currency.String(), withdrawRequest.Description, withdrawRequest.Amount)
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -242,19 +242,19 @@ func (k *Kraken) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (k *Kraken) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (k *Kraken) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (k *Kraken) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (k *Kraken) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (k *Kraken) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (k *Kraken) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -317,11 +317,19 @@ func (l *LakeBTC) GetExternalAccounts() ([]ExternalAccounts, error) {
 
 // CreateWithdraw allows your to withdraw to external account WARNING: Only for
 // BTC!
-func (l *LakeBTC) CreateWithdraw(amount float64, accountID int64) (Withdraw, error) {
+func (l *LakeBTC) CreateWithdraw(amount float64, accountID string) (Withdraw, error) {
 	resp := Withdraw{}
-	params := strconv.FormatFloat(amount, 'f', -1, 64) + ",btc," + strconv.FormatInt(accountID, 10)
+	params := strconv.FormatFloat(amount, 'f', -1, 64) + ",btc," + accountID
 
-	return resp, l.SendAuthenticatedHTTPRequest(lakeBTCCreateWithdraw, params, &resp)
+	err := l.SendAuthenticatedHTTPRequest(lakeBTCCreateWithdraw, params, &resp)
+	if err != nil {
+		return Withdraw{}, err
+	}
+	if len(resp.Error) > 0 {
+		return resp, errors.New(resp.Error)
+	}
+
+	return resp, nil
 }
 
 // SendHTTPRequest sends an unauthenticated http request

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -251,19 +251,28 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 func isAuthenticatedRequest() bool {
-	if l.APIKey == "" || l.APISecret == "" ||
-		l.APIKey == "Key" || l.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+	if (l.APIKey != "" && l.APIKey != "Key" &&
+		l.APISecret != "" && l.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (l.APIKey != "" && l.APIKey != "Key" &&
+		l.APISecret != "" && l.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -273,8 +282,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.EUR,
 	}
 	response, err := l.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -283,7 +294,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -300,8 +311,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := l.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -310,7 +324,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -327,8 +341,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := l.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -250,7 +250,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if l.APIKey == "" || l.APISecret == "" ||
 		l.APIKey == "Key" || l.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -263,8 +263,8 @@ func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -283,8 +283,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -310,8 +310,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/lakebtc/lakebtc_types.go
+++ b/exchanges/lakebtc/lakebtc_types.go
@@ -110,4 +110,5 @@ type Withdraw struct {
 	Source            string  `json:"source"`
 	ExternalAccountID int64   `json:"external_account_id,string"`
 	At                int64   `json:"at"`
+	Error             string  `json:"error"`
 }

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -205,19 +205,19 @@ func (l *LakeBTC) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (l *LakeBTC) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (l *LakeBTC) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (l *LakeBTC) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (l *LakeBTC) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (l *LakeBTC) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (l *LakeBTC) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -1,6 +1,7 @@
 package lakebtc
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/currency/pair"
+	"github.com/thrasher-/gocryptotrader/currency/symbol"
 	"github.com/thrasher-/gocryptotrader/exchanges"
 	"github.com/thrasher-/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-/gocryptotrader/exchanges/ticker"
@@ -206,7 +208,16 @@ func (l *LakeBTC) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, e
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (l *LakeBTC) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	if withdrawRequest.Currency.String() != symbol.BTC {
+		return "", errors.New("Only BTC supported for withdrawals")
+	}
+
+	resp, err := l.CreateWithdraw(withdrawRequest.Amount, withdrawRequest.Description)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v", resp.ID), nil
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/liqui/liqui.go
+++ b/exchanges/liqui/liqui.go
@@ -265,7 +265,15 @@ func (l *Liqui) WithdrawCoins(coin string, amount float64, address string) (With
 	req.Add("address", address)
 
 	var result WithdrawCoins
-	return result, l.SendAuthenticatedHTTPRequest(liquiWithdrawCoin, req, &result)
+	err := l.SendAuthenticatedHTTPRequest(liquiWithdrawCoin, req, &result)
+	if err != nil {
+		return WithdrawCoins{}, err
+	}
+	if len(result.Error) > 0 {
+		return result, errors.New(result.Error)
+	}
+
+	return result, nil
 }
 
 // SendHTTPRequest sends an unauthenticated HTTP request

--- a/exchanges/liqui/liqui.go
+++ b/exchanges/liqui/liqui.go
@@ -1,6 +1,7 @@
 package liqui
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -201,10 +202,13 @@ func (l *Liqui) Trade(pair, orderType string, amount, price float64) (float64, e
 	req.Add("type", orderType)
 	req.Add("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 	req.Add("rate", strconv.FormatFloat(price, 'f', -1, 64))
-
 	var result Trade
 
-	return result.OrderID, l.SendAuthenticatedHTTPRequest(liquiTrade, req, &result)
+	err := l.SendAuthenticatedHTTPRequest(liquiTrade, req, &result)
+	if result.Success == 0 {
+		return -1, errors.New(result.Error)
+	}
+	return result.OrderID, err
 }
 
 // GetActiveOrders returns the list of your active orders.
@@ -233,7 +237,11 @@ func (l *Liqui) CancelExistingOrder(OrderID int64) error {
 	req.Add("order_id", strconv.FormatInt(OrderID, 10))
 	var result CancelOrder
 
-	return l.SendAuthenticatedHTTPRequest(liquiCancelOrder, req, &result)
+	err := l.SendAuthenticatedHTTPRequest(liquiCancelOrder, req, &result)
+	if result.Success == 0 {
+		return errors.New(result.Error)
+	}
+	return err
 }
 
 // GetTradeHistory returns trade history

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -235,7 +235,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if l.APIKey == "" || l.APISecret == "" ||
 		l.APIKey == "Key" || l.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -248,8 +248,8 @@ func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -268,8 +268,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -295,8 +295,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/liqui/liqui_test.go
+++ b/exchanges/liqui/liqui_test.go
@@ -235,19 +235,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (l.APIKey != "" && l.APIKey != "Key" &&
-		l.APISecret != "" && l.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (l.APIKey != "" && l.APIKey != "Key" &&
-		l.APISecret != "" && l.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if l.APIKey != "" && l.APIKey != "Key" &&
+		l.APISecret != "" && l.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -256,7 +246,7 @@ func skipRealOrderTest() bool {
 func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -266,9 +256,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.EUR,
 	}
 	response, err := l.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -278,7 +268,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -293,10 +283,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	// Act
 	err := l.CancelOrder(orderCancellation)
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -306,7 +296,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -321,10 +311,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	// Act
 	resp, err := l.CancelAllOrders(orderCancellation)
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -337,5 +327,28 @@ func TestModifyOrder(t *testing.T) {
 	_, err := l.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	l.SetDefaults()
+	TestSetup(t)
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+	}
+
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := l.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !areTestAPIKeysSet() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/liqui/liqui_wrapper.go
+++ b/exchanges/liqui/liqui_wrapper.go
@@ -221,19 +221,24 @@ func (l *Liqui) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, err
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (l *Liqui) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := l.WithdrawCoins(withdrawRequest.Currency.String(), withdrawRequest.Amount, withdrawRequest.Address)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v", resp.TID), nil
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
 func (l *Liqui) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
 func (l *Liqui) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return "", common.ErrFunctionNotSupported
 }
 
 // GetWebsocket returns a pointer to the exchange websocket

--- a/exchanges/liqui/liqui_wrapper.go
+++ b/exchanges/liqui/liqui_wrapper.go
@@ -220,19 +220,19 @@ func (l *Liqui) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, err
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (l *Liqui) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (l *Liqui) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (l *Liqui) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (l *Liqui) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (l *Liqui) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (l *Liqui) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/localbitcoins/localbitcoins.go
+++ b/exchanges/localbitcoins/localbitcoins.go
@@ -560,14 +560,14 @@ func (l *LocalBitcoins) GetWalletBalance() (WalletBalanceInfo, error) {
 // On success, the response returns a message indicating success. It is highly
 // recommended to minimize the lifetime of access tokens with the money
 // permission. Use Logout() to make the current token expire instantly.
-func (l *LocalBitcoins) WalletSend(address string, amount float64, pin int) (bool, error) {
+func (l *LocalBitcoins) WalletSend(address string, amount float64, pin int64) (bool, error) {
 	values := url.Values{}
 	values.Set("address", address)
 	values.Set("amount", strconv.FormatFloat(amount, 'f', -1, 64))
 	path := localbitcoinsAPIWalletSend
 
 	if pin > 0 {
-		values.Set("pincode", strconv.Itoa(pin))
+		values.Set("pincode", fmt.Sprintf("%v", pin))
 		path = localbitcoinsAPIWalletSendPin
 	}
 

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -201,19 +201,28 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 func isAuthenticatedRequest() bool {
-	if l.APIKey == "" || l.APISecret == "" ||
-		l.APIKey == "Key" || l.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+	if (l.APIKey != "" && l.APIKey != "Key" &&
+		l.APISecret != "" && l.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (l.APIKey != "" && l.APIKey != "Key" &&
+		l.APISecret != "" && l.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -223,8 +232,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.EUR,
 	}
 	response, err := l.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -233,7 +244,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -250,8 +261,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := l.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -260,7 +274,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -277,8 +291,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := l.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -200,7 +200,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if l.APIKey == "" || l.APISecret == "" ||
 		l.APIKey == "Key" || l.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -213,8 +213,8 @@ func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -233,8 +233,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -260,8 +260,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -200,19 +200,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (l.APIKey != "" && l.APIKey != "Key" &&
-		l.APISecret != "" && l.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (l.APIKey != "" && l.APIKey != "Key" &&
-		l.APISecret != "" && l.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if l.APIKey != "" && l.APIKey != "Key" &&
+		l.APISecret != "" && l.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -222,7 +212,7 @@ func TestSubmitOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -232,9 +222,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.EUR,
 	}
 	response, err := l.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -244,7 +234,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -261,10 +251,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := l.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -274,7 +264,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	l.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -291,10 +281,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := l.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -307,5 +297,28 @@ func TestModifyOrder(t *testing.T) {
 	_, err := l.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	l.SetDefaults()
+	TestSetup(t)
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+	}
+
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := l.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !areTestAPIKeysSet() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -252,19 +252,19 @@ func (l *LocalBitcoins) GetDepositAddress(cryptocurrency pair.CurrencyItem) (str
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (l *LocalBitcoins) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (l *LocalBitcoins) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (l *LocalBitcoins) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (l *LocalBitcoins) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (l *LocalBitcoins) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (l *LocalBitcoins) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -253,7 +253,8 @@ func (l *LocalBitcoins) GetDepositAddress(cryptocurrency pair.CurrencyItem) (str
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (l *LocalBitcoins) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	_, err := l.WalletSend(withdrawRequest.Address, withdrawRequest.Amount, withdrawRequest.PIN)
+	return "", err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/okcoin/okcoin.go
+++ b/exchanges/okcoin/okcoin.go
@@ -558,10 +558,10 @@ func (o *OKCoin) Withdrawal(symbol string, fee float64, tradePWD, address string
 	v.Set("trade_pwd", tradePWD)
 	v.Set("withdraw_address", address)
 	v.Set("withdraw_amount", strconv.FormatFloat(amount, 'f', -1, 64))
+	v.Set("target", "address")
 	result := WithdrawalResponse{}
 
 	err := o.SendAuthenticatedHTTPRequest(okcoinWithdraw, v, &result)
-
 	if err != nil {
 		return 0, err
 	}

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -256,7 +256,7 @@ func TestWithdraw(t *testing.T) {
 		Currency:      "btc_usd",
 		Address:       "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
 		Description:   "WITHDRAW IT ALL",
-		TradePassword: "kA2BwU4FFpYm4g0Zu854",
+		TradePassword: "Password",
 		FeeAmount:     1,
 	}
 

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -150,7 +150,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if o.APIKey == "" || o.APISecret == "" ||
 		o.APIKey == "Key" || o.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -163,8 +163,8 @@ func TestSubmitOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -183,8 +183,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -210,8 +210,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/okcoin/okcoin_types.go
+++ b/exchanges/okcoin/okcoin_types.go
@@ -197,8 +197,9 @@ type BatchTrade struct {
 
 // CancelOrderResponse is a response type for a cancelled order
 type CancelOrderResponse struct {
-	Success string
-	Error   string
+	Success   string
+	ErrorCode string `json:"error_code"`
+	Result    bool   `json:"result"`
 }
 
 // OrderInfo holds data on an order

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -289,19 +289,19 @@ func (o *OKCoin) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (o *OKCoin) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (o *OKCoin) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (o *OKCoin) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (o *OKCoin) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (o *OKCoin) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (o *OKCoin) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -240,8 +240,10 @@ func (o *OKCoin) CancelOrder(order exchange.OrderCancellation) error {
 		return err
 	}
 
-	_, err = o.CancelExistingOrder(orders, exchange.FormatExchangeCurrency(o.Name, order.CurrencyPair).String())
-
+	resp, err := o.CancelExistingOrder(orders, exchange.FormatExchangeCurrency(o.Name, order.CurrencyPair).String())
+	if !resp.Result {
+		return errors.New(resp.ErrorCode)
+	}
 	return err
 }
 
@@ -266,7 +268,7 @@ func (o *OKCoin) CancelAllOrders(orderCancellation exchange.OrderCancellation) (
 			return cancelAllOrdersResponse, err
 		}
 
-		for _, order := range common.SplitStrings(resp.Error, ",") {
+		for _, order := range common.SplitStrings(resp.ErrorCode, ",") {
 			if err != nil {
 				cancelAllOrdersResponse.OrderStatus[order] = "Order could not be cancelled"
 			}

--- a/exchanges/okcoin/okcoin_wrapper.go
+++ b/exchanges/okcoin/okcoin_wrapper.go
@@ -292,7 +292,8 @@ func (o *OKCoin) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, er
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (o *OKCoin) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := o.Withdrawal(withdrawRequest.Currency.String(), withdrawRequest.FeeAmount, withdrawRequest.TradePassword, withdrawRequest.Address, withdrawRequest.Amount)
+	return fmt.Sprintf("%v", resp), err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/okex/okex.go
+++ b/exchanges/okex/okex.go
@@ -66,7 +66,7 @@ const (
 	spotCancelTrade    = "cancel_order"
 	spotOrderInfo      = "order_info"
 	spotMultiOrderInfo = "orders_info"
-	spotWithdraw       = "withdraw"
+	spotWithdraw       = "withdraw.do"
 	spotCancelWithdraw = "cancel_withdraw"
 	spotWithdrawInfo   = "withdraw_info"
 	spotAccountRecords = "account_records"
@@ -1224,4 +1224,30 @@ func (o *OKEX) GetBalance() ([]FullBalance, error) {
 	}
 
 	return balances, nil
+}
+
+// Withdrawal withdraws a cryptocurrency to a supplied address
+func (o *OKEX) Withdrawal(symbol string, fee float64, tradePWD, address string, amount float64) (int, error) {
+	v := url.Values{}
+	v.Set("symbol", symbol)
+
+	if fee != 0 {
+		v.Set("chargefee", strconv.FormatFloat(fee, 'f', -1, 64))
+	}
+	v.Set("trade_pwd", tradePWD)
+	v.Set("withdraw_address", address)
+	v.Set("withdraw_amount", strconv.FormatFloat(amount, 'f', -1, 64))
+	v.Set("target", "address")
+	resp := WithdrawalResponse{}
+
+	err := o.SendAuthenticatedHTTPRequest(spotWithdraw, v, &resp)
+	if err != nil {
+		return 0, err
+	}
+
+	if !resp.Result {
+		return 0, errors.New("unable to process withdrawal request")
+	}
+
+	return resp.WithdrawID, nil
 }

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -399,7 +399,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if o.APIKey == "" || o.APISecret == "" ||
 		o.APIKey == "Key" || o.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -412,8 +412,8 @@ func TestSubmitOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var p = pair.CurrencyPair{
@@ -432,8 +432,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -459,8 +459,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -400,19 +400,28 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 func isAuthenticatedRequest() bool {
-	if o.APIKey == "" || o.APISecret == "" ||
-		o.APIKey == "Key" || o.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+	if (o.APIKey != "" && o.APIKey != "Key" &&
+		o.APISecret != "" && o.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (o.APIKey != "" && o.APIKey != "Key" &&
+		o.APISecret != "" && o.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -422,8 +431,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.EUR,
 	}
 	response, err := o.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -432,7 +443,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -449,8 +460,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := o.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -459,7 +473,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -476,8 +490,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := o.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -399,19 +399,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (o.APIKey != "" && o.APIKey != "Key" &&
-		o.APISecret != "" && o.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (o.APIKey != "" && o.APIKey != "Key" &&
-		o.APISecret != "" && o.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if o.APIKey != "" && o.APIKey != "Key" &&
+		o.APISecret != "" && o.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -421,7 +411,7 @@ func TestSubmitOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -431,9 +421,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.EUR,
 	}
 	response, err := o.SubmitOrder(p, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -443,7 +433,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -460,10 +450,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := o.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -473,7 +463,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	o.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -490,10 +480,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := o.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -520,5 +510,30 @@ func TestModifyOrder(t *testing.T) {
 	_, err := o.ModifyOrder(exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	o.SetDefaults()
+	TestSetup(t)
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:        100,
+		Currency:      "btc_usd",
+		Address:       "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description:   "WITHDRAW IT ALL",
+		TradePassword: "kA2BwU4FFpYm4g0Zu854",
+		FeeAmount:     1,
+	}
+
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := o.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !areTestAPIKeysSet() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -521,7 +521,7 @@ func TestWithdraw(t *testing.T) {
 		Currency:      "btc_usd",
 		Address:       "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
 		Description:   "WITHDRAW IT ALL",
-		TradePassword: "kA2BwU4FFpYm4g0Zu854",
+		TradePassword: "Password",
 		FeeAmount:     1,
 	}
 

--- a/exchanges/okex/okex_types.go
+++ b/exchanges/okex/okex_types.go
@@ -463,3 +463,9 @@ type Balance struct {
 		} `json:"funds"`
 	} `json:"info"`
 }
+
+// WithdrawalResponse is a response type for withdrawal
+type WithdrawalResponse struct {
+	WithdrawID int  `json:"withdraw_id"`
+	Result     bool `json:"result"`
+}

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -288,19 +288,19 @@ func (o *OKEX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, erro
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (o *OKEX) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (o *OKEX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (o *OKEX) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (o *OKEX) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (o *OKEX) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (o *OKEX) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/okex/okex_wrapper.go
+++ b/exchanges/okex/okex_wrapper.go
@@ -289,7 +289,8 @@ func (o *OKEX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, erro
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (o *OKEX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := o.Withdrawal(withdrawRequest.Currency.String(), withdrawRequest.FeeAmount, withdrawRequest.TradePassword, withdrawRequest.Address, withdrawRequest.Amount)
+	return fmt.Sprintf("%v", resp), err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -195,19 +195,9 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isAuthenticatedRequest() bool {
-	if (p.APIKey != "" && p.APIKey != "Key" &&
-		p.APISecret != "" && p.APISecret != "Secret") &&
-		canManipulateRealOrders {
-		return true
-	}
-	return false
-}
-
-func skipRealOrderTest() bool {
-	if (p.APIKey != "" && p.APIKey != "Key" &&
-		p.APISecret != "" && p.APISecret != "Secret") &&
-		!canManipulateRealOrders {
+func areTestAPIKeysSet() bool {
+	if p.APIKey != "" && p.APIKey != "Key" &&
+		p.APISecret != "" && p.APISecret != "Secret" {
 		return true
 	}
 	return false
@@ -217,7 +207,7 @@ func TestSubmitOrder(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -227,9 +217,9 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := p.SubmitOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
+	if areTestAPIKeysSet() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
-	} else if !isAuthenticatedRequest() && err == nil {
+	} else if !areTestAPIKeysSet() && err == nil {
 		t.Error("Expecting an error when no keys are set")
 	}
 }
@@ -239,7 +229,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -256,10 +246,10 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := p.CancelOrder(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
@@ -269,7 +259,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-	if skipRealOrderTest() {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -286,10 +276,10 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := p.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if !isAuthenticatedRequest() && err == nil {
+	if !areTestAPIKeysSet() && err == nil {
 		t.Errorf("Expecting an error when no keys are set: %v", err)
 	}
-	if isAuthenticatedRequest() && err != nil {
+	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Could not cancel orders: %v", err)
 	}
 
@@ -302,5 +292,28 @@ func TestModifyOrder(t *testing.T) {
 	_, err := p.ModifyOrder(exchange.ModifyOrder{OrderID: "1337", Price: 1337})
 	if err == nil {
 		t.Error("Test Failed - ModifyOrder() error")
+	}
+}
+
+func TestWithdraw(t *testing.T) {
+	p.SetDefaults()
+	TestSetup(t)
+	var withdrawCryptoRequest = exchange.WithdrawRequest{
+		Amount:      100,
+		Currency:    symbol.LTC,
+		Address:     "1F5zVDgNjorJ51oGebSvNCrSAHpwGkUdDB",
+		Description: "WITHDRAW IT ALL",
+	}
+
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
+	}
+
+	_, err := p.WithdrawCryptocurrencyFunds(withdrawCryptoRequest)
+	if !areTestAPIKeysSet() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if areTestAPIKeysSet() && err != nil {
+		t.Errorf("Withdraw failed to be placed: %v", err)
 	}
 }

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -196,19 +196,28 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 func isAuthenticatedRequest() bool {
-	if p.APIKey == "" || p.APISecret == "" ||
-		p.APIKey == "Key" || p.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+	if (p.APIKey != "" && p.APIKey != "Key" &&
+		p.APISecret != "" && p.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (p.APIKey != "" && p.APIKey != "Key" &&
+		p.APISecret != "" && p.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -218,8 +227,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.LTC,
 	}
 	response, err := p.SubmitOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -228,7 +239,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -245,8 +256,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := p.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -255,7 +269,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -272,8 +286,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := p.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -195,7 +195,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if p.APIKey == "" || p.APISecret == "" ||
 		p.APIKey == "Key" || p.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -208,8 +208,8 @@ func TestSubmitOrder(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var pair = pair.CurrencyPair{
@@ -228,8 +228,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -255,8 +255,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -242,7 +242,8 @@ func (p *Poloniex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (p *Poloniex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	_, err := p.Withdraw(withdrawRequest.Currency.String(), withdrawRequest.Address, withdrawRequest.Amount)
+	return "", err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -241,19 +241,19 @@ func (p *Poloniex) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, 
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (p *Poloniex) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (p *Poloniex) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (p *Poloniex) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (p *Poloniex) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (p *Poloniex) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (p *Poloniex) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -325,7 +325,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if w.APIKey == "" || w.APISecret == "" ||
 		w.APIKey == "Key" || w.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -341,8 +341,8 @@ func TestSubmitOrder(t *testing.T) {
 	w.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var pair = pair.CurrencyPair{
@@ -364,8 +364,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	w.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -394,8 +394,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	w.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/wex/wex_test.go
+++ b/exchanges/wex/wex_test.go
@@ -326,12 +326,21 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 func isAuthenticatedRequest() bool {
-	if w.APIKey == "" || w.APISecret == "" ||
-		w.APIKey == "Key" || w.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+	if (w.APIKey != "" && w.APIKey != "Key" &&
+		w.APISecret != "" && w.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (w.APIKey != "" && w.APIKey != "Key" &&
+		w.APISecret != "" && w.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
@@ -341,7 +350,7 @@ func TestSubmitOrder(t *testing.T) {
 	w.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -351,8 +360,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := w.SubmitOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -364,7 +375,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	w.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -381,8 +392,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := w.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -394,7 +408,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	w.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -411,8 +425,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := w.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -239,7 +239,8 @@ func (w *WEX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (w *WEX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := w.WithdrawCoins(withdrawRequest.Currency.String(), withdrawRequest.Amount, withdrawRequest.Address)
+	return fmt.Sprintf("%v", resp.TID), err
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/wex/wex_wrapper.go
+++ b/exchanges/wex/wex_wrapper.go
@@ -238,19 +238,19 @@ func (w *WEX) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (w *WEX) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (w *WEX) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (w *WEX) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (w *WEX) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (w *WEX) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (w *WEX) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -314,7 +314,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if y.APIKey == "" || y.APISecret == "" ||
 		y.APIKey == "Key" || y.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -327,8 +327,8 @@ func TestSubmitOrder(t *testing.T) {
 	y.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	var pair = pair.CurrencyPair{
@@ -347,8 +347,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	y.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -374,8 +374,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	y.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -315,19 +315,28 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
 func isAuthenticatedRequest() bool {
-	if y.APIKey == "" || y.APISecret == "" ||
-		y.APIKey == "Key" || y.APISecret == "Secret" ||
-		!canManipulateRealOrders {
-		return false
+	if (y.APIKey != "" && y.APIKey != "Key" &&
+		y.APISecret != "" && y.APISecret != "Secret") &&
+		canManipulateRealOrders {
+		return true
 	}
-	return true
+	return false
+}
+
+func skipRealOrderTest() bool {
+	if (y.APIKey != "" && y.APIKey != "Key" &&
+		y.APISecret != "" && y.APISecret != "Secret") &&
+		!canManipulateRealOrders {
+		return true
+	}
+	return false
 }
 
 func TestSubmitOrder(t *testing.T) {
 	y.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -337,8 +346,10 @@ func TestSubmitOrder(t *testing.T) {
 		SecondCurrency: symbol.USD,
 	}
 	response, err := y.SubmitOrder(pair, exchange.Buy, exchange.Market, 1, 10, "hi")
-	if err != nil || !response.IsOrderPlaced {
+	if isAuthenticatedRequest() && (err != nil || !response.IsOrderPlaced) {
 		t.Errorf("Order failed to be placed: %v", err)
+	} else if !isAuthenticatedRequest() && err == nil {
+		t.Error("Expecting an error when no keys are set")
 	}
 }
 
@@ -347,7 +358,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	y.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -364,8 +375,11 @@ func TestCancelExchangeOrder(t *testing.T) {
 	err := y.CancelOrder(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 }
 
@@ -374,7 +388,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	y.SetDefaults()
 	TestSetup(t)
 
-		if skipRealOrderTest() {
+	if skipRealOrderTest() {
 		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
@@ -391,8 +405,11 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	resp, err := y.CancelAllOrders(orderCancellation)
 
 	// Assert
-	if err != nil {
-		t.Errorf("Could not cancel order: %s", err)
+	if !isAuthenticatedRequest() && err == nil {
+		t.Errorf("Expecting an error when no keys are set: %v", err)
+	}
+	if isAuthenticatedRequest() && err != nil {
+		t.Errorf("Could not cancel orders: %v", err)
 	}
 
 	if len(resp.OrderStatus) > 0 {

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -1,6 +1,7 @@
 package yobit
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -220,7 +221,14 @@ func (y *Yobit) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, err
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (y *Yobit) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	resp, err := y.WithdrawCoinsToAddress(withdrawRequest.Currency.String(), withdrawRequest.Amount, withdrawRequest.Address)
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Error) > 0 {
+		return "", errors.New(resp.Error)
+	}
+	return "", nil
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -219,19 +219,19 @@ func (y *Yobit) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, err
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (y *Yobit) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (y *Yobit) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (y *Yobit) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (y *Yobit) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (y *Yobit) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (y *Yobit) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -31,6 +31,7 @@ const (
 	zbTickers                         = "allTicker"
 	zbDepth                           = "depth"
 	zbUnfinishedOrdersIgnoreTradeType = "getUnfinishedOrdersIgnoreTradeType"
+	zbWithdraw                        = "withdraw"
 
 	zbAuthRate   = 100
 	zbUnauthRate = 100
@@ -439,4 +440,34 @@ var errorCode = map[int64]string{
 	3008: "Transaction history not found",
 	4001: "API interface is locked",
 	4002: "Request too frequently",
+}
+
+// Withdraw transfers funds
+func (z *ZB) Withdraw(currency, address, safepassword string, amount, fees float64, itransfer bool) (string, error) {
+	type response struct {
+		Code    int    `json:"code"`    // Result code
+		Message string `json:"message"` // Result Message
+		ID      string `json:"id"`      // Withdrawal ID
+	}
+
+	vals := url.Values{}
+	vals.Set("accesskey", z.APIKey)
+	vals.Set("amount", fmt.Sprintf("%v", amount))
+	vals.Set("currency", currency)
+	vals.Set("fees", fmt.Sprintf("%v", fees))
+	vals.Set("itransfer", fmt.Sprintf("%v", itransfer))
+	vals.Set("method", "withdraw")
+	vals.Set("recieveAddr", address)
+	vals.Set("safePwd", safepassword)
+
+	var resp response
+	err := z.SendAuthenticatedHTTPRequest("GET", zbWithdraw, vals, &resp)
+	if err != nil {
+		return "", err
+	}
+	if resp.Code != 1000 {
+		return "", errors.New(resp.Message)
+	}
+
+	return resp.ID, nil
 }

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -232,7 +232,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 
 // Any tests below this line have the ability to impact your orders on the exchange. Enable canManipulateRealOrders to run them
 // ----------------------------------------------------------------------------------------------------------------------------
-func isRealOrderTestEnabled() bool {
+func isAuthenticatedRequest() bool {
 	if z.APIKey == "" || z.APISecret == "" ||
 		z.APIKey == "Key" || z.APISecret == "Secret" ||
 		!canManipulateRealOrders {
@@ -245,7 +245,7 @@ func TestSubmitOrder(t *testing.T) {
 	z.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
+	if !isAuthenticatedRequest() {
 		t.Skip(fmt.Sprintf("ApiKey: %s. Can place orders: %v", z.APIKey, canManipulateRealOrders))
 	}
 	var pair = pair.CurrencyPair{
@@ -264,8 +264,8 @@ func TestCancelExchangeOrder(t *testing.T) {
 	z.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)
@@ -291,8 +291,8 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	z.SetDefaults()
 	TestSetup(t)
 
-	if !isRealOrderTestEnabled() {
-		t.Skip()
+		if skipRealOrderTest() {
+		t.Skip("API keys set, canManipulateRealOrders false, skipping test")
 	}
 
 	currencyPair := pair.NewCurrencyPair(symbol.LTC, symbol.BTC)

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -250,7 +250,7 @@ func (z *ZB) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error)
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
 func (z *ZB) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
-	return "", common.ErrNotYetImplemented
+	return z.Withdraw(withdrawRequest.Currency.Lower().String(), withdrawRequest.Address, withdrawRequest.TradePassword, withdrawRequest.Amount, withdrawRequest.FeeAmount, false)
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -249,19 +249,19 @@ func (z *ZB) GetDepositAddress(cryptocurrency pair.CurrencyItem) (string, error)
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func (z *ZB) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func (z *ZB) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a
 // withdrawal is submitted
-func (z *ZB) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func (z *ZB) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a
 // withdrawal is submitted
-func (z *ZB) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func (z *ZB) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/tools/exchange_template/wrapper_file.tmpl
+++ b/tools/exchange_template/wrapper_file.tmpl
@@ -154,19 +154,19 @@ func ({{.Variable}} *{{.CapitalName}}) GetDepositAddress(cryptocurrency pair.Cur
 
 // WithdrawCryptocurrencyFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func ({{.Variable}} *{{.CapitalName}}) WithdrawCryptocurrencyFunds(address string, cryptocurrency pair.CurrencyItem, amount float64) (string, error) {
+func ({{.Variable}} *{{.CapitalName}}) WithdrawCryptocurrencyFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFunds returns a withdrawal ID when a withdrawal is
 // submitted
-func ({{.Variable}} *{{.CapitalName}}) WithdrawFiatFunds(currency pair.CurrencyItem, amount float64) (string, error) {
+func ({{.Variable}} *{{.CapitalName}}) WithdrawFiatFunds(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 
 // WithdrawFiatFundsToInternationalBank returns a withdrawal ID when a withdrawal is
 // submitted
-func ({{.Variable}} *{{.CapitalName}}) WithdrawFiatFundsToInternationalBank(currency pair.CurrencyItem, amount float64) (string, error) {
+func ({{.Variable}} *{{.CapitalName}}) WithdrawFiatFundsToInternationalBank(withdrawRequest exchange.WithdrawRequest) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 


### PR DESCRIPTION
# Description

This maps wrapper functions for all exchanges for `WithdrawCryptocurrencyFunds`. It implements cryptocurrency withdrawals on exchanges where it was not implemented. It updates how real order tests are run to increase code coverage and legibility.
## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
`TestWithdraw` has been added to each exchange's test file. Below are notes for running the test on each exchange:

Exchange | Implemented | Tested | Notes
------------ | ------------- | ------------- | ------------- 
Alphapoint | n | n | Difficult to programmatically handle. Each exchange withdrawal template requires their own fields which would need to be manually mapped. No account means I cannot retrieve the required fields to populate requests.  To be addressed in a future PR
ANX | y | n | Our ANX implementation is returning 'UNAUTHORIZED' for all authorised endpoints and will be fixed in a separate PR
Binance | y | y | 
Bitfinex | y | y | 
Bitflyer | n | n | Account creation is closed and authorised endpoints have not been implemented. This will be fixed in a separate PR
Bithumb | y | n | Unable to activate API
Bitmex | y | y | 
Bitstamp | y | y | 
Bittrex | y | n | Testing passes signature verification, however recieve a response that it is unable to process request
BTCC | n | n | BTCC authenticated endpoints are not implemented. This will be fixed in a separate PR
BTCMarkets | y | y | 
CoinbasePro | y | n | Unable to activate API
Coinut | n | n | No ability to withdraw via API
Exmo | y | n | Unable to activate API
GateIO | y | y | 
Gemini | y | n | Sandbox API does not permit withdraw requests
HitBTC | y | y | 
Huobi | y | y | 
Huobi/Hadax | y | y | 
ItBit | n | n | No ability to withdraw via API
Kraken | y | y | 
LakeBTC | y | y | 
Liqui | y | n | Cannot properly sign up to Liqui, preventing testing
Localbitcoins | y | n | Not verified. Required for testing endpoint
OKCoin | y | y | 
OKEx | y | y | 
Poloniex | y | y | 
Wex | y | n | Wex is still facing issues and cannot be tested
Yobit | y | n | Yobit doesn't send me account creation emails, can't create API keys
ZB | y | n | Requires verification to add a withdrawal wallet

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules