### PR TITLE
fix wrong type of the huobi account data struct

### DIFF
--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -110,7 +110,7 @@ type Symbol struct {
 type Account struct {
 	ID     int64  `json:"id"`
 	Type   string `json:"type"`
-	State  string `json:"working"`
+	State  string `json:"state"`
 	UserID int64  `json:"user-id"`
 }
 


### PR DESCRIPTION
# Description
There is a wrong of typing in file huobi_type.go 
_type Account struct {
	ID     int64  `json:"id"`
	Type   string `json:"type"`
	State  string `json:"**working**"`
	UserID int64  `json:"user-id"`
}_
Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Please also consider improving test coverage whilst working on a certain package

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules