### PR TITLE
Added config option to enable pprof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,5 @@ profile_heap:
 	go tool pprof -http "localhost:$(GCTPROFILERLISTENPORT)" 'http://localhost:$(GCTLISTENPORT)/debug/pprof/heap'
 	
 .PHONY: profile_cpu
-.profile_cpu:
-	go tool pprof -http "localhost:$(GCTPROFILERLISTENPORT)" 'http://localhost:$(GCTLISTENPORT)/debug/pprof/cpu'
+profile_cpu:
+	go tool pprof -http "localhost:$(GCTPROFILERLISTENPORT)" 'http://localhost:$(GCTLISTENPORT)/debug/pprof/profile'

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ LDFLAGS = -ldflags "-w -s"
 GCTPKG = github.com/thrasher-/gocryptotrader
 LINTPKG = github.com/golangci/golangci-lint/cmd/golangci-lint@v1.15.0
 LINTBIN = $(GOPATH)/bin/golangci-lint
+GCTLISTENPORT=9050
+GCTPROFILERLISTENPORT=8085
 
 get:
 	GO111MODULE=on go get $(GCTPKG)
@@ -30,3 +32,11 @@ update_deps:
 	GO111MODULE=on go mod tidy
 	rm -rf vendor
 	GO111MODULE=on go mod vendor
+
+.PHONY: profile_heap
+profile_heap:
+	go tool pprof -http "localhost:$(GCTPROFILERLISTENPORT)" 'http://localhost:$(GCTLISTENPORT)/debug/pprof/heap'
+	
+.PHONY: profile_cpu
+.profile_cpu:
+	go tool pprof -http "localhost:$(GCTPROFILERLISTENPORT)" 'http://localhost:$(GCTLISTENPORT)/debug/pprof/cpu'

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	EncryptConfig     int                  `json:"encryptConfig"`
 	GlobalHTTPTimeout time.Duration        `json:"globalHTTPTimeout"`
 	Logging           log.Logging          `json:"logging"`
+	Profiler          ProfilerConfig       `json:"profiler"`
 	Currency          CurrencyConfig       `json:"currencyConfig"`
 	Communications    CommunicationsConfig `json:"communications"`
 	Portfolio         portfolio.Base       `json:"portfolioAddresses"`
@@ -116,6 +117,10 @@ type Config struct {
 	FiatDisplayCurrency string                    `json:"fiatDispayCurrency,omitempty"`
 	Cryptocurrencies    string                    `json:"cryptocurrencies,omitempty"`
 	SMS                 *SMSGlobalConfig          `json:"smsGlobal,omitempty"`
+}
+
+type ProfilerConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 // ExchangeConfig holds all the information needed for each enabled Exchange.

--- a/config_example.json
+++ b/config_example.json
@@ -9,6 +9,9 @@
   "level": "DEBUG|WARN|INFO|ERROR|FATAL",
   "rotate": false
  },
+ "profiler": {
+    "enabled": false
+   },
  "currencyConfig": {
   "forexProviders": [
    {

--- a/restful_router.go
+++ b/restful_router.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/gorilla/mux"
 	log "github.com/thrasher-/gocryptotrader/logger"
+
+	_ "net/http/pprof"
 )
 
 // RESTLogger logs the requests internally
@@ -114,6 +116,12 @@ func NewRouter() *mux.Router {
 			Name(route.Name).
 			Handler(RESTLogger(route.HandlerFunc, route.Name))
 	}
+
+	if bot.config.Profiler.Enabled {
+		log.Debugln("Profiler enabled")
+		router.PathPrefix("/debug").Handler(http.DefaultServeMux)
+	}
+
 	return router
 }
 

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -9,6 +9,9 @@
   "level": "DEBUG|WARN|INFO|ERROR|FATAL",
   "rotate": true
  },
+ "profiler": {
+    "enabled": false
+   },
  "currencyConfig": {
   "forexProviders": [
    {


### PR DESCRIPTION
# Description

Simple PR to enable pprof for ongoing performance testing

It adds a profiler config option that is disabled by default along with some Makefile aliases for ease of access with the net/http/pprof package for heap and CPU profiling

At the moment it listens on the same address as the REST interface this may change in future

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Automated testing using go test ./.. confirms all existing tests pass
Manual testing confirms pprof is working as intended when enabled

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules