### PR TITLE
OKEX websocket: Fix test race condition

### DIFF
--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -21,24 +21,12 @@ const (
 	canManipulateRealOrders = false
 )
 
-var o = OKCoin{}
+var o OKCoin
 var testSetupRan bool
 var spotCurrency = currency.NewPairWithDelimiter(currency.BTC.String(), currency.USD.String(), "-").Lower().String()
 
 // TestSetDefaults Sets standard default settings for running a test
 func TestSetDefaults(t *testing.T) {
-	if o.Name != OKGroupExchange {
-		o.SetDefaults()
-	}
-	if o.GetName() != OKGroupExchange {
-		t.Errorf("Test Failed - %v - SetDefaults() error", OKGroupExchange)
-	}
-	TestSetup(t)
-	t.Parallel()
-}
-
-// TestSetWsDefaults Sets websocket defaults
-func TestSetWsDefaults(t *testing.T) {
 	if o.Name != OKGroupExchange {
 		o.SetDefaults()
 	}
@@ -852,10 +840,8 @@ func TestWsLogin(t *testing.T) {
 
 // TestSubscribeToChannel API endpoint test
 func TestSubscribeToChannel(t *testing.T) {
-	defer disconnectFromWS()
-	TestSetWsDefaults(t)
+	TestSetDefaults(t)
 	if o.WebsocketConn == nil {
-		o.Websocket.Shutdown()
 		err := setupWSConnection()
 		if err != nil {
 			t.Error(err)
@@ -864,6 +850,7 @@ func TestSubscribeToChannel(t *testing.T) {
 	if !o.Websocket.IsConnected() {
 		t.Skip()
 	}
+	defer disconnectFromWS()
 	channelName := "spot/depth:LTC-BTC"
 	err := o.WsSubscribeToChannel(channelName)
 	if err != nil {
@@ -890,7 +877,7 @@ func TestSubscribeToChannel(t *testing.T) {
 // Then captures the error response
 func TestSubscribeToNonExistantChannel(t *testing.T) {
 	defer disconnectFromWS()
-	TestSetWsDefaults(t)
+	TestSetDefaults(t)
 	if o.WebsocketConn == nil {
 		o.Websocket.Shutdown()
 		err := setupWSConnection()


### PR DESCRIPTION
# Description

Fixes race condition in okcoin tests

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

go test ./... -race

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules