### PR TITLE
Optimisation: large structs/huge param fixes (part 2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,7 @@ linters-settings:
       - experimental
     disabled-checks:
       - wrapperFunc
-    #  - hugeParam
+      - hugeParam
       - importShadow
       - rangeValCopy
       - methodExprCall

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,7 @@ linters-settings:
       - experimental
     disabled-checks:
       - wrapperFunc
-      - hugeParam
+    #  - hugeParam
       - importShadow
       - rangeValCopy
       - methodExprCall

--- a/currency/code.go
+++ b/currency/code.go
@@ -347,7 +347,7 @@ func (b *BaseCodes) RegisterFiat(c string) (Code, error) {
 }
 
 // LoadItem sets item data
-func (b *BaseCodes) LoadItem(item Item) error {
+func (b *BaseCodes) LoadItem(item *Item) error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	for i := range b.Items {
@@ -386,7 +386,7 @@ func (b *BaseCodes) LoadItem(item Item) error {
 		}
 	}
 
-	b.Items = append(b.Items, &item)
+	b.Items = append(b.Items, item)
 	return nil
 }
 
@@ -414,7 +414,7 @@ type Item struct {
 }
 
 // String conforms to the stringer interface
-func (i Item) String() string {
+func (i *Item) String() string {
 	return i.FullName
 }
 

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -213,7 +213,7 @@ func TestBaseCode(t *testing.T) {
 			true)
 	}
 
-	err = main.LoadItem(Item{
+	err = main.LoadItem(&Item{
 		ID:       0,
 		FullName: "Cardano",
 		Role:     Cryptocurrency,
@@ -421,6 +421,6 @@ func TestItemString(t *testing.T) {
 	if newItem.String() != expected {
 		t.Errorf("Test Failed - Item String() error expected %s but recieved %s",
 			expected,
-			newItem)
+			&newItem)
 	}
 }

--- a/currency/forexprovider/forexprovider.go
+++ b/currency/forexprovider/forexprovider.go
@@ -130,7 +130,7 @@ func StartFXService(fxProviders []base.Settings) (*ForexProviders, error) {
 	}
 
 	if handler.Primary.Provider == nil {
-		return nil, errors.New("no foreign exchange providers enabled")
+		return nil, errors.New("no Foreign primary provider enabled")
 	}
 
 	return handler, nil

--- a/currency/forexprovider/forexprovider.go
+++ b/currency/forexprovider/forexprovider.go
@@ -130,7 +130,7 @@ func StartFXService(fxProviders []base.Settings) (*ForexProviders, error) {
 	}
 
 	if handler.Primary.Provider == nil {
-		return nil, errors.New("no Foreign primary provider enabled")
+		return nil, errors.New("no primary forex provider enabled")
 	}
 
 	return handler, nil

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -370,41 +370,37 @@ func (s *Storage) WriteCurrencyDataToFile(path string, mainUpdate bool) error {
 
 // LoadFileCurrencyData loads currencies into the currency codes
 func (s *Storage) LoadFileCurrencyData(f *File) error {
-	for _, contract := range f.Contracts {
-		contract := contract
-		err := s.currencyCodes.LoadItem(&contract)
+
+	for i := range f.Contracts {
+		err := s.currencyCodes.LoadItem(&f.Contracts[i])
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, crypto := range f.Cryptocurrency {
-		crypto := crypto
-		err := s.currencyCodes.LoadItem(&crypto)
+	for i := range f.Cryptocurrency {
+		err := s.currencyCodes.LoadItem(&f.Cryptocurrency[i])
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, fiat := range f.FiatCurrency {
-		fiat := fiat
-		err := s.currencyCodes.LoadItem(&fiat)
+	for i := range f.Token {
+		err := s.currencyCodes.LoadItem(&f.Token[i])
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, token := range f.Token {
-		token := token
-		err := s.currencyCodes.LoadItem(&token)
+	for i := range f.FiatCurrency {
+		err := s.currencyCodes.LoadItem(&f.FiatCurrency[i])
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, unset := range f.UnsetCurrency {
-		unset := unset
-		err := s.currencyCodes.LoadItem(&unset)
+	for i := range f.UnsetCurrency {
+		err := s.currencyCodes.LoadItem(&f.UnsetCurrency[i])
 		if err != nil {
 			return err
 		}

--- a/currency/storage.go
+++ b/currency/storage.go
@@ -316,7 +316,7 @@ func (s *Storage) SeedCurrencyAnalysisData() error {
 		return err
 	}
 
-	err = s.LoadFileCurrencyData(fromFile)
+	err = s.LoadFileCurrencyData(&fromFile)
 	if err != nil {
 		return err
 	}
@@ -369,37 +369,42 @@ func (s *Storage) WriteCurrencyDataToFile(path string, mainUpdate bool) error {
 }
 
 // LoadFileCurrencyData loads currencies into the currency codes
-func (s *Storage) LoadFileCurrencyData(f File) error {
+func (s *Storage) LoadFileCurrencyData(f *File) error {
 	for _, contract := range f.Contracts {
-		err := s.currencyCodes.LoadItem(contract)
+		contract := contract
+		err := s.currencyCodes.LoadItem(&contract)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, crypto := range f.Cryptocurrency {
-		err := s.currencyCodes.LoadItem(crypto)
+		crypto := crypto
+		err := s.currencyCodes.LoadItem(&crypto)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, fiat := range f.FiatCurrency {
-		err := s.currencyCodes.LoadItem(fiat)
+		fiat := fiat
+		err := s.currencyCodes.LoadItem(&fiat)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, token := range f.Token {
-		err := s.currencyCodes.LoadItem(token)
+		token := token
+		err := s.currencyCodes.LoadItem(&token)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, unset := range f.UnsetCurrency {
-		err := s.currencyCodes.LoadItem(unset)
+		unset := unset
+		err := s.currencyCodes.LoadItem(&unset)
 		if err != nil {
 			return err
 		}

--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -619,7 +619,7 @@ func TestModifyOrder(t *testing.T) {
 	a := &Alphapoint{}
 	a.SetDefaults()
 
-	_, err := a.ModifyOrder(exchange.ModifyOrder{})
+	_, err := a.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/alphapoint/alphapoint_wrapper.go
+++ b/exchanges/alphapoint/alphapoint_wrapper.go
@@ -152,7 +152,7 @@ func (a *Alphapoint) SubmitOrder(p currency.Pair, side exchange.OrderSide, order
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (a *Alphapoint) ModifyOrder(_ exchange.ModifyOrder) (string, error) {
+func (a *Alphapoint) ModifyOrder(_ *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -355,7 +355,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := a.ModifyOrder(exchange.ModifyOrder{})
+	_, err := a.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -289,7 +289,7 @@ func (a *ANX) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType ex
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (a *ANX) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (a *ANX) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -437,7 +437,7 @@ func (b *Binance) GetBestPrice(symbol string) (BestPrice, error) {
 }
 
 // NewOrder sends a new order to Binance
-func (b *Binance) NewOrder(o NewOrderRequest) (NewOrderResponse, error) {
+func (b *Binance) NewOrder(o *NewOrderRequest) (NewOrderResponse, error) {
 	var resp NewOrderResponse
 
 	path := fmt.Sprintf("%s%s", b.APIUrl, newOrder)

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -466,7 +466,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := b.ModifyOrder(exchange.ModifyOrder{})
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -143,7 +143,7 @@ func TestNewOrder(t *testing.T) {
 	if testAPIKey == "" || testAPISecret == "" {
 		t.Skip()
 	}
-	_, err := b.NewOrder(NewOrderRequest{
+	_, err := b.NewOrder(&NewOrderRequest{
 		Symbol:      "BTCUSDT",
 		Side:        BinanceRequestParamsSideSell,
 		TradeType:   BinanceRequestParamsOrderLimit,

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -61,7 +61,7 @@ func (b *Binance) SeedLocalCache(p currency.Pair) error {
 	newOrderBook.Pair = currency.NewPairFromString(formattedPair.String())
 	newOrderBook.AssetType = ticker.Spot
 
-	return b.Websocket.Orderbook.LoadSnapshot(newOrderBook, b.GetName(), false)
+	return b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, b.GetName(), false)
 }
 
 // UpdateLocalCache updates and returns the most recent iteration of the orderbook

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -65,7 +65,7 @@ func (b *Binance) SeedLocalCache(p currency.Pair) error {
 }
 
 // UpdateLocalCache updates and returns the most recent iteration of the orderbook
-func (b *Binance) UpdateLocalCache(ob WebsocketDepthStream) error {
+func (b *Binance) UpdateLocalCache(ob *WebsocketDepthStream) error {
 	m.Lock()
 	ID, ok := lastUpdateID[ob.Pair]
 	if !ok {
@@ -323,7 +323,7 @@ func (b *Binance) WsHandleData() {
 						continue
 					}
 
-					err = b.UpdateLocalCache(depth)
+					err = b.UpdateLocalCache(&depth)
 					if err != nil {
 						b.Websocket.DataHandler <- fmt.Errorf("binance_websocket.go - UpdateLocalCache error: %s",
 							err)

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -232,7 +232,7 @@ func (b *Binance) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderTyp
 		TimeInForce: BinanceRequestParamsTimeGTC,
 	}
 
-	response, err := b.NewOrder(orderRequest)
+	response, err := b.NewOrder(&orderRequest)
 
 	if response.OrderID > 0 {
 		submitOrderResponse.OrderID = fmt.Sprintf("%v", response.OrderID)

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -247,7 +247,7 @@ func (b *Binance) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderTyp
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Binance) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *Binance) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -823,7 +823,7 @@ func TestCancelAllExchangeOrdera(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := b.ModifyOrder(exchange.ModifyOrder{})
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -522,13 +522,13 @@ func (b *Bitfinex) WsInsertSnapshot(p currency.Pair, assetType string, books []W
 		return errors.New("bitfinex.go error - no orderbooks in item lists")
 	}
 
-	var newOrderbook orderbook.Base
-	newOrderbook.Asks = ask
-	newOrderbook.AssetType = assetType
-	newOrderbook.Bids = bid
-	newOrderbook.Pair = p
+	var newOrderBook orderbook.Base
+	newOrderBook.Asks = ask
+	newOrderBook.AssetType = assetType
+	newOrderBook.Bids = bid
+	newOrderBook.Pair = p
 
-	err := b.Websocket.Orderbook.LoadSnapshot(newOrderbook, b.GetName(), false)
+	err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, b.GetName(), false)
 	if err != nil {
 		return fmt.Errorf("bitfinex.go error - %s", err)
 	}

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -216,7 +216,7 @@ func (b *Bitfinex) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderTy
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bitfinex) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *Bitfinex) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -369,7 +369,7 @@ func TestWithdraw(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := b.ModifyOrder(exchange.ModifyOrder{})
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -173,7 +173,7 @@ func (b *Bitflyer) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderTy
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bitflyer) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *Bitflyer) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -421,7 +421,7 @@ func TestGetAccountInfo(t *testing.T) {
 
 func TestModifyOrder(t *testing.T) {
 	curr := currency.NewPairFromString("BTCUSD")
-	_, err := b.ModifyOrder(exchange.ModifyOrder{OrderID: "1337",
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{OrderID: "1337",
 		Price:        100,
 		Amount:       1000,
 		OrderSide:    exchange.SellOrderSide,

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -215,7 +215,7 @@ func (b *Bithumb) SubmitOrder(p currency.Pair, side exchange.OrderSide, _ exchan
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bithumb) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *Bithumb) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	order, err := b.ModifyTrade(action.OrderID,
 		action.CurrencyPair.Base.String(),
 		common.StringToLower(action.OrderSide.ToString()),

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -278,7 +278,7 @@ func (b *Bitmex) GetTrollboxConnectedUsers() (ConnectedUsers, error) {
 // GetAccountExecutions returns all raw transactions, which includes order
 // opening and cancelation, and order status changes. It can be quite noisy.
 // More focused information is available at /execution/tradeHistory.
-func (b *Bitmex) GetAccountExecutions(params GenericRequestParams) ([]Execution, error) {
+func (b *Bitmex) GetAccountExecutions(params *GenericRequestParams) ([]Execution, error) {
 	var executionList []Execution
 
 	return executionList, b.SendAuthenticatedHTTPRequest(http.MethodGet,
@@ -289,7 +289,7 @@ func (b *Bitmex) GetAccountExecutions(params GenericRequestParams) ([]Execution,
 
 // GetAccountExecutionTradeHistory returns all balance-affecting executions.
 // This includes each trade, insurance charge, and settlement.
-func (b *Bitmex) GetAccountExecutionTradeHistory(params GenericRequestParams) ([]Execution, error) {
+func (b *Bitmex) GetAccountExecutionTradeHistory(params *GenericRequestParams) ([]Execution, error) {
 	var tradeHistory []Execution
 
 	return tradeHistory, b.SendAuthenticatedHTTPRequest(http.MethodGet,
@@ -308,7 +308,7 @@ func (b *Bitmex) GetFullFundingHistory() ([]Funding, error) {
 }
 
 // GetInstruments returns instrument data
-func (b *Bitmex) GetInstruments(params GenericRequestParams) ([]Instrument, error) {
+func (b *Bitmex) GetInstruments(params *GenericRequestParams) ([]Instrument, error) {
 	var instruments []Instrument
 
 	return instruments, b.SendHTTPRequest(bitmexEndpointInstruments,
@@ -317,7 +317,7 @@ func (b *Bitmex) GetInstruments(params GenericRequestParams) ([]Instrument, erro
 }
 
 // GetActiveInstruments returns active instruments
-func (b *Bitmex) GetActiveInstruments(params GenericRequestParams) ([]Instrument, error) {
+func (b *Bitmex) GetActiveInstruments(params *GenericRequestParams) ([]Instrument, error) {
 	var activeInstruments []Instrument
 
 	return activeInstruments, b.SendHTTPRequest(bitmexEndpointActiveInstruments,
@@ -345,7 +345,7 @@ func (b *Bitmex) GetActiveIntervals() (InstrumentInterval, error) {
 }
 
 // GetCompositeIndex returns composite index
-func (b *Bitmex) GetCompositeIndex(params GenericRequestParams) ([]IndexComposite, error) {
+func (b *Bitmex) GetCompositeIndex(params *GenericRequestParams) ([]IndexComposite, error) {
 	var compositeIndices []IndexComposite
 
 	return compositeIndices, b.SendHTTPRequest(bitmexEndpointCompositeIndex,
@@ -361,7 +361,7 @@ func (b *Bitmex) GetIndices() ([]Instrument, error) {
 }
 
 // GetInsuranceFundHistory returns insurance fund history
-func (b *Bitmex) GetInsuranceFundHistory(params GenericRequestParams) ([]Insurance, error) {
+func (b *Bitmex) GetInsuranceFundHistory(params *GenericRequestParams) ([]Insurance, error) {
 	var history []Insurance
 
 	return history, b.SendHTTPRequest(bitmexEndpointIndices, params, &history)
@@ -382,7 +382,7 @@ func (b *Bitmex) GetAliasOnLeaderboard() (Alias, error) {
 }
 
 // GetLiquidationOrders returns liquidation orders
-func (b *Bitmex) GetLiquidationOrders(params GenericRequestParams) ([]Liquidation, error) {
+func (b *Bitmex) GetLiquidationOrders(params *GenericRequestParams) ([]Liquidation, error) {
 	var orders []Liquidation
 
 	return orders, b.SendHTTPRequest(bitmexEndpointLiquidation,
@@ -401,7 +401,7 @@ func (b *Bitmex) GetCurrentNotifications() ([]Notification, error) {
 }
 
 // GetOrders returns all the orders, open and closed
-func (b *Bitmex) GetOrders(params OrdersRequest) ([]Order, error) {
+func (b *Bitmex) GetOrders(params *OrdersRequest) ([]Order, error) {
 	var orders []Order
 
 	return orders, b.SendAuthenticatedHTTPRequest(http.MethodGet,
@@ -411,7 +411,7 @@ func (b *Bitmex) GetOrders(params OrdersRequest) ([]Order, error) {
 }
 
 // AmendOrder amends the quantity or price of an open order
-func (b *Bitmex) AmendOrder(params OrderAmendParams) (Order, error) {
+func (b *Bitmex) AmendOrder(params *OrderAmendParams) (Order, error) {
 	var order Order
 
 	return order, b.SendAuthenticatedHTTPRequest(http.MethodPut,
@@ -421,7 +421,7 @@ func (b *Bitmex) AmendOrder(params OrderAmendParams) (Order, error) {
 }
 
 // CreateOrder creates a new order
-func (b *Bitmex) CreateOrder(params OrderNewParams) (Order, error) {
+func (b *Bitmex) CreateOrder(params *OrderNewParams) (Order, error) {
 	var orderInfo Order
 
 	return orderInfo, b.SendAuthenticatedHTTPRequest(http.MethodPost,
@@ -432,7 +432,7 @@ func (b *Bitmex) CreateOrder(params OrderNewParams) (Order, error) {
 
 // CancelOrders cancels one or a batch of orders on the exchange and returns
 // a cancelled order list
-func (b *Bitmex) CancelOrders(params OrderCancelParams) ([]Order, error) {
+func (b *Bitmex) CancelOrders(params *OrderCancelParams) ([]Order, error) {
 	var cancelledOrders []Order
 
 	return cancelledOrders, b.SendAuthenticatedHTTPRequest(http.MethodDelete,
@@ -551,7 +551,7 @@ func (b *Bitmex) TransferMargin(params PositionTransferIsolatedMarginParams) (Po
 }
 
 // GetQuotes returns quotations
-func (b *Bitmex) GetQuotes(params GenericRequestParams) ([]Quote, error) {
+func (b *Bitmex) GetQuotes(params *GenericRequestParams) ([]Quote, error) {
 	var quotations []Quote
 
 	return quotations, b.SendHTTPRequest(bitmexEndpointQuote,
@@ -560,7 +560,7 @@ func (b *Bitmex) GetQuotes(params GenericRequestParams) ([]Quote, error) {
 }
 
 // GetQuotesByBuckets returns previous quotes in time buckets
-func (b *Bitmex) GetQuotesByBuckets(params QuoteGetBucketedParams) ([]Quote, error) {
+func (b *Bitmex) GetQuotesByBuckets(params *QuoteGetBucketedParams) ([]Quote, error) {
 	var quotations []Quote
 
 	return quotations, b.SendHTTPRequest(bitmexEndpointQuoteBucketed,
@@ -569,7 +569,7 @@ func (b *Bitmex) GetQuotesByBuckets(params QuoteGetBucketedParams) ([]Quote, err
 }
 
 // GetSettlementHistory returns settlement history
-func (b *Bitmex) GetSettlementHistory(params GenericRequestParams) ([]Settlement, error) {
+func (b *Bitmex) GetSettlementHistory(params *GenericRequestParams) ([]Settlement, error) {
 	var history []Settlement
 
 	return history, b.SendHTTPRequest(bitmexEndpointSettlement,
@@ -599,14 +599,14 @@ func (b *Bitmex) GetStatSummary() ([]StatsUSD, error) {
 }
 
 // GetTrade returns executed trades on the desk
-func (b *Bitmex) GetTrade(params GenericRequestParams) ([]Trade, error) {
+func (b *Bitmex) GetTrade(params *GenericRequestParams) ([]Trade, error) {
 	var trade []Trade
 
 	return trade, b.SendHTTPRequest(bitmexEndpointTrade, params, &trade)
 }
 
 // GetPreviousTrades previous trade history in time buckets
-func (b *Bitmex) GetPreviousTrades(params TradeGetBucketedParams) ([]Trade, error) {
+func (b *Bitmex) GetPreviousTrades(params *TradeGetBucketedParams) ([]Trade, error) {
 	var trade []Trade
 
 	return trade, b.SendHTTPRequest(bitmexEndpointTradeBucketed,
@@ -625,7 +625,7 @@ func (b *Bitmex) GetUserInfo() (User, error) {
 }
 
 // UpdateUserInfo updates user information
-func (b *Bitmex) UpdateUserInfo(params UserUpdateParams) (User, error) {
+func (b *Bitmex) UpdateUserInfo(params *UserUpdateParams) (User, error) {
 	var userInfo User
 
 	return userInfo, b.SendAuthenticatedHTTPRequest(http.MethodPut,

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -110,14 +110,14 @@ func TestGetTrollboxConnectedUsers(t *testing.T) {
 }
 
 func TestGetAccountExecutions(t *testing.T) {
-	_, err := b.GetAccountExecutions(GenericRequestParams{})
+	_, err := b.GetAccountExecutions(&GenericRequestParams{})
 	if err == nil {
 		t.Error("test failed - GetAccountExecutions() error", err)
 	}
 }
 
 func TestGetAccountExecutionTradeHistory(t *testing.T) {
-	_, err := b.GetAccountExecutionTradeHistory(GenericRequestParams{})
+	_, err := b.GetAccountExecutionTradeHistory(&GenericRequestParams{})
 	if err == nil {
 		t.Error("test failed - GetAccountExecutionTradeHistory() error", err)
 	}
@@ -131,14 +131,14 @@ func TestGetFundingHistory(t *testing.T) {
 }
 
 func TestGetInstruments(t *testing.T) {
-	_, err := b.GetInstruments(GenericRequestParams{})
+	_, err := b.GetInstruments(&GenericRequestParams{})
 	if err != nil {
 		t.Error("test failed - GetInstruments() error", err)
 	}
 }
 
 func TestGetActiveInstruments(t *testing.T) {
-	_, err := b.GetActiveInstruments(GenericRequestParams{})
+	_, err := b.GetActiveInstruments(&GenericRequestParams{})
 	if err != nil {
 		t.Error("test failed - GetActiveInstruments() error", err)
 	}
@@ -159,7 +159,7 @@ func TestGetActiveIntervals(t *testing.T) {
 }
 
 func TestGetCompositeIndex(t *testing.T) {
-	_, err := b.GetCompositeIndex(GenericRequestParams{})
+	_, err := b.GetCompositeIndex(&GenericRequestParams{})
 	if err == nil {
 		t.Error("test failed - GetCompositeIndex() error", err)
 	}
@@ -173,7 +173,7 @@ func TestGetIndices(t *testing.T) {
 }
 
 func TestGetInsuranceFundHistory(t *testing.T) {
-	_, err := b.GetInsuranceFundHistory(GenericRequestParams{})
+	_, err := b.GetInsuranceFundHistory(&GenericRequestParams{})
 	if err != nil {
 		t.Error("test failed - GetInsuranceFundHistory() error", err)
 	}
@@ -194,7 +194,7 @@ func TestGetAliasOnLeaderboard(t *testing.T) {
 }
 
 func TestGetLiquidationOrders(t *testing.T) {
-	_, err := b.GetLiquidationOrders(GenericRequestParams{})
+	_, err := b.GetLiquidationOrders(&GenericRequestParams{})
 	if err != nil {
 		t.Error("test failed - GetLiquidationOrders() error", err)
 	}
@@ -208,14 +208,14 @@ func TestGetCurrentNotifications(t *testing.T) {
 }
 
 func TestAmendOrder(t *testing.T) {
-	_, err := b.AmendOrder(OrderAmendParams{})
+	_, err := b.AmendOrder(&OrderAmendParams{})
 	if err == nil {
 		t.Error("test failed - AmendOrder() error", err)
 	}
 }
 
 func TestCreateOrder(t *testing.T) {
-	_, err := b.CreateOrder(OrderNewParams{Symbol: "XBTM15",
+	_, err := b.CreateOrder(&OrderNewParams{Symbol: "XBTM15",
 		Price:    219.0,
 		ClOrdID:  "mm_bitmex_1a/oemUeQ4CAJZgP3fjHsA",
 		OrderQty: 98})
@@ -225,7 +225,7 @@ func TestCreateOrder(t *testing.T) {
 }
 
 func TestCancelOrders(t *testing.T) {
-	_, err := b.CancelOrders(OrderCancelParams{})
+	_, err := b.CancelOrders(&OrderCancelParams{})
 	if err == nil {
 		t.Error("test failed - CancelOrders() error", err)
 	}
@@ -309,14 +309,14 @@ func TestTransferMargin(t *testing.T) {
 }
 
 func TestGetQuotesByBuckets(t *testing.T) {
-	_, err := b.GetQuotesByBuckets(QuoteGetBucketedParams{})
+	_, err := b.GetQuotesByBuckets(&QuoteGetBucketedParams{})
 	if err == nil {
 		t.Error("test failed - GetQuotesByBuckets() error", err)
 	}
 }
 
 func TestGetSettlementHistory(t *testing.T) {
-	_, err := b.GetSettlementHistory(GenericRequestParams{})
+	_, err := b.GetSettlementHistory(&GenericRequestParams{})
 	if err != nil {
 		t.Error("test failed - GetSettlementHistory() error", err)
 	}
@@ -344,7 +344,7 @@ func TestGetStatSummary(t *testing.T) {
 }
 
 func TestGetTrade(t *testing.T) {
-	_, err := b.GetTrade(GenericRequestParams{
+	_, err := b.GetTrade(&GenericRequestParams{
 		Symbol:    "XBTUSD",
 		StartTime: time.Now().Format(time.RFC3339),
 		Reverse:   true})
@@ -354,7 +354,7 @@ func TestGetTrade(t *testing.T) {
 }
 
 func TestGetPreviousTrades(t *testing.T) {
-	_, err := b.GetPreviousTrades(TradeGetBucketedParams{})
+	_, err := b.GetPreviousTrades(&TradeGetBucketedParams{})
 	if err == nil {
 		t.Error("test failed - GetPreviousTrades() error", err)
 	}

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -590,7 +590,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := b.ModifyOrder(exchange.ModifyOrder{OrderID: "1337"})
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{OrderID: "1337"})
 	if err == nil {
 		t.Error("Test Failed - ModifyOrder() error")
 	}

--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -321,7 +321,7 @@ func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, currencyPai
 	switch action {
 	case bitmexActionInitialData:
 		if !snapshotloaded[currencyPair][assetType] {
-			var newOrderbook orderbook.Base
+			var newOrderBook orderbook.Base
 			var bids, asks []orderbook.Item
 
 			for _, orderbookItem := range data {
@@ -342,12 +342,12 @@ func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, currencyPai
 				return errors.New("bitmex_websocket.go error - snapshot not initialised correctly")
 			}
 
-			newOrderbook.Asks = asks
-			newOrderbook.Bids = bids
-			newOrderbook.AssetType = assetType
-			newOrderbook.Pair = currencyPair
+			newOrderBook.Asks = asks
+			newOrderBook.Bids = bids
+			newOrderBook.AssetType = assetType
+			newOrderBook.Pair = currencyPair
 
-			err := b.Websocket.Orderbook.LoadSnapshot(newOrderbook, b.GetName(), false)
+			err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, b.GetName(), false)
 			if err != nil {
 				return fmt.Errorf("bitmex_websocket.go process orderbook error -  %s",
 					err)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -32,7 +32,7 @@ func (b *Bitmex) Run() {
 		log.Debugf("%s %d currencies enabled: %s.\n", b.GetName(), len(b.EnabledPairs), b.EnabledPairs)
 	}
 
-	marketInfo, err := b.GetActiveInstruments(GenericRequestParams{})
+	marketInfo, err := b.GetActiveInstruments(&GenericRequestParams{})
 	if err != nil {
 		log.Errorf("%s Failed to get available symbols.\n", b.GetName())
 
@@ -60,7 +60,7 @@ func (b *Bitmex) UpdateTicker(p currency.Pair, assetType string) (ticker.Price, 
 	var tickerPrice ticker.Price
 	currency := exchange.FormatExchangeCurrency(b.Name, p)
 
-	tick, err := b.GetTrade(GenericRequestParams{
+	tick, err := b.GetTrade(&GenericRequestParams{
 		Symbol:    currency.String(),
 		StartTime: time.Now().Format(time.RFC3339),
 		Reverse:   true,
@@ -193,7 +193,7 @@ func (b *Bitmex) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType
 		orderNewParams.Price = price
 	}
 
-	response, err := b.CreateOrder(orderNewParams)
+	response, err := b.CreateOrder(&orderNewParams)
 	if response.OrderID != "" {
 		submitOrderResponse.OrderID = response.OrderID
 	}
@@ -218,7 +218,7 @@ func (b *Bitmex) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	params.OrderQty = int32(action.Amount)
 	params.Price = action.Price
 
-	order, err := b.AmendOrder(params)
+	order, err := b.AmendOrder(&params)
 	if err != nil {
 		return "", err
 	}
@@ -231,7 +231,7 @@ func (b *Bitmex) CancelOrder(order *exchange.OrderCancellation) error {
 	var params = OrderCancelParams{
 		OrderID: order.OrderID,
 	}
-	_, err := b.CancelOrders(params)
+	_, err := b.CancelOrders(&params)
 
 	return err
 }
@@ -315,7 +315,7 @@ func (b *Bitmex) GetActiveOrders(getOrdersRequest *exchange.GetOrdersRequest) ([
 	params := OrdersRequest{}
 	params.Filter = "{\"open\":true}"
 
-	resp, err := b.GetOrders(params)
+	resp, err := b.GetOrders(&params)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (b *Bitmex) GetActiveOrders(getOrdersRequest *exchange.GetOrdersRequest) ([
 func (b *Bitmex) GetOrderHistory(getOrdersRequest *exchange.GetOrdersRequest) ([]exchange.OrderDetail, error) {
 	var orders []exchange.OrderDetail
 	params := OrdersRequest{}
-	resp, err := b.GetOrders(params)
+	resp, err := b.GetOrders(&params)
 	if err != nil {
 		return nil, err
 	}

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -207,7 +207,7 @@ func (b *Bitmex) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bitmex) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *Bitmex) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	var params OrderAmendParams
 
 	if math.Mod(action.Amount, 1) != 0 {

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -487,7 +487,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := b.ModifyOrder(exchange.ModifyOrder{})
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/bitstamp/bitstamp_websocket.go
+++ b/exchanges/bitstamp/bitstamp_websocket.go
@@ -107,7 +107,7 @@ func (b *Bitstamp) WsConnect() error {
 			return err
 		}
 
-		var newOrderbook orderbook.Base
+		var newOrderBook orderbook.Base
 
 		var asks []orderbook.Item
 		for _, ask := range orderbookSeed.Asks {
@@ -125,12 +125,12 @@ func (b *Bitstamp) WsConnect() error {
 			bids = append(bids, item)
 		}
 
-		newOrderbook.Asks = asks
-		newOrderbook.Bids = bids
-		newOrderbook.Pair = p
-		newOrderbook.AssetType = "SPOT"
+		newOrderBook.Asks = asks
+		newOrderBook.Bids = bids
+		newOrderBook.Pair = p
+		newOrderBook.AssetType = "SPOT"
 
-		err = b.Websocket.Orderbook.LoadSnapshot(newOrderbook, b.GetName(), false)
+		err = b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, b.GetName(), false)
 		if err != nil {
 			return err
 		}

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -210,7 +210,7 @@ func (b *Bitstamp) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderTy
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bitstamp) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *Bitstamp) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -436,7 +436,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := b.ModifyOrder(exchange.ModifyOrder{})
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -227,7 +227,7 @@ func (b *Bittrex) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderTyp
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *Bittrex) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *Bittrex) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -296,7 +296,7 @@ func TestWithdraw(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := b.ModifyOrder(exchange.ModifyOrder{})
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/btcc/btcc_websocket.go
+++ b/exchanges/btcc/btcc_websocket.go
@@ -403,14 +403,14 @@ func (b *BTCC) WsProcessOrderbookSnapshot(ob WsOrderbookSnapshot) error {
 		bids = append(bids, orderbook.Item{Price: data.Price, Amount: newSize})
 	}
 
-	var newOrderbook orderbook.Base
+	var newOrderBook orderbook.Base
 
-	newOrderbook.Asks = asks
-	newOrderbook.AssetType = "SPOT"
-	newOrderbook.Bids = bids
-	newOrderbook.Pair = currency.NewPairFromString(ob.Symbol)
+	newOrderBook.Asks = asks
+	newOrderBook.AssetType = "SPOT"
+	newOrderBook.Bids = bids
+	newOrderBook.Pair = currency.NewPairFromString(ob.Symbol)
 
-	err := b.Websocket.Orderbook.LoadSnapshot(newOrderbook, b.GetName(), false)
+	err := b.Websocket.Orderbook.LoadSnapshot(&newOrderBook, b.GetName(), false)
 	if err != nil {
 		return err
 	}

--- a/exchanges/btcc/btcc_websocket.go
+++ b/exchanges/btcc/btcc_websocket.go
@@ -191,13 +191,13 @@ func (b *BTCC) WsHandleData() {
 
 				switch orderbook.Type {
 				case "F":
-					err = b.WsProcessOrderbookSnapshot(orderbook)
+					err = b.WsProcessOrderbookSnapshot(&orderbook)
 					if err != nil {
 						b.Websocket.DataHandler <- err
 					}
 
 				case "I":
-					err = b.WsProcessOrderbookUpdate(orderbook)
+					err = b.WsProcessOrderbookUpdate(&orderbook)
 					if err != nil {
 						b.Websocket.DataHandler <- err
 					}
@@ -380,7 +380,7 @@ func (b *BTCC) WsSubcribeToTrades() error {
 }
 
 // WsProcessOrderbookSnapshot processes a new orderbook snapshot
-func (b *BTCC) WsProcessOrderbookSnapshot(ob WsOrderbookSnapshot) error {
+func (b *BTCC) WsProcessOrderbookSnapshot(ob *WsOrderbookSnapshot) error {
 	var asks, bids []orderbook.Item
 	for _, data := range ob.List {
 		var newSize float64
@@ -425,7 +425,7 @@ func (b *BTCC) WsProcessOrderbookSnapshot(ob WsOrderbookSnapshot) error {
 }
 
 // WsProcessOrderbookUpdate processes an orderbook update
-func (b *BTCC) WsProcessOrderbookUpdate(ob WsOrderbookSnapshot) error {
+func (b *BTCC) WsProcessOrderbookUpdate(ob *WsOrderbookSnapshot) error {
 	var asks, bids []orderbook.Item
 	for _, data := range ob.List {
 		var newSize float64

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -109,7 +109,7 @@ func (b *BTCC) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType e
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *BTCC) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *BTCC) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -391,7 +391,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := b.ModifyOrder(exchange.ModifyOrder{})
+	_, err := b.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -202,7 +202,7 @@ func (b *BTCMarkets) SubmitOrder(p currency.Pair, side exchange.OrderSide, order
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *BTCMarkets) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *BTCMarkets) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/btse/btse_websocket.go
+++ b/exchanges/btse/btse_websocket.go
@@ -159,7 +159,7 @@ func (b *BTSE) WsHandleData() {
 					continue
 				}
 
-				err = b.wsProcessSnapshot(snapshot)
+				err = b.wsProcessSnapshot(&snapshot)
 				if err != nil {
 					b.Websocket.DataHandler <- err
 					continue
@@ -170,7 +170,7 @@ func (b *BTSE) WsHandleData() {
 }
 
 // ProcessSnapshot processes the initial orderbook snap shot
-func (b *BTSE) wsProcessSnapshot(snapshot websocketOrderbookSnapshot) error {
+func (b *BTSE) wsProcessSnapshot(snapshot *websocketOrderbookSnapshot) error {
 	var base orderbook.Base
 	for _, bid := range snapshot.Bids {
 		p := strings.Replace(bid[0].(string), ",", "", -1)

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -161,7 +161,7 @@ func (b *BTSE) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType e
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (b *BTSE) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (b *BTSE) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -530,7 +530,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := c.ModifyOrder(exchange.ModifyOrder{})
+	_, err := c.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -173,7 +173,7 @@ func (c *CoinbasePro) WsHandleData() {
 					continue
 				}
 
-				err = c.ProcessSnapshot(snapshot)
+				err = c.ProcessSnapshot(&snapshot)
 				if err != nil {
 					c.Websocket.DataHandler <- err
 					continue
@@ -198,7 +198,7 @@ func (c *CoinbasePro) WsHandleData() {
 }
 
 // ProcessSnapshot processes the initial orderbook snap shot
-func (c *CoinbasePro) ProcessSnapshot(snapshot WebsocketOrderbookSnapshot) error {
+func (c *CoinbasePro) ProcessSnapshot(snapshot *WebsocketOrderbookSnapshot) error {
 	var base *orderbook.Base
 	for _, bid := range snapshot.Bids {
 		price, err := strconv.ParseFloat(bid[0].(string), 64)

--- a/exchanges/coinbasepro/coinbasepro_websocket.go
+++ b/exchanges/coinbasepro/coinbasepro_websocket.go
@@ -199,7 +199,7 @@ func (c *CoinbasePro) WsHandleData() {
 
 // ProcessSnapshot processes the initial orderbook snap shot
 func (c *CoinbasePro) ProcessSnapshot(snapshot WebsocketOrderbookSnapshot) error {
-	var base orderbook.Base
+	var base *orderbook.Base
 	for _, bid := range snapshot.Bids {
 		price, err := strconv.ParseFloat(bid[0].(string), 64)
 		if err != nil {

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -214,7 +214,7 @@ func (c *CoinbasePro) SubmitOrder(p currency.Pair, side exchange.OrderSide, orde
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (c *CoinbasePro) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (c *CoinbasePro) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -323,7 +323,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := c.ModifyOrder(exchange.ModifyOrder{})
+	_, err := c.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -100,7 +100,7 @@ func (c *COINUT) WsHandleData() {
 					continue
 				}
 
-				err = c.WsProcessOrderbookSnapshot(orderbooksnapshot)
+				err = c.WsProcessOrderbookSnapshot(&orderbooksnapshot)
 				if err != nil {
 					c.Websocket.DataHandler <- err
 					continue
@@ -122,7 +122,7 @@ func (c *COINUT) WsHandleData() {
 					continue
 				}
 
-				err = c.WsProcessOrderbookUpdate(orderbookUpdate)
+				err = c.WsProcessOrderbookUpdate(&orderbookUpdate)
 				if err != nil {
 					c.Websocket.DataHandler <- err
 					continue
@@ -313,7 +313,7 @@ func (c *COINUT) WsSubscribe() error {
 }
 
 // WsProcessOrderbookSnapshot processes the orderbook snapshot
-func (c *COINUT) WsProcessOrderbookSnapshot(ob WsOrderbookSnapshot) error {
+func (c *COINUT) WsProcessOrderbookSnapshot(ob *WsOrderbookSnapshot) error {
 	var bids []orderbook.Item
 	for _, bid := range ob.Buy {
 		bids = append(bids, orderbook.Item{
@@ -340,7 +340,7 @@ func (c *COINUT) WsProcessOrderbookSnapshot(ob WsOrderbookSnapshot) error {
 }
 
 // WsProcessOrderbookUpdate process an orderbook update
-func (c *COINUT) WsProcessOrderbookUpdate(ob WsOrderbookUpdate) error {
+func (c *COINUT) WsProcessOrderbookUpdate(ob *WsOrderbookUpdate) error {
 	p := currency.NewPairFromString(instrumentListByCode[ob.InstID])
 
 	if ob.Side == "buy" {

--- a/exchanges/coinut/coinut_websocket.go
+++ b/exchanges/coinut/coinut_websocket.go
@@ -330,13 +330,13 @@ func (c *COINUT) WsProcessOrderbookSnapshot(ob WsOrderbookSnapshot) error {
 		})
 	}
 
-	var newOrderbook orderbook.Base
-	newOrderbook.Asks = asks
-	newOrderbook.Bids = bids
-	newOrderbook.Pair = currency.NewPairFromString(instrumentListByCode[ob.InstID])
-	newOrderbook.AssetType = "SPOT"
+	var newOrderBook orderbook.Base
+	newOrderBook.Asks = asks
+	newOrderBook.Bids = bids
+	newOrderBook.Pair = currency.NewPairFromString(instrumentListByCode[ob.InstID])
+	newOrderBook.AssetType = "SPOT"
 
-	return c.Websocket.Orderbook.LoadSnapshot(newOrderbook, c.GetName(), false)
+	return c.Websocket.Orderbook.LoadSnapshot(&newOrderBook, c.GetName(), false)
 }
 
 // WsProcessOrderbookUpdate process an orderbook update

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -269,7 +269,7 @@ func (c *COINUT) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (c *COINUT) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (c *COINUT) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -316,7 +316,7 @@ type IBotExchange interface {
 
 	GetFundingHistory() ([]FundHistory, error)
 	SubmitOrder(p currency.Pair, side OrderSide, orderType OrderType, amount, price float64, clientID string) (SubmitOrderResponse, error)
-	ModifyOrder(action ModifyOrder) (string, error)
+	ModifyOrder(action *ModifyOrder) (string, error)
 	CancelOrder(order *OrderCancellation) error
 	CancelAllOrders(orders *OrderCancellation) (CancelAllOrdersResponse, error)
 	GetOrderInfo(orderID string) (OrderDetail, error)

--- a/exchanges/exchange_websocket.go
+++ b/exchanges/exchange_websocket.go
@@ -352,7 +352,7 @@ func (w *Websocket) GetName() string {
 // WebsocketOrderbookLocal defines a local cache of orderbooks for amending,
 // appending and deleting changes and updates the main store in orderbook.go
 type WebsocketOrderbookLocal struct {
-	ob          []orderbook.Base
+	ob          []*orderbook.Base
 	lastUpdated time.Time
 	m           sync.Mutex
 }
@@ -380,7 +380,7 @@ func (w *WebsocketOrderbookLocal) Update(bidTargets, askTargets []orderbook.Item
 	var orderbookAddress *orderbook.Base
 	for i := range w.ob {
 		if w.ob[i].Pair == p && w.ob[i].AssetType == assetType {
-			orderbookAddress = &w.ob[i]
+			orderbookAddress = w.ob[i]
 		}
 	}
 
@@ -467,7 +467,7 @@ func (w *WebsocketOrderbookLocal) Update(bidTargets, askTargets []orderbook.Item
 // LoadSnapshot loads initial snapshot of orderbook data, overite allows full
 // orderbook to be completely rewritten because the exchange is a doing a full
 // update not an incremental one
-func (w *WebsocketOrderbookLocal) LoadSnapshot(newOrderbook orderbook.Base, exchName string, overwrite bool) error {
+func (w *WebsocketOrderbookLocal) LoadSnapshot(newOrderbook *orderbook.Base, exchName string, overwrite bool) error {
 	if len(newOrderbook.Asks) == 0 || len(newOrderbook.Bids) == 0 {
 		return errors.New("exchange.go websocket orderbook cache LoadSnapshot() error - snapshot ask and bids are nil")
 	}
@@ -499,7 +499,7 @@ func (w *WebsocketOrderbookLocal) UpdateUsingID(bidTargets, askTargets []orderbo
 	var orderbookAddress *orderbook.Base
 	for i := range w.ob {
 		if w.ob[i].Pair == p && w.ob[i].AssetType == assetType {
-			orderbookAddress = &w.ob[i]
+			orderbookAddress = w.ob[i]
 		}
 	}
 

--- a/exchanges/exchange_websocket_test.go
+++ b/exchanges/exchange_websocket_test.go
@@ -159,7 +159,7 @@ func TestInsertingSnapShots(t *testing.T) {
 	snapShot1.AssetType = "SPOT"
 	snapShot1.Pair = currency.NewPairFromString("BTCUSD")
 
-	wsTest.Websocket.Orderbook.LoadSnapshot(snapShot1, "ExchangeTest", false)
+	wsTest.Websocket.Orderbook.LoadSnapshot(&snapShot1, "ExchangeTest", false)
 
 	var snapShot2 orderbook.Base
 	asks = []orderbook.Item{
@@ -195,7 +195,7 @@ func TestInsertingSnapShots(t *testing.T) {
 	snapShot2.AssetType = "SPOT"
 	snapShot2.Pair = currency.NewPairFromString("LTCUSD")
 
-	wsTest.Websocket.Orderbook.LoadSnapshot(snapShot2, "ExchangeTest", false)
+	wsTest.Websocket.Orderbook.LoadSnapshot(&snapShot2, "ExchangeTest", false)
 
 	var snapShot3 orderbook.Base
 	asks = []orderbook.Item{
@@ -231,7 +231,7 @@ func TestInsertingSnapShots(t *testing.T) {
 	snapShot3.AssetType = "FUTURES"
 	snapShot3.Pair = currency.NewPairFromString("LTCUSD")
 
-	wsTest.Websocket.Orderbook.LoadSnapshot(snapShot3, "ExchangeTest", false)
+	wsTest.Websocket.Orderbook.LoadSnapshot(&snapShot3, "ExchangeTest", false)
 
 	if len(wsTest.Websocket.Orderbook.ob) != 3 {
 		t.Error("test failed - inserting orderbook data")

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -369,7 +369,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := e.ModifyOrder(exchange.ModifyOrder{})
+	_, err := e.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -233,7 +233,7 @@ func (e *EXMO) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType e
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (e *EXMO) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (e *EXMO) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -386,7 +386,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := g.ModifyOrder(exchange.ModifyOrder{})
+	_, err := g.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -264,13 +264,13 @@ func (g *Gateio) WsHandleData() {
 						g.Websocket.DataHandler <- errors.New("gatio websocket error - cannot access bid data")
 					}
 
-					var newOrderbook orderbook.Base
-					newOrderbook.Asks = asks
-					newOrderbook.Bids = bids
-					newOrderbook.AssetType = "SPOT"
-					newOrderbook.Pair = currency.NewPairFromString(c)
+					var newOrderBook orderbook.Base
+					newOrderBook.Asks = asks
+					newOrderBook.Bids = bids
+					newOrderBook.AssetType = "SPOT"
+					newOrderBook.Pair = currency.NewPairFromString(c)
 
-					err = g.Websocket.Orderbook.LoadSnapshot(newOrderbook,
+					err = g.Websocket.Orderbook.LoadSnapshot(&newOrderBook,
 						g.GetName(),
 						false)
 					if err != nil {

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -236,7 +236,7 @@ func (g *Gateio) SubmitOrder(p currency.Pair, side exchange.OrderSide, _ exchang
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (g *Gateio) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (g *Gateio) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -540,7 +540,7 @@ func (g *Gemini) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		if err != nil {
 			return 0, err
 		}
-		fee = calculateTradingFee(notionVolume, feeBuilder.PurchasePrice, feeBuilder.Amount, feeBuilder.IsMaker)
+		fee = calculateTradingFee(&notionVolume, feeBuilder.PurchasePrice, feeBuilder.Amount, feeBuilder.IsMaker)
 	case exchange.CryptocurrencyWithdrawalFee:
 		// TODO: no free transactions after 10; Need database to know how many trades have been done
 		// Could do via trade history, but would require analysis of response and dates to determine level of fee
@@ -554,7 +554,7 @@ func (g *Gemini) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func calculateTradingFee(notionVolume NotionalVolume, purchasePrice, amount float64, isMaker bool) float64 {
+func calculateTradingFee(notionVolume *NotionalVolume, purchasePrice, amount float64, isMaker bool) float64 {
 	var volumeFee float64
 	if isMaker {
 		volumeFee = (float64(notionVolume.MakerFee) / 100)

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -468,7 +468,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := Session[1].ModifyOrder(exchange.ModifyOrder{})
+	_, err := Session[1].ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -43,11 +43,11 @@ func (g *Gemini) WsConnect() error {
 
 	go g.WsHandleData()
 
-	return g.WsSubscribe(dialer)
+	return g.WsSubscribe(&dialer)
 }
 
 // WsSubscribe subscribes to the full websocket suite on gemini exchange
-func (g *Gemini) WsSubscribe(dialer websocket.Dialer) error {
+func (g *Gemini) WsSubscribe(dialer *websocket.Dialer) error {
 	enabledCurrencies := g.GetEnabledCurrencies()
 	for i, c := range enabledCurrencies {
 		val := url.Values{}

--- a/exchanges/gemini/gemini_websocket.go
+++ b/exchanges/gemini/gemini_websocket.go
@@ -153,13 +153,13 @@ func (g *Gemini) WsHandleData() {
 							}
 						}
 
-						var newOrderbook orderbook.Base
-						newOrderbook.Asks = asks
-						newOrderbook.Bids = bids
-						newOrderbook.AssetType = "SPOT"
-						newOrderbook.Pair = resp.Currency
+						var newOrderBook orderbook.Base
+						newOrderBook.Asks = asks
+						newOrderBook.Bids = bids
+						newOrderBook.AssetType = "SPOT"
+						newOrderBook.Pair = resp.Currency
 
-						err := g.Websocket.Orderbook.LoadSnapshot(newOrderbook,
+						err := g.Websocket.Orderbook.LoadSnapshot(&newOrderBook,
 							g.GetName(),
 							false)
 						if err != nil {

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -179,7 +179,7 @@ func (g *Gemini) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (g *Gemini) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (g *Gemini) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -292,7 +292,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := h.ModifyOrder(exchange.ModifyOrder{})
+	_, err := h.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/hitbtc/hitbtc_websocket.go
+++ b/exchanges/hitbtc/hitbtc_websocket.go
@@ -240,13 +240,13 @@ func (h *HitBTC) WsProcessOrderbookSnapshot(ob WsOrderbook) error {
 
 	p := currency.NewPairFromString(ob.Params.Symbol)
 
-	var newOrderbook orderbook.Base
-	newOrderbook.Asks = asks
-	newOrderbook.Bids = bids
-	newOrderbook.AssetType = "SPOT"
-	newOrderbook.Pair = p
+	var newOrderBook orderbook.Base
+	newOrderBook.Asks = asks
+	newOrderBook.Bids = bids
+	newOrderBook.AssetType = "SPOT"
+	newOrderBook.Pair = p
 
-	err := h.Websocket.Orderbook.LoadSnapshot(newOrderbook, h.GetName(), false)
+	err := h.Websocket.Orderbook.LoadSnapshot(&newOrderBook, h.GetName(), false)
 	if err != nil {
 		return err
 	}

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -209,7 +209,7 @@ func (h *HitBTC) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (h *HitBTC) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (h *HitBTC) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -539,7 +539,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := h.ModifyOrder(exchange.ModifyOrder{})
+	_, err := h.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/huobi/huobi_websocket.go
+++ b/exchanges/huobi/huobi_websocket.go
@@ -140,7 +140,7 @@ func (h *HUOBI) WsHandleData() {
 
 				data := common.SplitStrings(depth.Channel, ".")
 
-				h.WsProcessOrderbook(depth, data[1])
+				h.WsProcessOrderbook(&depth, data[1])
 
 			case common.StringContains(init.Channel, "kline"):
 				var kline WsKline
@@ -186,7 +186,7 @@ func (h *HUOBI) WsHandleData() {
 }
 
 // WsProcessOrderbook processes new orderbook data
-func (h *HUOBI) WsProcessOrderbook(ob WsDepth, symbol string) error {
+func (h *HUOBI) WsProcessOrderbook(ob *WsDepth, symbol string) error {
 	var bids []orderbook.Item
 	for _, data := range ob.Tick.Bids {
 		bidLevel := data.([]interface{})

--- a/exchanges/huobi/huobi_websocket.go
+++ b/exchanges/huobi/huobi_websocket.go
@@ -203,12 +203,12 @@ func (h *HUOBI) WsProcessOrderbook(ob WsDepth, symbol string) error {
 
 	p := currency.NewPairFromString(symbol)
 
-	var newOrderbook orderbook.Base
-	newOrderbook.Asks = asks
-	newOrderbook.Bids = bids
-	newOrderbook.Pair = p
+	var newOrderBook orderbook.Base
+	newOrderBook.Asks = asks
+	newOrderBook.Bids = bids
+	newOrderBook.Pair = p
 
-	err := h.Websocket.Orderbook.LoadSnapshot(newOrderbook, h.GetName(), false)
+	err := h.Websocket.Orderbook.LoadSnapshot(&newOrderBook, h.GetName(), false)
 	if err != nil {
 		return err
 	}

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -316,7 +316,7 @@ func (h *HUOBI) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType 
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (h *HUOBI) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (h *HUOBI) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -520,7 +520,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := h.ModifyOrder(exchange.ModifyOrder{})
+	_, err := h.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/huobihadax/huobihadax_websocket.go
+++ b/exchanges/huobihadax/huobihadax_websocket.go
@@ -141,7 +141,7 @@ func (h *HUOBIHADAX) WsHandleData() {
 
 				data := common.SplitStrings(depth.Channel, ".")
 
-				h.WsProcessOrderbook(depth, data[1])
+				h.WsProcessOrderbook(&depth, data[1])
 
 			case common.StringContains(init.Channel, "kline"):
 				var kline WsKline
@@ -187,7 +187,7 @@ func (h *HUOBIHADAX) WsHandleData() {
 }
 
 // WsProcessOrderbook processes new orderbook data
-func (h *HUOBIHADAX) WsProcessOrderbook(ob WsDepth, symbol string) error {
+func (h *HUOBIHADAX) WsProcessOrderbook(ob *WsDepth, symbol string) error {
 	var bids []orderbook.Item
 	for _, data := range ob.Tick.Bids {
 		bidLevel := data.([]interface{})

--- a/exchanges/huobihadax/huobihadax_websocket.go
+++ b/exchanges/huobihadax/huobihadax_websocket.go
@@ -204,12 +204,12 @@ func (h *HUOBIHADAX) WsProcessOrderbook(ob WsDepth, symbol string) error {
 
 	p := currency.NewPairFromString(symbol)
 
-	var newOrderbook orderbook.Base
-	newOrderbook.Asks = asks
-	newOrderbook.Bids = bids
-	newOrderbook.Pair = p
+	var newOrderBook orderbook.Base
+	newOrderBook.Asks = asks
+	newOrderBook.Bids = bids
+	newOrderBook.Pair = p
 
-	err := h.Websocket.Orderbook.LoadSnapshot(newOrderbook, h.GetName(), false)
+	err := h.Websocket.Orderbook.LoadSnapshot(&newOrderBook, h.GetName(), false)
 	if err != nil {
 		return err
 	}

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -272,7 +272,7 @@ func (h *HUOBIHADAX) SubmitOrder(p currency.Pair, side exchange.OrderSide, order
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (h *HUOBIHADAX) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (h *HUOBIHADAX) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -371,7 +371,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := i.ModifyOrder(exchange.ModifyOrder{})
+	_, err := i.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -233,7 +233,7 @@ func (i *ItBit) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType 
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (i *ItBit) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (i *ItBit) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -808,7 +808,7 @@ func (k *Kraken) GetTradeVolume(feeinfo bool, symbol ...string) (TradeVolumeResp
 }
 
 // AddOrder adds a new order for Kraken exchange
-func (k *Kraken) AddOrder(symbol, side, orderType string, volume, price, price2, leverage float64, args AddOrderOptions) (AddOrderResponse, error) {
+func (k *Kraken) AddOrder(symbol, side, orderType string, volume, price, price2, leverage float64, args *AddOrderOptions) (AddOrderResponse, error) {
 	params := url.Values{
 		"pair":      {symbol},
 		"type":      {common.StringToLower(side)},

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -206,7 +206,7 @@ func TestGetTradeVolume(t *testing.T) {
 func TestAddOrder(t *testing.T) {
 	t.Parallel()
 	args := AddOrderOptions{Oflags: "fcib"}
-	_, err := k.AddOrder("XXBTZUSD", "sell", "market", 0.00000001, 0, 0, 0, args)
+	_, err := k.AddOrder("XXBTZUSD", "sell", "market", 0.00000001, 0, 0, 0, &args)
 	if err == nil {
 		t.Error("Test Failed - AddOrder() error", err)
 	}

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -459,7 +459,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := k.ModifyOrder(exchange.ModifyOrder{})
+	_, err := k.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -228,7 +228,7 @@ func (k *Kraken) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (k *Kraken) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (k *Kraken) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -213,7 +213,7 @@ func (k *Kraken) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType
 		price,
 		0,
 		0,
-		args)
+		&args)
 
 	if len(response.TransactionIds) > 0 {
 		submitOrderResponse.OrderID = strings.Join(response.TransactionIds, ", ")

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -356,7 +356,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := l.ModifyOrder(exchange.ModifyOrder{})
+	_, err := l.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -185,7 +185,7 @@ func (l *LakeBTC) SubmitOrder(p currency.Pair, side exchange.OrderSide, _ exchan
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (l *LakeBTC) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (l *LakeBTC) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/localbitcoins/localbitcoins.go
+++ b/exchanges/localbitcoins/localbitcoins.go
@@ -219,7 +219,7 @@ func (l *LocalBitcoins) Getads(args ...string) (AdData, error) {
 // params - see localbitcoins_types.go AdEdit for reference
 // adID - string for the ad you already created
 // TODO
-func (l *LocalBitcoins) EditAd(_ AdEdit, adID string) error {
+func (l *LocalBitcoins) EditAd(_ *AdEdit, adID string) error {
 	type response struct {
 		Data AdData `json:"data"`
 	}
@@ -232,7 +232,7 @@ func (l *LocalBitcoins) EditAd(_ AdEdit, adID string) error {
 //
 // params - see localbitcoins_types.go AdCreate for reference
 // TODO
-func (l *LocalBitcoins) CreateAd(_ AdCreate) error {
+func (l *LocalBitcoins) CreateAd(_ *AdCreate) error {
 	return l.SendAuthenticatedHTTPRequest(http.MethodPost, localbitcoinsAPIAdCreate, nil, nil)
 }
 

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -89,7 +89,7 @@ func TestEditAd(t *testing.T) {
 		t.Skip()
 	}
 	edit := AdEdit{}
-	err := l.EditAd(edit, "1337")
+	err := l.EditAd(&edit, "1337")
 	if err == nil {
 		t.Error("Test Failed - EditAd() error", err)
 	}

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -316,7 +316,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := l.ModifyOrder(exchange.ModifyOrder{})
+	_, err := l.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -188,7 +188,7 @@ func (l *LocalBitcoins) SubmitOrder(p currency.Pair, side exchange.OrderSide, _ 
 	}
 
 	// Does not return any orderID, so create the add, then get the order
-	err := l.CreateAd(params)
+	err := l.CreateAd(&params)
 	if err != nil {
 		return submitOrderResponse, err
 	}

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -231,7 +231,7 @@ func (l *LocalBitcoins) SubmitOrder(p currency.Pair, side exchange.OrderSide, _ 
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (l *LocalBitcoins) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (l *LocalBitcoins) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -1165,7 +1165,7 @@ func TestGetAccountInfo(t *testing.T) {
 // TestModifyOrder Wrapper test
 func TestModifyOrder(t *testing.T) {
 	TestSetRealOrderDefaults(t)
-	_, err := o.ModifyOrder(exchange.ModifyOrder{})
+	_, err := o.ModifyOrder(&exchange.ModifyOrder{})
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
 	}

--- a/exchanges/okex/okex.go
+++ b/exchanges/okex/okex.go
@@ -455,7 +455,7 @@ func (o *OKEX) GetETTBillsDetails(currency string) (resp []okgroup.GetETTBillsDe
 // You can place an order only if you have enough funds. Once your order is placed,
 // the amount will be put on hold in the order lifecycle.
 // The assets and amount on hold depends on the order's specific type and parameters.
-func (o *OKEX) PlaceETTOrder(request okgroup.PlaceETTOrderRequest) (resp okgroup.PlaceETTOrderResponse, _ error) {
+func (o *OKEX) PlaceETTOrder(request *okgroup.PlaceETTOrderRequest) (resp okgroup.PlaceETTOrderResponse, _ error) {
 	return resp, o.SendHTTPRequest(http.MethodPost, okGroupETTSubsection, okgroup.OKGroupOrders, nil, &resp, true)
 }
 

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1949,7 +1949,7 @@ func TestGetAccountInfo(t *testing.T) {
 func TestModifyOrder(t *testing.T) {
 	TestSetRealOrderDefaults(t)
 	t.Parallel()
-	_, err := o.ModifyOrder(exchange.ModifyOrder{})
+	_, err := o.ModifyOrder(&exchange.ModifyOrder{})
 	if err != common.ErrFunctionNotSupported {
 		t.Errorf("Expected '%v', received: '%v'", common.ErrFunctionNotSupported, err)
 	}

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1514,7 +1514,7 @@ func TestPlaceETTOrder(t *testing.T) {
 		ETT:           "OK06",
 	}
 
-	_, err := o.PlaceETTOrder(request)
+	_, err := o.PlaceETTOrder(&request)
 	testStandardErrorHandling(t, err)
 }
 

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -645,7 +645,7 @@ func (o *OKGroup) WsProcessUpdateOrderbook(wsEventData *WebsocketDataWrapper, in
 	sort.Slice(internalOrderbook.Bids, func(i, j int) bool {
 		return internalOrderbook.Bids[i].Price > internalOrderbook.Bids[j].Price
 	})
-	checksum := o.CalculateUpdateOrderbookChecksum(internalOrderbook)
+	checksum := o.CalculateUpdateOrderbookChecksum(&internalOrderbook)
 	if checksum == wsEventData.Checksum {
 		if o.Verbose {
 			log.Debug("Orderbook valid")
@@ -733,7 +733,7 @@ func (o *OKGroup) CalculatePartialOrderbookChecksum(orderbookData *WebsocketData
 // The checksum is made up of the price and the quantity with a semicolon (:) deliminating them
 // This will also work when there are less than 25 entries (for whatever reason)
 // eg Bid:Ask:Bid:Ask:Ask:Ask
-func (o *OKGroup) CalculateUpdateOrderbookChecksum(orderbookData orderbook.Base) int32 {
+func (o *OKGroup) CalculateUpdateOrderbookChecksum(orderbookData *orderbook.Base) int32 {
 	var checksum string
 	iterations := 25
 	for i := 0; i < iterations; i++ {

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -612,7 +612,7 @@ func (o *OKGroup) WsProcessPartialOrderBook(wsEventData *WebsocketDataWrapper, i
 		ExchangeName: o.GetName(),
 	}
 
-	err := o.Websocket.Orderbook.LoadSnapshot(newOrderBook, o.GetName(), true)
+	err := o.Websocket.Orderbook.LoadSnapshot(&newOrderBook, o.GetName(), true)
 	if err != nil {
 		return err
 	}
@@ -655,7 +655,7 @@ func (o *OKGroup) WsProcessUpdateOrderbook(wsEventData *WebsocketDataWrapper, in
 			log.Debug("Internalising orderbook")
 		}
 
-		err := o.Websocket.Orderbook.LoadSnapshot(internalOrderbook, o.GetName(), true)
+		err := o.Websocket.Orderbook.LoadSnapshot(&internalOrderbook, o.GetName(), true)
 		if err != nil {
 			log.Error(err)
 		}

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -242,7 +242,7 @@ func (o *OKGroup) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderTyp
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (o *OKGroup) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (o *OKGroup) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -319,7 +319,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := p.ModifyOrder(exchange.ModifyOrder{OrderID: "1337", Price: 1337})
+	_, err := p.ModifyOrder(&exchange.ModifyOrder{OrderID: "1337", Price: 1337})
 	if err == nil {
 		t.Error("Test Failed - ModifyOrder() error")
 	}

--- a/exchanges/poloniex/poloniex_websocket.go
+++ b/exchanges/poloniex/poloniex_websocket.go
@@ -318,13 +318,13 @@ func (p *Poloniex) WsProcessOrderbookSnapshot(ob []interface{}, symbol string) e
 		})
 	}
 
-	var newOrderbook orderbook.Base
-	newOrderbook.Asks = asks
-	newOrderbook.Bids = bids
-	newOrderbook.AssetType = "SPOT"
-	newOrderbook.Pair = currency.NewPairFromString(symbol)
+	var newOrderBook orderbook.Base
+	newOrderBook.Asks = asks
+	newOrderBook.Bids = bids
+	newOrderBook.AssetType = "SPOT"
+	newOrderBook.Pair = currency.NewPairFromString(symbol)
 
-	return p.Websocket.Orderbook.LoadSnapshot(newOrderbook, p.GetName(), false)
+	return p.Websocket.Orderbook.LoadSnapshot(&newOrderBook, p.GetName(), false)
 }
 
 // WsProcessOrderbookUpdate processses new orderbook updates

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -209,7 +209,7 @@ func (p *Poloniex) SubmitOrder(currencyPair currency.Pair, side exchange.OrderSi
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (p *Poloniex) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (p *Poloniex) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	oID, err := strconv.ParseInt(action.OrderID, 10, 64)
 	if err != nil {
 		return "", err

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -423,7 +423,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := y.ModifyOrder(exchange.ModifyOrder{})
+	_, err := y.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -184,7 +184,7 @@ func (y *Yobit) SubmitOrder(p currency.Pair, side exchange.OrderSide, orderType 
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (y *Yobit) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (y *Yobit) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -375,7 +375,7 @@ func TestGetAccountInfo(t *testing.T) {
 }
 
 func TestModifyOrder(t *testing.T) {
-	_, err := z.ModifyOrder(exchange.ModifyOrder{})
+	_, err := z.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
 		t.Error("Test failed - ModifyOrder() error")
 	}

--- a/exchanges/zb/zb_websocket.go
+++ b/exchanges/zb/zb_websocket.go
@@ -223,13 +223,13 @@ func (z *ZB) WsHandleData() {
 				channelInfo := common.SplitStrings(result.Channel, "_")
 				cPair := currency.NewPairFromString(channelInfo[0])
 
-				var newOrderbook orderbook.Base
-				newOrderbook.Asks = asks
-				newOrderbook.Bids = bids
-				newOrderbook.AssetType = "SPOT"
-				newOrderbook.Pair = cPair
+				var newOrderBook orderbook.Base
+				newOrderBook.Asks = asks
+				newOrderBook.Bids = bids
+				newOrderBook.AssetType = "SPOT"
+				newOrderBook.Pair = cPair
 
-				err = z.Websocket.Orderbook.LoadSnapshot(newOrderbook,
+				err = z.Websocket.Orderbook.LoadSnapshot(&newOrderBook,
 					z.GetName(),
 					true)
 				if err != nil {

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -217,7 +217,7 @@ func (z *ZB) SubmitOrder(p currency.Pair, side exchange.OrderSide, _ exchange.Or
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func (z *ZB) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func (z *ZB) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrFunctionNotSupported
 }
 

--- a/main.go
+++ b/main.go
@@ -147,7 +147,8 @@ func main() {
 		bot.dataDir,
 		*verbosity)
 	if err != nil {
-		log.Warn("currency updater system failed to start", err)
+		log.Fatalf("currency updater system failed to start %v", err)
+
 	}
 
 	bot.portfolio = &portfolio.Portfolio

--- a/tools/exchange_template/wrapper_file.tmpl
+++ b/tools/exchange_template/wrapper_file.tmpl
@@ -122,7 +122,7 @@ func ({{.Variable}} *{{.CapitalName}}) SubmitOrder(p currency.Pair, side exchang
 
 // ModifyOrder will allow of changing orderbook placement and limit to
 // market conversion
-func ({{.Variable}} *{{.CapitalName}}) ModifyOrder(action exchange.ModifyOrder) (string, error) {
+func ({{.Variable}} *{{.CapitalName}}) ModifyOrder(action *exchange.ModifyOrder) (string, error) {
 	return "", common.ErrNotYetImplemented
 }
 


### PR DESCRIPTION
# Description

Second round of pointer usage for large structs this should take care of all the simple changes that don't require code changes 

Also includes a case correction for newOrderBook to make it consistent across the code base

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Automated testing using go test 
Manual building and running with all exchanges enabled as well

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules