### PR TITLE
Kraken websocket support

### DIFF
--- a/currency/pair.go
+++ b/currency/pair.go
@@ -62,7 +62,7 @@ func NewPairFromIndex(currencyPair, index string) (Pair, error) {
 // NewPairFromString converts currency string into a new CurrencyPair
 // with or without delimeter
 func NewPairFromString(currencyPair string) Pair {
-	delimiters := []string{"_", "-"}
+	delimiters := []string{"_", "-", "/"}
 	var delimiter string
 	for _, x := range delimiters {
 		if strings.Contains(currencyPair, x) {

--- a/exchanges/exchange_websocket.go
+++ b/exchanges/exchange_websocket.go
@@ -205,11 +205,7 @@ func (w *Websocket) Connect() error {
 		return fmt.Errorf("exchange_websocket.go connection error %s",
 			err)
 	}
-
-	if !w.connected {
-		w.Connected <- struct{}{}
-	}
-
+	w.connected = true
 	return nil
 }
 

--- a/exchanges/exchange_websocket.go
+++ b/exchanges/exchange_websocket.go
@@ -141,7 +141,8 @@ func (w *Websocket) trafficMonitor(wg *sync.WaitGroup) {
 		select {
 		case <-w.ShutdownC: // Returns on shutdown channel close
 			return
-
+		case <-w.Connected:
+			w.connected = true
 		case <-w.TrafficAlert: // Resets timer on traffic
 			if !w.connected {
 				w.Connected <- struct{}{}
@@ -205,9 +206,9 @@ func (w *Websocket) Connect() error {
 			err)
 	}
 
-	// Divert for incoming websocket traffic
-	w.Connected <- struct{}{}
-	w.connected = true
+	if !w.connected {
+		w.Connected <- struct{}{}
+	}
 
 	return nil
 }

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -89,8 +89,13 @@ func (k *Kraken) SetDefaults() {
 		common.NewHTTPClientWithTimeout(exchange.DefaultHTTPTimeout))
 	k.APIUrlDefault = krakenAPIURL
 	k.APIUrl = k.APIUrlDefault
-	k.WebsocketURL = krakenWSURL
 	k.WebsocketInit()
+	k.WebsocketURL = krakenWSURL
+	k.Websocket.Functionality = exchange.WebsocketTickerSupported |
+		exchange.WebsocketTradeDataSupported |
+		exchange.WebsocketKlineSupported |
+		exchange.WebsocketOrderbookSupported
+
 }
 
 // Setup sets current exchange configuration
@@ -105,6 +110,7 @@ func (k *Kraken) Setup(exch config.ExchangeConfig) {
 		k.SetHTTPClientUserAgent(exch.HTTPUserAgent)
 		k.RESTPollingDelay = exch.RESTPollingDelay
 		k.Verbose = exch.Verbose
+		k.Websocket.SetWsStatusAndConnection(exch.Websocket)
 		k.BaseCurrencies = exch.BaseCurrencies
 		k.AvailablePairs = exch.AvailablePairs
 		k.EnabledPairs = exch.EnabledPairs

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -629,13 +629,13 @@ func TestSubscribeToChannel(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	defer k.Websocket.Shutdown()
 	k.Websocket.Connect()
 	<-k.Websocket.TrafficAlert
 	err := k.WsSubscribeToChannel("ticker", []string{"XBT/USD"}, 1)
 	if err != nil {
 		t.Error(err)
 	}
+	k.Websocket.Shutdown()
 }
 
 // TestSubscribeToNonExistentChannel websocket test
@@ -653,11 +653,10 @@ func TestSubscribeToNonExistentChannel(t *testing.T) {
 		t.Error(err)
 	}
 	subscriptionError := false
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 7; i++ {
 		response := <-k.Websocket.DataHandler
 		if err, ok := response.(error); ok && err != nil {
 			subscriptionError = true
-			t.Log(err)
 			break
 		}
 	}
@@ -673,7 +672,6 @@ func TestSubscribeUnsubscribeToChannel(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	defer k.Websocket.Shutdown()
 	k.Websocket.Connect()
 	<-k.Websocket.TrafficAlert
 	err := k.WsSubscribeToChannel("ticker", []string{"XBT/USD"}, 1)
@@ -684,6 +682,7 @@ func TestSubscribeUnsubscribeToChannel(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	k.Websocket.Shutdown()
 }
 
 // TestUnsubscribeWithoutSubscription websocket test
@@ -693,7 +692,6 @@ func TestUnsubscribeWithoutSubscription(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	defer k.Websocket.Shutdown()
 	k.Websocket.Connect()
 	<-k.Websocket.TrafficAlert
 	err := k.WsUnsubscribeToChannel("ticker", []string{"XBT/USD"}, 3)
@@ -701,10 +699,9 @@ func TestUnsubscribeWithoutSubscription(t *testing.T) {
 		t.Error(err)
 	}
 	unsubscriptionError := false
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 7; i++ {
 		response := <-k.Websocket.DataHandler
 		if err, ok := response.(error); ok && err != nil {
-			t.Log(err)
 			if err.Error() == "Subscription Not Found" {
 				unsubscriptionError = true
 				break
@@ -714,6 +711,7 @@ func TestUnsubscribeWithoutSubscription(t *testing.T) {
 	if !unsubscriptionError {
 		t.Error("Expected error")
 	}
+	k.Websocket.Shutdown()
 }
 
 // TestUnsubscribeWithChannelID websocket test
@@ -723,7 +721,6 @@ func TestUnsubscribeWithChannelID(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	defer k.Websocket.Shutdown()
 	k.Websocket.Connect()
 	<-k.Websocket.TrafficAlert
 	err := k.WsUnsubscribeToChannelByChannelID(3)
@@ -731,10 +728,9 @@ func TestUnsubscribeWithChannelID(t *testing.T) {
 		t.Error(err)
 	}
 	unsubscriptionError := false
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 7; i++ {
 		response := <-k.Websocket.DataHandler
 		if err, ok := response.(error); ok && err != nil {
-			t.Log(err)
 			if err.Error() == "Subscription Not Found" {
 				unsubscriptionError = true
 				break
@@ -744,6 +740,7 @@ func TestUnsubscribeWithChannelID(t *testing.T) {
 	if !unsubscriptionError {
 		t.Error("Expected error")
 	}
+	k.Websocket.Shutdown()
 }
 
 // TestUnsubscribeFromNonExistentChennel websocket test
@@ -753,7 +750,6 @@ func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	defer k.Websocket.Shutdown()
 	k.Websocket.Connect()
 	<-k.Websocket.DataHandler
 	err := k.WsUnsubscribeToChannel("ticker", []string{"tseries"}, 0)
@@ -761,10 +757,9 @@ func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
 		t.Error(err)
 	}
 	unsubscriptionError := false
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 7; i++ {
 		response := <-k.Websocket.DataHandler
 		if err, ok := response.(error); ok && err != nil {
-			t.Log(err)
 			unsubscriptionError = true
 			break
 		}
@@ -772,4 +767,5 @@ func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
 	if !unsubscriptionError {
 		t.Error("Expected error")
 	}
+	k.Websocket.Shutdown()
 }

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -18,10 +18,12 @@ const (
 	canManipulateRealOrders = false
 )
 
+// TestSetDefaults setup func
 func TestSetDefaults(t *testing.T) {
 	k.SetDefaults()
 }
 
+// TestSetup setup func
 func TestSetup(t *testing.T) {
 	cfg := config.GetConfig()
 	cfg.LoadConfig("../../testdata/configtest.json")
@@ -33,10 +35,11 @@ func TestSetup(t *testing.T) {
 	krakenConfig.APIKey = apiKey
 	krakenConfig.APISecret = apiSecret
 	krakenConfig.ClientID = clientID
-
+	krakenConfig.WebsocketURL = k.WebsocketURL
 	k.Setup(krakenConfig)
 }
 
+// TestGetServerTime API endpoint test
 func TestGetServerTime(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetServerTime()
@@ -45,6 +48,7 @@ func TestGetServerTime(t *testing.T) {
 	}
 }
 
+// TestGetAssets API endpoint test
 func TestGetAssets(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetAssets()
@@ -53,6 +57,7 @@ func TestGetAssets(t *testing.T) {
 	}
 }
 
+// TestGetAssetPairs API endpoint test
 func TestGetAssetPairs(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetAssetPairs()
@@ -61,6 +66,7 @@ func TestGetAssetPairs(t *testing.T) {
 	}
 }
 
+// TestGetTicker API endpoint test
 func TestGetTicker(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetTicker("BCHEUR")
@@ -69,6 +75,7 @@ func TestGetTicker(t *testing.T) {
 	}
 }
 
+// TestGetTickers API endpoint test
 func TestGetTickers(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetTickers("LTCUSD,ETCUSD")
@@ -77,6 +84,7 @@ func TestGetTickers(t *testing.T) {
 	}
 }
 
+// TestGetOHLC API endpoint test
 func TestGetOHLC(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetOHLC("BCHEUR")
@@ -85,6 +93,7 @@ func TestGetOHLC(t *testing.T) {
 	}
 }
 
+// TestGetDepth API endpoint test
 func TestGetDepth(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetDepth("BCHEUR")
@@ -93,6 +102,7 @@ func TestGetDepth(t *testing.T) {
 	}
 }
 
+// TestGetTrades API endpoint test
 func TestGetTrades(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetTrades("BCHEUR")
@@ -101,6 +111,7 @@ func TestGetTrades(t *testing.T) {
 	}
 }
 
+// TestGetSpread API endpoint test
 func TestGetSpread(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetSpread("BCHEUR")
@@ -109,6 +120,7 @@ func TestGetSpread(t *testing.T) {
 	}
 }
 
+// TestGetBalance API endpoint test
 func TestGetBalance(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetBalance()
@@ -117,6 +129,7 @@ func TestGetBalance(t *testing.T) {
 	}
 }
 
+// TestGetTradeBalance API endpoint test
 func TestGetTradeBalance(t *testing.T) {
 	t.Parallel()
 	args := TradeBalanceOptions{Asset: "ZEUR"}
@@ -126,6 +139,7 @@ func TestGetTradeBalance(t *testing.T) {
 	}
 }
 
+// TestGetOpenOrders API endpoint test
 func TestGetOpenOrders(t *testing.T) {
 	t.Parallel()
 	args := OrderInfoOptions{Trades: true}
@@ -135,6 +149,7 @@ func TestGetOpenOrders(t *testing.T) {
 	}
 }
 
+// TestGetClosedOrders API endpoint test
 func TestGetClosedOrders(t *testing.T) {
 	t.Parallel()
 	args := GetClosedOrdersOptions{Trades: true, Start: "OE4KV4-4FVQ5-V7XGPU"}
@@ -144,6 +159,7 @@ func TestGetClosedOrders(t *testing.T) {
 	}
 }
 
+// TestQueryOrdersInfo API endpoint test
 func TestQueryOrdersInfo(t *testing.T) {
 	t.Parallel()
 	args := OrderInfoOptions{Trades: true}
@@ -153,6 +169,7 @@ func TestQueryOrdersInfo(t *testing.T) {
 	}
 }
 
+// TestGetTradesHistory API endpoint test
 func TestGetTradesHistory(t *testing.T) {
 	t.Parallel()
 	args := GetTradesHistoryOptions{Trades: true, Start: "TMZEDR-VBJN2-NGY6DX", End: "TVRXG2-R62VE-RWP3UW"}
@@ -162,6 +179,7 @@ func TestGetTradesHistory(t *testing.T) {
 	}
 }
 
+// TestQueryTrades API endpoint test
 func TestQueryTrades(t *testing.T) {
 	t.Parallel()
 	_, err := k.QueryTrades(true, "TMZEDR-VBJN2-NGY6DX", "TFLWIB-KTT7L-4TWR3L", "TDVRAH-2H6OS-SLSXRX")
@@ -170,6 +188,7 @@ func TestQueryTrades(t *testing.T) {
 	}
 }
 
+// TestOpenPositions API endpoint test
 func TestOpenPositions(t *testing.T) {
 	t.Parallel()
 	_, err := k.OpenPositions(false)
@@ -178,6 +197,7 @@ func TestOpenPositions(t *testing.T) {
 	}
 }
 
+// TestGetLedgers API endpoint test
 func TestGetLedgers(t *testing.T) {
 	t.Parallel()
 	args := GetLedgersOptions{Start: "LRUHXI-IWECY-K4JYGO", End: "L5NIY7-JZQJD-3J4M2V", Ofs: 15}
@@ -187,6 +207,7 @@ func TestGetLedgers(t *testing.T) {
 	}
 }
 
+// TestQueryLedgers API endpoint test
 func TestQueryLedgers(t *testing.T) {
 	t.Parallel()
 	_, err := k.QueryLedgers("LVTSFS-NHZVM-EXNZ5M")
@@ -195,6 +216,7 @@ func TestQueryLedgers(t *testing.T) {
 	}
 }
 
+// TestGetTradeVolume API endpoint test
 func TestGetTradeVolume(t *testing.T) {
 	t.Parallel()
 	_, err := k.GetTradeVolume(true, "OAVY7T-MV5VK-KHDF5X")
@@ -203,6 +225,7 @@ func TestGetTradeVolume(t *testing.T) {
 	}
 }
 
+// TestAddOrder API endpoint test
 func TestAddOrder(t *testing.T) {
 	t.Parallel()
 	args := AddOrderOptions{Oflags: "fcib"}
@@ -212,6 +235,7 @@ func TestAddOrder(t *testing.T) {
 	}
 }
 
+// TestCancelExistingOrder API endpoint test
 func TestCancelExistingOrder(t *testing.T) {
 	t.Parallel()
 	_, err := k.CancelExistingOrder("OAVY7T-MV5VK-KHDF5X")
@@ -231,6 +255,7 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFee logic test
 func TestGetFee(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -313,6 +338,7 @@ func TestGetFee(t *testing.T) {
 	}
 }
 
+// TestFormatWithdrawPermissions logic test
 func TestFormatWithdrawPermissions(t *testing.T) {
 	k.SetDefaults()
 	expectedResult := exchange.AutoWithdrawCryptoWithSetupText + " & " + exchange.WithdrawCryptoWith2FAText + " & " + exchange.AutoWithdrawFiatWithSetupText + " & " + exchange.WithdrawFiatWith2FAText
@@ -324,6 +350,7 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
+// TestGetActiveOrders wrapper test
 func TestGetActiveOrders(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -340,6 +367,7 @@ func TestGetActiveOrders(t *testing.T) {
 	}
 }
 
+// TestGetOrderHistory wrapper test
 func TestGetOrderHistory(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -366,6 +394,7 @@ func areTestAPIKeysSet() bool {
 	return false
 }
 
+// TestSubmitOrder wrapper test
 func TestSubmitOrder(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -387,6 +416,7 @@ func TestSubmitOrder(t *testing.T) {
 	}
 }
 
+// TestCancelExchangeOrder wrapper test
 func TestCancelExchangeOrder(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -413,6 +443,7 @@ func TestCancelExchangeOrder(t *testing.T) {
 	}
 }
 
+// TestCancelAllExchangeOrders wrapper test
 func TestCancelAllExchangeOrders(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -444,6 +475,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 	}
 }
 
+// TestGetAccountInfo wrapper test
 func TestGetAccountInfo(t *testing.T) {
 	if apiKey != "" || apiSecret != "" || clientID != "" {
 		_, err := k.GetAccountInfo()
@@ -458,6 +490,7 @@ func TestGetAccountInfo(t *testing.T) {
 	}
 }
 
+// TestModifyOrder wrapper test
 func TestModifyOrder(t *testing.T) {
 	_, err := k.ModifyOrder(&exchange.ModifyOrder{})
 	if err == nil {
@@ -465,6 +498,7 @@ func TestModifyOrder(t *testing.T) {
 	}
 }
 
+// TestWithdraw wrapper test
 func TestWithdraw(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -489,6 +523,7 @@ func TestWithdraw(t *testing.T) {
 	}
 }
 
+// TestWithdrawFiat wrapper test
 func TestWithdrawFiat(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -514,6 +549,7 @@ func TestWithdrawFiat(t *testing.T) {
 	}
 }
 
+// TestWithdrawInternationalBank wrapper test
 func TestWithdrawInternationalBank(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -539,6 +575,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 	}
 }
 
+// TestGetDepositAddress wrapper test
 func TestGetDepositAddress(t *testing.T) {
 	if areTestAPIKeysSet() {
 		_, err := k.GetDepositAddress(currency.BTC, "")
@@ -553,6 +590,7 @@ func TestGetDepositAddress(t *testing.T) {
 	}
 }
 
+// TestWithdrawStatus wrapper test
 func TestWithdrawStatus(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
@@ -570,10 +608,10 @@ func TestWithdrawStatus(t *testing.T) {
 	}
 }
 
+// TestWithdrawCancel wrapper test
 func TestWithdrawCancel(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
-
 	_, err := k.WithdrawCancel(currency.BTC, "")
 	if areTestAPIKeysSet() && err == nil {
 		t.Error("Test Failed - WithdrawCancel() error cannot be nil")
@@ -584,67 +622,32 @@ func TestWithdrawCancel(t *testing.T) {
 
 // ---------------------------- Websocket tests -----------------------------------------
 
-func websocketSetup(t *testing.T) {
-	if k.WebsocketConn == nil {
-		k.Websocket.Shutdown()
-		if !k.Websocket.IsEnabled() {
-			err := k.WebsocketSetup(k.WsConnect,
-				k.Name,
-				true,
-				krakenWSURL,
-				krakenWSURL)
-			if err != nil {
-				t.Error(err)
-			}
-			k.Websocket.DataHandler = make(chan interface{}, 500)
-			k.Websocket.SetWsStatusAndConnection(true)
-		}
-	}
-	if !k.Websocket.IsConnected() {
-		t.Skip("Could not connect to websocket. Skipping")
-	}
-}
-
-func TestConnectToWebsocket(t *testing.T) {
-	k.SetDefaults()
-	TestSetup(t)
-	k.Verbose = true
-	if k.WebsocketConn == nil {
-		k.Websocket.Shutdown()
-		if !k.Websocket.IsEnabled() {
-			err := k.WebsocketSetup(k.WsConnect,
-				k.Name,
-				true,
-				krakenWSURL,
-				krakenWSURL)
-			if err != nil {
-				t.Error(err)
-			}
-			k.Websocket.DataHandler = make(chan interface{}, 500)
-			k.Websocket.SetWsStatusAndConnection(true)
-		}
-	}
-	if !k.Websocket.IsConnected() {
-		t.Error("Could not connect to websocket")
-	}
-}
-
+// TestSubscribeToChannel websocket test
 func TestSubscribeToChannel(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
-	k.Verbose = true
-	websocketSetup(t)
+	if !k.Websocket.IsEnabled() {
+		t.Skip("Websocket not enabled, skipping")
+	}
+	defer k.Websocket.Shutdown()
+	k.Websocket.Connect()
+	<-k.Websocket.TrafficAlert
 	err := k.WsSubscribeToChannel("ticker", []string{"XBT/USD"}, 1)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
-func TestSubscribeToPewdiepie(t *testing.T) {
+// TestSubscribeToNonExistentChannel websocket test
+func TestSubscribeToNonExistentChannel(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
-	k.Verbose = true
-	websocketSetup(t)
+	if !k.Websocket.IsEnabled() {
+		t.Skip("Websocket not enabled, skipping")
+	}
+	defer k.Websocket.Shutdown()
+	k.Websocket.Connect()
+	<-k.Websocket.TrafficAlert
 	err := k.WsSubscribeToChannel("ticker", []string{"pewdiepie"}, 1)
 	if err != nil {
 		t.Error(err)
@@ -663,11 +666,16 @@ func TestSubscribeToPewdiepie(t *testing.T) {
 	}
 }
 
+// TestSubscribeUnsubscribeToChannel websocket test
 func TestSubscribeUnsubscribeToChannel(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
-	k.Verbose = true
-	websocketSetup(t)
+	if !k.Websocket.IsEnabled() {
+		t.Skip("Websocket not enabled, skipping")
+	}
+	defer k.Websocket.Shutdown()
+	k.Websocket.Connect()
+	<-k.Websocket.TrafficAlert
 	err := k.WsSubscribeToChannel("ticker", []string{"XBT/USD"}, 1)
 	if err != nil {
 		t.Error(err)
@@ -678,11 +686,16 @@ func TestSubscribeUnsubscribeToChannel(t *testing.T) {
 	}
 }
 
+// TestUnsubscribeWithoutSubscription websocket test
 func TestUnsubscribeWithoutSubscription(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
-	k.Verbose = true
-	websocketSetup(t)
+	if !k.Websocket.IsEnabled() {
+		t.Skip("Websocket not enabled, skipping")
+	}
+	defer k.Websocket.Shutdown()
+	k.Websocket.Connect()
+	<-k.Websocket.TrafficAlert
 	err := k.WsUnsubscribeToChannel("ticker", []string{"XBT/USD"}, 3)
 	if err != nil {
 		t.Error(err)
@@ -703,11 +716,16 @@ func TestUnsubscribeWithoutSubscription(t *testing.T) {
 	}
 }
 
+// TestUnsubscribeWithChannelID websocket test
 func TestUnsubscribeWithChannelID(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
-	k.Verbose = true
-	websocketSetup(t)
+	if !k.Websocket.IsEnabled() {
+		t.Skip("Websocket not enabled, skipping")
+	}
+	defer k.Websocket.Shutdown()
+	k.Websocket.Connect()
+	<-k.Websocket.TrafficAlert
 	err := k.WsUnsubscribeToChannelByChannelID(3)
 	if err != nil {
 		t.Error(err)
@@ -728,11 +746,16 @@ func TestUnsubscribeWithChannelID(t *testing.T) {
 	}
 }
 
-func TestUnsubscribeFromTSeries(t *testing.T) {
+// TestUnsubscribeFromNonExistentChennel websocket test
+func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
-	k.Verbose = true
-	websocketSetup(t)
+	if !k.Websocket.IsEnabled() {
+		t.Skip("Websocket not enabled, skipping")
+	}
+	defer k.Websocket.Shutdown()
+	k.Websocket.Connect()
+	<-k.Websocket.DataHandler
 	err := k.WsUnsubscribeToChannel("ticker", []string{"tseries"}, 0)
 	if err != nil {
 		t.Error(err)

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -624,30 +624,36 @@ func TestWithdrawCancel(t *testing.T) {
 
 // TestSubscribeToChannel websocket test
 func TestSubscribeToChannel(t *testing.T) {
-	k.SetDefaults()
-	TestSetup(t)
+	if k.Name == "" {
+		k.SetDefaults()
+		TestSetup(t)
+	}
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	k.Websocket.Connect()
+	if !k.Websocket.IsConnected() {
+		k.Websocket.Connect()
+	}
+
 	<-k.Websocket.TrafficAlert
 	err := k.WsSubscribeToChannel("ticker", []string{"XBT/USD"}, 1)
 	if err != nil {
 		t.Error(err)
 	}
-	k.Websocket.Shutdown()
 }
 
 // TestSubscribeToNonExistentChannel websocket test
 func TestSubscribeToNonExistentChannel(t *testing.T) {
-	k.SetDefaults()
-	TestSetup(t)
+	if k.Name == "" {
+		k.SetDefaults()
+		TestSetup(t)
+	}
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	defer k.Websocket.Shutdown()
-	k.Websocket.Connect()
-	<-k.Websocket.TrafficAlert
+	if !k.Websocket.IsConnected() {
+		k.Websocket.Connect()
+	}
 	err := k.WsSubscribeToChannel("ticker", []string{"pewdiepie"}, 1)
 	if err != nil {
 		t.Error(err)
@@ -667,13 +673,16 @@ func TestSubscribeToNonExistentChannel(t *testing.T) {
 
 // TestSubscribeUnsubscribeToChannel websocket test
 func TestSubscribeUnsubscribeToChannel(t *testing.T) {
-	k.SetDefaults()
-	TestSetup(t)
+	if k.Name == "" {
+		k.SetDefaults()
+		TestSetup(t)
+	}
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	k.Websocket.Connect()
-	<-k.Websocket.TrafficAlert
+	if !k.Websocket.IsConnected() {
+		k.Websocket.Connect()
+	}
 	err := k.WsSubscribeToChannel("ticker", []string{"XBT/USD"}, 1)
 	if err != nil {
 		t.Error(err)
@@ -682,18 +691,20 @@ func TestSubscribeUnsubscribeToChannel(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	k.Websocket.Shutdown()
 }
 
 // TestUnsubscribeWithoutSubscription websocket test
 func TestUnsubscribeWithoutSubscription(t *testing.T) {
-	k.SetDefaults()
-	TestSetup(t)
+	if k.Name == "" {
+		k.SetDefaults()
+		TestSetup(t)
+	}
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	k.Websocket.Connect()
-	<-k.Websocket.TrafficAlert
+	if !k.Websocket.IsConnected() {
+		k.Websocket.Connect()
+	}
 	err := k.WsUnsubscribeToChannel("ticker", []string{"XBT/USD"}, 3)
 	if err != nil {
 		t.Error(err)
@@ -711,18 +722,20 @@ func TestUnsubscribeWithoutSubscription(t *testing.T) {
 	if !unsubscriptionError {
 		t.Error("Expected error")
 	}
-	k.Websocket.Shutdown()
 }
 
 // TestUnsubscribeWithChannelID websocket test
 func TestUnsubscribeWithChannelID(t *testing.T) {
-	k.SetDefaults()
-	TestSetup(t)
+	if k.Name == "" {
+		k.SetDefaults()
+		TestSetup(t)
+	}
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	k.Websocket.Connect()
-	<-k.Websocket.TrafficAlert
+	if !k.Websocket.IsConnected() {
+		k.Websocket.Connect()
+	}
 	err := k.WsUnsubscribeToChannelByChannelID(3)
 	if err != nil {
 		t.Error(err)
@@ -740,18 +753,20 @@ func TestUnsubscribeWithChannelID(t *testing.T) {
 	if !unsubscriptionError {
 		t.Error("Expected error")
 	}
-	k.Websocket.Shutdown()
 }
 
 // TestUnsubscribeFromNonExistentChennel websocket test
 func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
-	k.SetDefaults()
-	TestSetup(t)
+	if k.Name == "" {
+		k.SetDefaults()
+		TestSetup(t)
+	}
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	k.Websocket.Connect()
-	<-k.Websocket.DataHandler
+	if !k.Websocket.IsConnected() {
+		k.Websocket.Connect()
+	}
 	err := k.WsUnsubscribeToChannel("ticker", []string{"tseries"}, 0)
 	if err != nil {
 		t.Error(err)
@@ -767,5 +782,4 @@ func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
 	if !unsubscriptionError {
 		t.Error("Expected error")
 	}
-	k.Websocket.Shutdown()
 }

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -609,7 +609,24 @@ func TestConnectToWebsocket(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)
 	k.Verbose = true
-	websocketSetup(t)
+	if k.WebsocketConn == nil {
+		k.Websocket.Shutdown()
+		if !k.Websocket.IsEnabled() {
+			err := k.WebsocketSetup(k.WsConnect,
+				k.Name,
+				true,
+				krakenWSURL,
+				krakenWSURL)
+			if err != nil {
+				t.Error(err)
+			}
+			k.Websocket.DataHandler = make(chan interface{}, 500)
+			k.Websocket.SetWsStatusAndConnection(true)
+		}
+	}
+	if !k.Websocket.IsConnected() {
+		t.Error("Could not connect to websocket")
+	}
 }
 
 func TestSubscribeToChannel(t *testing.T) {

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -438,20 +438,6 @@ type WebsocketStatusResponse struct {
 
 type WebsocketDataResponse []interface{}
 
-
-
-type WebsocketTickerResponseData struct {
-	A []interface{} `json:"a"`
-	B []interface{} `json:"b"`
-	C []string      `json:"c"`
-	V []string      `json:"v"`
-	P []string      `json:"p"`
-	T []int64       `json:"t"`
-	L []string      `json:"l"`
-	H []string      `json:"h"`
-	O []string      `json:"o"`
-}
-
 type WebsocketErrorResponse struct {
 	ErrorMessage string `json:"errorMessage"`
 }

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -396,13 +396,19 @@ type WebsocketSubscriptionEventRequest struct {
 }
 
 // WebsocketUnsubscribeEventRequest  handles WS unsubscribe events
-// You can choose to fill (requestID, pairs, subscription) OR ChannelID
 type WebsocketUnsubscribeEventRequest struct {
 	Event        string                    `json:"event"`           // unsubscribe
 	RequestID    int64                     `json:"reqid,omitempty"` // Optional, client originated ID reflected in response message.
 	Pairs        []string                  `json:"pair,omitempty"`  // Array of currency pairs (pair1,pair2,pair3).
 	Subscription WebsocketSubscriptionData `json:"subscription,omitempty"`
-	ChannelID    int64                     `json:"channelID,omitempty"`
+}
+
+// WebsocketUnsubscribeByChannelIDEventRequest  handles WS unsubscribe events
+type WebsocketUnsubscribeByChannelIDEventRequest struct {
+	Event     string   `json:"event"`           // unsubscribe
+	RequestID int64    `json:"reqid,omitempty"` // Optional, client originated ID reflected in response message.
+	Pairs     []string `json:"pair,omitempty"`  // Array of currency pairs (pair1,pair2,pair3).
+	ChannelID int64    `json:"channelID,omitempty"`
 }
 
 // WebsocketSubscriptionData contains details on WS channel

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -386,3 +386,79 @@ type WithdrawStatusResponse struct {
 	Time   float64 `json:"time"`
 	Status string  `json:"status"`
 }
+
+// WebsocketSubscriptionEventRequest handles WS subscription events
+type WebsocketSubscriptionEventRequest struct {
+	Event        string                    `json:"event"`           // subscribe
+	RequestID    int64                     `json:"reqid,omitempty"` // Optional, client originated ID reflected in response message.
+	Pairs        []string                  `json:"pair"`            // Array of currency pairs (pair1,pair2,pair3).
+	Subscription WebsocketSubscriptionData `json:"subscription,omitempty"`
+}
+
+// WebsocketUnsubscribeEventRequest  handles WS unsubscribe events
+// You can choose to fill (requestID, pairs, subscription) OR ChannelID
+type WebsocketUnsubscribeEventRequest struct {
+	Event        string                    `json:"event"`           // unsubscribe
+	RequestID    int64                     `json:"reqid,omitempty"` // Optional, client originated ID reflected in response message.
+	Pairs        []string                  `json:"pair,omitempty"`  // Array of currency pairs (pair1,pair2,pair3).
+	Subscription WebsocketSubscriptionData `json:"subscription,omitempty"`
+	ChannelID    int64                     `json:"channelID,omitempty"`
+}
+
+// WebsocketSubscriptionData contains details on WS channel
+type WebsocketSubscriptionData struct {
+	Name     string `json:"name,omitempty"`     // ticker|ohlc|trade|book|spread|*, * for all (ohlc interval value is 1 if all channels subscribed)
+	Interval int64  `json:"interval,omitempty"` // Optional - Time interval associated with ohlc subscription in minutes. Default 1. Valid Interval values: 1|5|15|30|60|240|1440|10080|21600
+	Depth    int64  `json:"depth,omitempty"`    // Optional - depth associated with book subscription in number of levels each side, default 10. Valid Options are: 10, 25, 100, 500, 1000
+}
+
+// WebsocketDataResponse holds all data response types
+type WebsocketEventResponse struct {
+	Event        string                            `json:"event"`
+	Status       string                            `json:"status"`
+	Pair         currency.Pair                     `json:"pair,omitempty"`
+	Subscription WebsocketSubscriptionResponseData `json:"subscription,omitempty"`
+	WebsocketSubscriptionEventResponse
+	WebsocketStatusResponse
+	WebsocketErrorResponse
+}
+
+type WebsocketSubscriptionEventResponse struct {
+	ChannelID float64 `json:"channelID"`
+}
+
+type WebsocketSubscriptionResponseData struct {
+	Name string `json:"name"`
+}
+
+type WebsocketStatusResponse struct {
+	ConnectionID float64 `json:"connectionID"`
+	Version      string  `json:"version"`
+}
+
+type WebsocketDataResponse []interface{}
+
+
+
+type WebsocketTickerResponseData struct {
+	A []interface{} `json:"a"`
+	B []interface{} `json:"b"`
+	C []string      `json:"c"`
+	V []string      `json:"v"`
+	P []string      `json:"p"`
+	T []int64       `json:"t"`
+	L []string      `json:"l"`
+	H []string      `json:"h"`
+	O []string      `json:"o"`
+}
+
+type WebsocketErrorResponse struct {
+	ErrorMessage string `json:"errorMessage"`
+}
+
+// Holds relevant data for channels to identify what we're doing
+type WebsocketChannelData struct {
+	Subscription string
+	Pair         currency.Pair
+	ChannelID    float64
+}

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -395,14 +395,6 @@ type WebsocketSubscriptionEventRequest struct {
 	Subscription WebsocketSubscriptionData `json:"subscription,omitempty"`
 }
 
-// WebsocketUnsubscribeEventRequest  handles WS unsubscribe events
-type WebsocketUnsubscribeEventRequest struct {
-	Event        string                    `json:"event"`           // unsubscribe
-	RequestID    int64                     `json:"reqid,omitempty"` // Optional, client originated ID reflected in response message.
-	Pairs        []string                  `json:"pair,omitempty"`  // Array of currency pairs (pair1,pair2,pair3).
-	Subscription WebsocketSubscriptionData `json:"subscription,omitempty"`
-}
-
 // WebsocketUnsubscribeByChannelIDEventRequest  handles WS unsubscribe events
 type WebsocketUnsubscribeByChannelIDEventRequest struct {
 	Event     string   `json:"event"`           // unsubscribe

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -317,7 +317,7 @@ func (k *Kraken) WsSubscribeToChannel(topic string, currencies []string, request
 
 // WsUnsubscribeToChannel sends a request to WS to unsubscribe to supplied channel name and pairs
 func (k *Kraken) WsUnsubscribeToChannel(topic string, currencies []string, requestID int64) error {
-	resp := WebsocketUnsubscribeEventRequest{
+	resp := WebsocketSubscriptionEventRequest{
 		Event: krakenWsUnsubscribe,
 		Pairs: currencies,
 		Subscription: WebsocketSubscriptionData{

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -1,0 +1,483 @@
+package kraken
+
+import (
+	"bytes"
+	"compress/flate"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/thrasher-/gocryptotrader/common"
+	"github.com/thrasher-/gocryptotrader/currency"
+	exchange "github.com/thrasher-/gocryptotrader/exchanges"
+	log "github.com/thrasher-/gocryptotrader/logger"
+)
+
+// List of all websocket channels to subscribe to
+const (
+	krakenWSURL              = "wss://ws.kraken.com"
+	krakenWSSandboxURL       = "wss://sandbox.kraken.com"
+	krakenWSSupportedVersion = "0.1.1"
+	// If a checksum fails, then resubscribing to the channel fails, fatal after these attempts
+	krakenWsResubscribeFailureLimit   = 3
+	krakenWsResubscribeDelayInSeconds = 3
+
+	krakenWsHeartbeat          = "heartbeat"
+	krakenWsPing               = "ping"
+	krakenWsPong               = "pong"
+	krakenWsSystemStatus       = "systemStatus"
+	krakenWsSubscribe          = "subscribe"
+	krakenWsSubscriptionStatus = "subscriptionStatus"
+	krakenWsUnsubscribe        = "unsubscribe"
+	krakenWsTicker             = "ticker"
+	krakenWsOHLC               = "ohlc"
+	krakenWsTrade              = "trade"
+	krakenWsSpread             = "spread"
+	krakenWsOrderbook          = "book"
+	// Spot endpoints
+
+)
+
+// orderbookMutex Ensures if two entries arrive at once, only one can be processed at a time
+var orderbookMutex sync.Mutex
+var subscriptionChannelPair []WebsocketChannelData
+
+// writeToWebsocket sends a message to the websocket endpoint
+func (k *Kraken) writeToWebsocket(message string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.Verbose {
+		log.Debugf("Sending message to WS: %v", message)
+	}
+	return k.WebsocketConn.WriteMessage(websocket.TextMessage, []byte(message))
+}
+
+// WsConnect initiates a websocket connection
+func (k *Kraken) WsConnect() error {
+	if !k.Websocket.IsEnabled() || !k.IsEnabled() {
+		return errors.New(exchange.WebsocketNotEnabled)
+	}
+
+	var dialer websocket.Dialer
+	if k.Websocket.GetProxyAddress() != "" {
+		proxy, err := url.Parse(k.Websocket.GetProxyAddress())
+		if err != nil {
+			return err
+		}
+
+		dialer.Proxy = http.ProxyURL(proxy)
+	}
+
+	var err error
+	if k.Verbose {
+		log.Debugf("Attempting to connect to %v", k.Websocket.GetWebsocketURL())
+	}
+	k.WebsocketConn, _, err = dialer.Dial(k.Websocket.GetWebsocketURL(),
+		http.Header{})
+	if err != nil {
+		return fmt.Errorf("%s Unable to connect to Websocket. Error: %s",
+			k.Name,
+			err)
+	}
+	if k.Verbose {
+		log.Debugf("Successful connection to %v", k.Websocket.GetWebsocketURL())
+	}
+
+	go k.WsHandleData()
+	go k.wsPingHandler()
+
+	err = k.WsSubscribeToDefaults()
+	if err != nil {
+		return fmt.Errorf("error: Could not subscribe to the %v websocket %s",
+			k.GetName(), err)
+	}
+	return nil
+}
+
+// WsSubscribeToDefaults subscribes to the websocket channels
+func (k *Kraken) WsSubscribeToDefaults() (err error) {
+	channelsToSubscribe := []string{krakenWsTicker, krakenWsTrade, krakenWsOrderbook, krakenWsOHLC, krakenWsSpread}
+	for _, pair := range k.EnabledPairs {
+		formattedPair := strings.ToUpper(strings.Replace(pair.String(), "-", "/", 1))
+		for _, channel := range channelsToSubscribe {
+			err = k.WsSubscribeToChannel(channel, []string{formattedPair}, 0)
+			if err != nil {
+				return
+			}
+		}
+	}
+	return nil
+}
+
+// WsReadData reads data from the websocket connection
+func (k *Kraken) WsReadData() (exchange.WebsocketResponse, error) {
+	mType, resp, err := k.WebsocketConn.ReadMessage()
+	if err != nil {
+		return exchange.WebsocketResponse{}, err
+	}
+
+	k.Websocket.TrafficAlert <- struct{}{}
+	var standardMessage []byte
+	switch mType {
+	case websocket.TextMessage:
+		standardMessage = resp
+
+	case websocket.BinaryMessage:
+		reader := flate.NewReader(bytes.NewReader(resp))
+		standardMessage, err = ioutil.ReadAll(reader)
+		reader.Close()
+		if err != nil {
+			return exchange.WebsocketResponse{}, err
+		}
+	}
+	if k.Verbose {
+		log.Debugf("%v Websocket message received: %v", k.Name, string(standardMessage))
+	}
+
+	return exchange.WebsocketResponse{Raw: standardMessage}, nil
+}
+
+// wsPingHandler sends a message "ping" every 27 to maintain the connection to the websocket
+func (k *Kraken) wsPingHandler() {
+	k.Websocket.Wg.Add(1)
+	defer k.Websocket.Wg.Done()
+	ticker := time.NewTicker(time.Second * 27)
+	for {
+		select {
+		case <-k.Websocket.ShutdownC:
+			return
+
+		case <-ticker.C:
+			pingEvent := fmt.Sprintf("{\"event\":\"%v\"}", krakenWsPing)
+			err := k.writeToWebsocket(pingEvent)
+			if k.Verbose {
+				log.Debugf("%v sending ping", k.GetName())
+			}
+			if err != nil {
+				k.Websocket.DataHandler <- err
+				return
+			}
+		}
+	}
+}
+
+// WsHandleData handles the read data from the websocket connection
+func (k *Kraken) WsHandleData() {
+	k.Websocket.Wg.Add(1)
+	defer func() {
+		err := k.WebsocketConn.Close()
+		if err != nil {
+			k.Websocket.DataHandler <- fmt.Errorf("okex_websocket.go - Unable to to close Websocket connection. Error: %s",
+				err)
+		}
+		k.Websocket.Wg.Done()
+	}()
+
+	for {
+		select {
+		case <-k.Websocket.ShutdownC:
+			return
+		default:
+			resp, err := k.WsReadData()
+			if err != nil {
+				k.Websocket.DataHandler <- err
+				return
+			}
+			// event response handling
+			var eventResponse WebsocketEventResponse
+			err = common.JSONDecode(resp.Raw, &eventResponse)
+			if err == nil && eventResponse.Event != "" {
+				k.WsHandleEventResponse(&eventResponse)
+				continue
+			}
+			// data handling
+			var dataResponse WebsocketDataResponse
+			err = common.JSONDecode(resp.Raw, &dataResponse)
+			log.Debug(dataResponse[0])
+			if err == nil && dataResponse[0].(float64) >= 0 {
+				k.WsHandleDataResponse(dataResponse)
+				continue
+			}
+
+			// Unknown data handling
+			k.Websocket.DataHandler <- fmt.Errorf("unrecognised response: %v", string(resp.Raw))
+			continue
+		}
+	}
+}
+
+// WsHandleDataResponse classifies the WS response and sends to appropriate handler
+func (k *Kraken) WsHandleDataResponse(response WebsocketDataResponse) {
+	channelID := response[0].(float64)
+	channelData := getSubscriptionChannelData(channelID)
+	switch channelData.Subscription {
+	case krakenWsTicker:
+		if k.Verbose {
+			log.Debugf("%v Websocket ticker data received", k.GetName())
+		}
+		k.wsProcessTickers(channelData, response[1])
+	case krakenWsOHLC:
+		if k.Verbose {
+			log.Debugf("%v Websocket OHLC data received", k.GetName())
+		}
+		k.wsProcessCandles(channelData, response[1])
+	case krakenWsOrderbook:
+		if k.Verbose {
+			log.Debugf("%v Websocket Orderbook data received", k.GetName())
+		}
+	case krakenWsSpread:
+		if k.Verbose {
+			log.Debugf("%v Websocket Spread data received", k.GetName())
+		}
+	case krakenWsTrade:
+		if k.Verbose {
+			log.Debugf("%v Websocket Trade data received", k.GetName())
+		}
+		k.wsProcessTrades(channelData, response[1])
+	default:
+		log.Errorf("%v Unidentified websocket data received: %v", k.GetName(), response)
+	}
+}
+
+// WsHandleDataResponse classifies the WS response and sends to appropriate handler
+func (k *Kraken) WsHandleEventResponse(response *WebsocketEventResponse) {
+	switch response.Event {
+	case krakenWsHeartbeat:
+		if k.Verbose {
+			log.Debugf("%v Websocket heartbeat data received", k.GetName())
+		}
+	case krakenWsPong:
+		if k.Verbose {
+			log.Debugf("%v Websocket pong data received", k.GetName())
+		}
+	case krakenWsSystemStatus:
+		if k.Verbose {
+			log.Debugf("%v Websocket status data received", k.GetName())
+		}
+		if response.Status != "online" {
+			k.Websocket.DataHandler <- fmt.Errorf("%v Websocket status '%v'", k.GetName(), response.Status)
+		}
+		if response.WebsocketStatusResponse.Version != krakenWSSupportedVersion {
+			log.Warnf("%v New version of Websocket API released. Was %v Now %v", k.GetName(), krakenWSSupportedVersion, response.WebsocketStatusResponse.Version)
+		}
+	case krakenWsSubscriptionStatus:
+		if k.Verbose {
+			log.Debugf("%v Websocket subscription status data received", k.GetName())
+		}
+		if response.Status != "subscribed" {
+			k.Websocket.DataHandler <- fmt.Errorf(response.WebsocketErrorResponse.ErrorMessage)
+			k.ResubscribeToChannel(response.Subscription.Name, response.Pair)
+			return
+		}
+		addNewSubscriptionChannelData(response)
+	default:
+		log.Errorf("%v Unidentified websocket data received: %v", k.GetName(), response)
+	}
+}
+
+// WsSubscribeToChannel sends a request to WS to subscribe to supplied channel name and pairs
+func (k *Kraken) WsSubscribeToChannel(topic string, currencies []string, requestID int64) error {
+	resp := WebsocketSubscriptionEventRequest{
+		Event: krakenWsSubscribe,
+		Pairs: currencies,
+		Subscription: WebsocketSubscriptionData{
+			Name: topic,
+		},
+	}
+	if requestID > 0 {
+		resp.RequestID = requestID
+	}
+	json, err := common.JSONEncode(resp)
+	if err != nil {
+		return err
+	}
+	err = k.writeToWebsocket(string(json))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// WsUnsubscribeToChannel sends a request to WS to unsubscribe to supplied channel name and pairs
+func (k *Kraken) WsUnsubscribeToChannel(topic string, currencies []string, requestID int64) error {
+	resp := WebsocketUnsubscribeEventRequest{
+		Event: krakenWsUnsubscribe,
+		Pairs: currencies,
+		Subscription: WebsocketSubscriptionData{
+			Name: topic,
+		},
+	}
+	if requestID > 0 {
+		resp.RequestID = requestID
+	}
+	json, err := common.JSONEncode(resp)
+	if err != nil {
+		return err
+	}
+	err = k.writeToWebsocket(string(json))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// WsUnsubscribeToChannelByChannelID sends a request to WS to unsubscribe to supplied channel ID
+func (k *Kraken) WsUnsubscribeToChannelByChannelID(channelID int64) error {
+	resp := WebsocketUnsubscribeEventRequest{
+		Event:     krakenWsUnsubscribe,
+		ChannelID: channelID,
+	}
+	json, err := common.JSONEncode(resp)
+	if err != nil {
+		return err
+	}
+	err = k.writeToWebsocket(string(json))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func addNewSubscriptionChannelData(response *WebsocketEventResponse) {
+	for i := range subscriptionChannelPair {
+		if response.ChannelID == subscriptionChannelPair[i].ChannelID {
+			return
+		}
+	}
+	subscriptionChannelPair = append(subscriptionChannelPair, WebsocketChannelData{
+		Subscription: response.Subscription.Name,
+		Pair:         response.Pair,
+		ChannelID:    response.ChannelID,
+	})
+}
+
+func getSubscriptionChannelData(id float64) WebsocketChannelData {
+	for i := range subscriptionChannelPair {
+		if id == subscriptionChannelPair[i].ChannelID {
+			return subscriptionChannelPair[i]
+		}
+	}
+	return WebsocketChannelData{}
+}
+
+// resubscribeToChannel will attempt to unsubscribe and resubscribe to a channel
+func (k *Kraken) ResubscribeToChannel(channel string, pair currency.Pair) {
+	if krakenWsResubscribeFailureLimit > 0 {
+		var successfulUnsubscribe bool
+		for i := 0; i < krakenWsResubscribeFailureLimit; i++ {
+			err := k.WsUnsubscribeToChannel(channel, []string{pair.String()}, 0)
+			if err != nil {
+				log.Error(err)
+				time.Sleep(krakenWsResubscribeDelayInSeconds * time.Second)
+				continue
+			}
+			successfulUnsubscribe = true
+			break
+		}
+		if !successfulUnsubscribe {
+			log.Fatalf("%v websocket channel %v failed to unsubscribe after %v attempts", k.GetName(), channel, krakenWsResubscribeFailureLimit)
+		}
+		successfulSubscribe := true
+		for i := 0; i < krakenWsResubscribeFailureLimit; i++ {
+			err := k.WsSubscribeToChannel(channel, []string{pair.String()}, 0)
+			if err != nil {
+				log.Error(err)
+				time.Sleep(krakenWsResubscribeDelayInSeconds * time.Second)
+				continue
+			}
+			successfulSubscribe = true
+			break
+		}
+		if !successfulSubscribe {
+			log.Fatalf("%v websocket channel %v failed to resubscribe after %v attempts", k.GetName(), channel, krakenWsResubscribeFailureLimit)
+		}
+	} else {
+		log.Fatalf("%v websocket channel %v cannot resubscribe. Limit: %v", k.GetName(), channel, krakenWsResubscribeFailureLimit)
+	}
+}
+
+// wsProcessTickers converts ticker data and sends it to the datahandler
+func (k *Kraken) wsProcessTickers(channelData WebsocketChannelData, data interface{}) {
+	tickerData := data.(map[string]interface{})
+	closeData := tickerData["c"].([]interface{})
+	openData := tickerData["o"].([]interface{})
+	lowData := tickerData["l"].([]interface{})
+	highData := tickerData["h"].([]interface{})
+	volumeData := tickerData["v"].([]interface{})
+	closePrice, _ := strconv.ParseFloat(closeData[0].(string), 64)
+	openPrice, _ := strconv.ParseFloat(openData[0].(string), 64)
+	highPrice, _ := strconv.ParseFloat(highData[0].(string), 64)
+	lowPrice, _ := strconv.ParseFloat(lowData[0].(string), 64)
+	quantity, _ := strconv.ParseFloat(volumeData[0].(string), 64)
+
+	k.Websocket.DataHandler <- exchange.TickerData{
+		Timestamp:  time.Now(),
+		Exchange:   k.GetName(),
+		AssetType:  "SPOT",
+		Pair:       channelData.Pair,
+		ClosePrice: closePrice,
+		OpenPrice:  openPrice,
+		HighPrice:  highPrice,
+		LowPrice:   lowPrice,
+		Quantity:   quantity,
+	}
+}
+
+// wsProcessTrades converts trade data and sends it to the datahandler
+func (k *Kraken) wsProcessTrades(channelData WebsocketChannelData, data interface{}) {
+	tradeData := data.([]interface{})
+	for i := range tradeData {
+		trade := tradeData[i].([]interface{})
+		timeData, _ := strconv.ParseInt(trade[2].(string), 10, 64)
+		timeUnix := time.Unix(timeData, 0)
+		price, _ := strconv.ParseFloat(trade[0].(string), 64)
+		amount, _ := strconv.ParseFloat(trade[1].(string), 64)
+
+		k.Websocket.DataHandler <- exchange.TradeData{
+			AssetType:    "SPOT",
+			CurrencyPair: channelData.Pair,
+			EventTime:    time.Now().Unix(),
+			Exchange:     k.GetName(),
+			Price:        price,
+			Amount:       amount,
+			Timestamp:    timeUnix,
+			Side:         trade[3].(string),
+		}
+	}
+}
+
+// wsProcessCandles converts candle data and sends it to the data handler
+func (k *Kraken) wsProcessCandles(channelData WebsocketChannelData, data interface{}) {
+	candleData := data.([]interface{})
+	startTimeData, _ := strconv.ParseInt(candleData[0].(string), 10, 64)
+	startTimeUnix := time.Unix(startTimeData, 0)
+	endTimeData, _ := strconv.ParseInt(candleData[1].(string), 10, 64)
+	endTimeUnix := time.Unix(endTimeData, 0)
+	high, _ := strconv.ParseFloat(candleData[3].(string), 64)
+	low, _ := strconv.ParseFloat(candleData[4].(string), 64)
+	open, _ := strconv.ParseFloat(candleData[2].(string), 64)
+	close, _ := strconv.ParseFloat(candleData[5].(string), 64)
+	volume, _ := strconv.ParseFloat(candleData[7].(string), 64)
+
+	k.Websocket.DataHandler <- exchange.KlineData{
+		AssetType:  "SPOT",
+		Pair:       channelData.Pair,
+		Timestamp:  time.Now(),
+		Exchange:   k.GetName(),
+		StartTime:  startTimeUnix,
+		CloseTime:  endTimeUnix,
+		Interval:   "60",
+		HighPrice:  high,
+		LowPrice:   low,
+		OpenPrice:  open,
+		ClosePrice: close,
+		Volume:     volume,
+	}
+}

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -56,7 +56,7 @@ func (k *Kraken) writeToWebsocket(message []byte) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	if k.Verbose {
-		log.Debugf("Sending message to WS: %v", message)
+		log.Debugf("Sending message to WS: %v", string(message))
 	}
 	return k.WebsocketConn.WriteMessage(websocket.TextMessage, message)
 }

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -307,7 +307,7 @@ func (k *Kraken) WithdrawFiatFundsToInternationalBank(withdrawRequest *exchange.
 
 // GetWebsocket returns a pointer to the exchange websocket
 func (k *Kraken) GetWebsocket() (*exchange.Websocket, error) {
-	return nil, common.ErrFunctionNotSupported
+	return k.Websocket, nil
 }
 
 // GetFeeByType returns an estimate of fee based on type of transaction

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1662,7 +1662,7 @@ func TestSubscribeToNonExistantChannel(t *testing.T) {
 		return
 	}
 	var errorReceived bool
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 7; i++ {
 		response := <-o.Websocket.DataHandler
 		if err, ok := response.(error); ok && err != nil {
 			t.Log(response)

--- a/exchanges/okgroup/okgroup_types.go
+++ b/exchanges/okgroup/okgroup_types.go
@@ -1135,12 +1135,12 @@ type GetSwapForceLiquidatedOrdersRequest struct {
 
 // GetSwapForceLiquidatedOrdersResponse response data for GetSwapForceLiquidatedOrders
 type GetSwapForceLiquidatedOrdersResponse struct {
-	Loss         float64 `json:"loss"`
-	Size         int64   `json:"size"`
-	Price        float64 `json:"price"`
+	Loss         float64 `json:"loss,string"`
+	Size         int64   `json:"size,string"`
+	Price        float64 `json:"price,string"`
 	CreatedAt    string  `json:"created_at"`
 	InstrumentID string  `json:"instrument_id"`
-	Type         int64   `json:"type"`
+	Type         int64   `json:"type,string"`
 }
 
 // GetSwapOnHoldAmountForOpenOrdersResponse response data for GetSwapOnHoldAmountForOpenOrders

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -1052,7 +1052,7 @@
   },
   {
    "name": "OKCOIN International",
-   "enabled": false,
+   "enabled": true,
    "verbose": false,
    "websocket": false,
    "useSandbox": false,

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -934,8 +934,8 @@
   {
    "name": "Kraken",
    "enabled": true,
-   "verbose": false,
-   "websocket": false,
+   "verbose": true,
+   "websocket": true,
    "useSandbox": false,
    "restPollingDelay": 10,
    "httpTimeout": 15000000000,
@@ -1052,7 +1052,7 @@
   },
   {
    "name": "OKCOIN International",
-   "enabled": true,
+   "enabled": false,
    "verbose": false,
    "websocket": false,
    "useSandbox": false,
@@ -1093,7 +1093,7 @@
   },
   {
    "name": "OKEX",
-   "enabled": true,
+   "enabled": false,
    "verbose": false,
    "websocket": false,
    "useSandbox": false,

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -934,7 +934,7 @@
   {
    "name": "Kraken",
    "enabled": true,
-   "verbose": true,
+   "verbose": false,
    "websocket": true,
    "useSandbox": false,
    "restPollingDelay": 10,
@@ -1093,7 +1093,7 @@
   },
   {
    "name": "OKEX",
-   "enabled": false,
+   "enabled": true,
    "verbose": false,
    "websocket": false,
    "useSandbox": false,


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/9261323/55305167-da8ed000-549a-11e9-8d3e-c56d4cf44395.png)

This PR adds Kraken websocket support to GCT

## Things to consider
- Kraken orderbook data keeps last updated timestamps per price. GCT orderbook data has it per update. So there is a chance that orderbook data can be technically out of sync. I try to address it by taking the last updated currency vs the latest ob update.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
New WS tests for kraken. All tests run simultaneously and builds and tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules