### PR TITLE
Binance websocket fixes for #271 & #270

### DIFF
--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -94,6 +94,7 @@ func (b *Binance) SetDefaults() {
 	b.APIUrlDefault = apiURL
 	b.APIUrl = b.APIUrlDefault
 	b.WebsocketInit()
+	b.WebsocketURL = binanceDefaultWebsocketURL
 	b.Websocket.Functionality = exchange.WebsocketTradeDataSupported |
 		exchange.WebsocketTickerSupported |
 		exchange.WebsocketKlineSupported |
@@ -112,6 +113,7 @@ func (b *Binance) Setup(exch *config.ExchangeConfig) {
 		b.SetHTTPClientUserAgent(exch.HTTPUserAgent)
 		b.RESTPollingDelay = exch.RESTPollingDelay
 		b.Verbose = exch.Verbose
+		b.Websocket.SetWsStatusAndConnection(exch.Websocket)
 		b.BaseCurrencies = exch.BaseCurrencies
 		b.AvailablePairs = exch.AvailablePairs
 		b.EnabledPairs = exch.EnabledPairs

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -185,6 +185,7 @@ func (b *Binance) WSConnect() error {
 // WSReadData reads from the websocket connection and returns the response
 func (b *Binance) WSReadData() (exchange.WebsocketResponse, error) {
 	msgType, resp, err := b.WebsocketConn.ReadMessage()
+
 	if err != nil {
 		return exchange.WebsocketResponse{}, err
 	}
@@ -226,8 +227,8 @@ func (b *Binance) WsHandleData() {
 						string(read.Raw))
 					continue
 				}
-
-				switch multiStreamData.Stream {
+				streamType := strings.Split(multiStreamData.Stream, "@")
+				switch streamType[1] {
 				case "trade":
 					trade := TradeStream{}
 

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -16,7 +16,6 @@ import (
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 	"github.com/thrasher-/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-/gocryptotrader/exchanges/ticker"
-	log "github.com/thrasher-/gocryptotrader/logger"
 )
 
 const (
@@ -172,7 +171,6 @@ func (b *Binance) WSConnect() error {
 		}
 	}
 
-	log.Debugf("%v", wsurl)
 	b.WebsocketConn, _, err = Dialer.Dial(wsurl, http.Header{})
 	if err != nil {
 		return fmt.Errorf("binance_websocket.go - Unable to connect to Websocket. Error: %s",

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -16,6 +16,7 @@ import (
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 	"github.com/thrasher-/gocryptotrader/exchanges/orderbook"
 	"github.com/thrasher-/gocryptotrader/exchanges/ticker"
+	log "github.com/thrasher-/gocryptotrader/logger"
 )
 
 const (
@@ -171,6 +172,7 @@ func (b *Binance) WSConnect() error {
 		}
 	}
 
+	log.Debugf("%v", wsurl)
 	b.WebsocketConn, _, err = Dialer.Dial(wsurl, http.Header{})
 	if err != nil {
 		return fmt.Errorf("binance_websocket.go - Unable to connect to Websocket. Error: %s",
@@ -275,17 +277,18 @@ func (b *Binance) WsHandleData() {
 
 					var wsTicker exchange.TickerData
 
-					wsTicker.Timestamp = time.Unix(0, t.EventTime)
+					wsTicker.Timestamp = time.Unix(t.EventTime/1000, 0)
 					wsTicker.Pair = currency.NewPairFromString(t.Symbol)
 					wsTicker.AssetType = ticker.Spot
 					wsTicker.Exchange = b.GetName()
-					wsTicker.ClosePrice, _ = strconv.ParseFloat(t.CurrDayClose, 64)
+					wsTicker.ClosePrice, _ = strconv.ParseFloat(t.PrevDayClose, 64)
 					wsTicker.Quantity, _ = strconv.ParseFloat(t.TotalTradedVolume, 64)
 					wsTicker.OpenPrice, _ = strconv.ParseFloat(t.OpenPrice, 64)
 					wsTicker.HighPrice, _ = strconv.ParseFloat(t.HighPrice, 64)
 					wsTicker.LowPrice, _ = strconv.ParseFloat(t.LowPrice, 64)
 
 					b.Websocket.DataHandler <- wsTicker
+
 					continue
 				case "kline":
 					kline := KlineStream{}

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -279,7 +279,7 @@ func (b *Binance) WsHandleData() {
 					wsTicker.Pair = currency.NewPairFromString(t.Symbol)
 					wsTicker.AssetType = ticker.Spot
 					wsTicker.Exchange = b.GetName()
-					wsTicker.ClosePrice, _ = strconv.ParseFloat(t.PrevDayClose, 64)
+					wsTicker.ClosePrice, _ = strconv.ParseFloat(t.CurrDayClose, 64)
 					wsTicker.Quantity, _ = strconv.ParseFloat(t.TotalTradedVolume, 64)
 					wsTicker.OpenPrice, _ = strconv.ParseFloat(t.OpenPrice, 64)
 					wsTicker.HighPrice, _ = strconv.ParseFloat(t.HighPrice, 64)


### PR DESCRIPTION
# Description

Updates binance to enable websocket cleanly 
Converts event timestamp to correct timestamp 
Also fixes a bug introduced in #161 the the switch statement does not correctly strip before the @ symbol causing no cases to be detected.

Fixes #271 #270 

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Automated testing using go test
Manual testing of binance endpoint and websocket data

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules