### PR TITLE
Offline worst case trade fees

### DIFF
--- a/exchanges/alphapoint/alphapoint_test.go
+++ b/exchanges/alphapoint/alphapoint_test.go
@@ -10,8 +10,8 @@ import (
 
 const (
 	onlineTest              = false
-	testAPIKey              = ""
-	testAPISecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	canManipulateRealOrders = false
 )
 
@@ -29,13 +29,13 @@ func TestSetDefaults(t *testing.T) {
 }
 
 func testSetAPIKey(a *Alphapoint) {
-	a.APIKey = testAPIKey
-	a.APISecret = testAPISecret
+	a.APIKey = apiKey
+	a.APISecret = apiSecret
 	a.AuthenticatedAPISupport = true
 }
 
 func testIsAPIKeysSet(a *Alphapoint) bool {
-	if testAPIKey != "" && testAPISecret != "" && a.AuthenticatedAPISupport {
+	if apiKey != "" && apiSecret != "" && a.AuthenticatedAPISupport {
 		return true
 	}
 	return false

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -454,8 +454,8 @@ func (a *ANX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency, feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -463,7 +463,8 @@ func (a *ANX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -463,7 +463,7 @@ func (a *ANX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/anx/anx.go
+++ b/exchanges/anx/anx.go
@@ -454,11 +454,17 @@ func (a *ANX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency, feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func (a *ANX) calculateTradingFee(purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/anx/anx_test.go
+++ b/exchanges/anx/anx_test.go
@@ -11,8 +11,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey              = ""
-	testAPISecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	canManipulateRealOrders = false
 )
 
@@ -54,8 +54,8 @@ func TestSetup(t *testing.T) {
 		t.Error("Test Failed - ANX Setup() init error")
 	}
 	a.Setup(&anxConfig)
-	a.APIKey = testAPIKey
-	a.APISecret = testAPISecret
+	a.APIKey = apiKey
+	a.APISecret = apiSecret
 	a.AuthenticatedAPISupport = true
 
 	if !a.Enabled {
@@ -135,6 +135,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
 		IsMaker:       false,
 		PurchasePrice: 1,
+	}
+}
+
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	a.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
 	}
 }
 
@@ -341,7 +356,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if testAPIKey != "" || testAPISecret != "" {
+	if apiKey != "" || apiSecret != "" {
 		_, err := a.GetAccountInfo()
 		if err != nil {
 			t.Error("test failed - GetAccountInfo() error:", err)

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -367,6 +367,10 @@ func (a *ANX) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (a *ANX) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (a.APIKey == "" || a.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return a.GetFee(feeBuilder)
 }
 

--- a/exchanges/anx/anx_wrapper.go
+++ b/exchanges/anx/anx_wrapper.go
@@ -368,7 +368,7 @@ func (a *ANX) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (a *ANX) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (a.APIKey == "" || a.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return a.GetFee(feeBuilder)

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -708,11 +708,17 @@ func (b *Binance) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount, multiplier)
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 // getMultiplier retrieves account based taker/maker fees

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -717,7 +717,7 @@ func (b *Binance) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/binance/binance.go
+++ b/exchanges/binance/binance.go
@@ -708,8 +708,8 @@ func (b *Binance) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount, multiplier)
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -717,7 +717,8 @@ func (b *Binance) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -11,8 +11,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey              = ""
-	testAPISecret           = ""
+	apiKey              = ""
+	apiSecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -31,8 +31,8 @@ func TestSetup(t *testing.T) {
 	}
 
 	binanceConfig.AuthenticatedAPISupport = true
-	binanceConfig.APIKey = testAPIKey
-	binanceConfig.APISecret = testAPISecret
+	binanceConfig.APIKey = apiKey
+	binanceConfig.APISecret = apiSecret
 	b.Setup(&binanceConfig)
 }
 
@@ -140,7 +140,7 @@ func TestGetBestPrice(t *testing.T) {
 func TestNewOrder(t *testing.T) {
 	t.Parallel()
 
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 	_, err := b.NewOrder(&NewOrderRequest{
@@ -160,7 +160,7 @@ func TestNewOrder(t *testing.T) {
 func TestCancelExistingOrder(t *testing.T) {
 	t.Parallel()
 
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 
@@ -173,7 +173,7 @@ func TestCancelExistingOrder(t *testing.T) {
 func TestQueryOrder(t *testing.T) {
 	t.Parallel()
 
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 
@@ -186,7 +186,7 @@ func TestQueryOrder(t *testing.T) {
 func TestOpenOrders(t *testing.T) {
 	t.Parallel()
 
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 
@@ -199,7 +199,7 @@ func TestOpenOrders(t *testing.T) {
 func TestAllOrders(t *testing.T) {
 	t.Parallel()
 
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 
@@ -210,7 +210,7 @@ func TestAllOrders(t *testing.T) {
 }
 
 func TestGetAccount(t *testing.T) {
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 	t.Parallel()
@@ -240,13 +240,28 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
 	var feeBuilder = setFeeBuilder()
 
-	if testAPIKey != "" || testAPISecret != "" {
+	if apiKey != "" || apiSecret != "" {
 		// CryptocurrencyTradeFee Basic
 		if resp, err := b.GetFee(feeBuilder); resp != float64(0.1) || err != nil {
 			t.Error(err)
@@ -455,7 +470,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 func TestGetAccountInfo(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 

--- a/exchanges/binance/binance_test.go
+++ b/exchanges/binance/binance_test.go
@@ -11,8 +11,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	apiKey              = ""
-	apiSecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	canManipulateRealOrders = false
 )
 

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -324,6 +324,10 @@ func (b *Binance) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Binance) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 }
 

--- a/exchanges/binance/binance_wrapper.go
+++ b/exchanges/binance/binance_wrapper.go
@@ -325,7 +325,7 @@ func (b *Binance) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Binance) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -1086,11 +1086,17 @@ func (b *Bitfinex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankDepositFee(feeBuilder.Amount)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 // GetCryptocurrencyWithdrawalFee returns an estimate of fee based on type of transaction

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -1086,8 +1086,8 @@ func (b *Bitfinex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankDepositFee(feeBuilder.Amount)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -1095,8 +1095,10 @@ func (b *Bitfinex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// does not require an API request, requires manual updating
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.001 * price * amount
 }
 
 // GetCryptocurrencyWithdrawalFee returns an estimate of fee based on type of transaction

--- a/exchanges/bitfinex/bitfinex.go
+++ b/exchanges/bitfinex/bitfinex.go
@@ -1095,7 +1095,7 @@ func (b *Bitfinex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 // does not require an API request, requires manual updating
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.001 * price * amount

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -14,8 +14,8 @@ import (
 
 // Please supply your own keys here to do better tests
 const (
-	testAPIKey              = ""
-	testAPISecret           = ""
+	apiKey              = ""
+	apiSecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -30,8 +30,8 @@ func TestSetup(t *testing.T) {
 		t.Error("Test Failed - Bitfinex Setup() init error")
 	}
 	b.Setup(&bfxConfig)
-	b.APIKey = testAPIKey
-	b.APISecret = testAPISecret
+	b.APIKey = apiKey
+	b.APISecret = apiSecret
 	if !b.Enabled || b.AuthenticatedAPISupport || b.RESTPollingDelay != time.Duration(10) ||
 		b.Verbose || b.Websocket.IsEnabled() || len(b.BaseCurrencies) < 1 ||
 		len(b.AvailablePairs) < 1 || len(b.EnabledPairs) < 1 {
@@ -619,12 +619,27 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 	var feeBuilder = setFeeBuilder()
 
-	if testAPIKey != "" || testAPISecret != "" {
+	if apiKey != "" || apiSecret != "" {
 		// CryptocurrencyTradeFee Basic
 		if resp, err := b.GetFee(feeBuilder); resp != float64(0.002) || err != nil {
 			t.Error(err)

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -14,8 +14,8 @@ import (
 
 // Please supply your own keys here to do better tests
 const (
-	apiKey              = ""
-	apiSecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	canManipulateRealOrders = false
 )
 

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -329,6 +329,10 @@ func (b *Bitfinex) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bitfinex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 }
 

--- a/exchanges/bitfinex/bitfinex_wrapper.go
+++ b/exchanges/bitfinex/bitfinex_wrapper.go
@@ -330,7 +330,7 @@ func (b *Bitfinex) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bitfinex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/bitflyer/bitflyer.go
+++ b/exchanges/bitflyer/bitflyer.go
@@ -404,17 +404,12 @@ func (b *Bitflyer) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.BankTransactionType, feeBuilder.FiatCurrency, feeBuilder.Amount)
 	case exchange.OfflineTradeFee:
-		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
-}
-
-// getOfflineTradeFee calculates the worst case-scenario trading fee
-func getOfflineTradeFee(price, amount float64) float64 {
-	return 0.0012 * price * amount
 }
 
 // calculateTradingFee returns fee when performing a trade

--- a/exchanges/bitflyer/bitflyer.go
+++ b/exchanges/bitflyer/bitflyer.go
@@ -403,8 +403,8 @@ func (b *Bitflyer) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getDepositFee(feeBuilder.BankTransactionType, feeBuilder.FiatCurrency)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.BankTransactionType, feeBuilder.FiatCurrency, feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -412,15 +412,15 @@ func (b *Bitflyer) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0012 * price * amount
 }
 
 // calculateTradingFee returns fee when performing a trade
-func calculateTradingFee(purchasePrice, amount float64) float64 {
-	fee := 0.0015
+func calculateTradingFee(price, amount float64) float64 {
 	// bitflyer has fee tiers, but does not disclose them via API, so the largest has to be assumed
-	return fee * amount * purchasePrice
+	return 0.0012 * price * amount
 }
 
 func getDepositFee(bankTransactionType exchange.InternationalBankTransactionType, c currency.Code) (fee float64) {

--- a/exchanges/bitflyer/bitflyer.go
+++ b/exchanges/bitflyer/bitflyer.go
@@ -412,7 +412,7 @@ func (b *Bitflyer) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0012 * price * amount
 }

--- a/exchanges/bitflyer/bitflyer.go
+++ b/exchanges/bitflyer/bitflyer.go
@@ -403,11 +403,17 @@ func (b *Bitflyer) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getDepositFee(feeBuilder.BankTransactionType, feeBuilder.FiatCurrency)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.BankTransactionType, feeBuilder.FiatCurrency, feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 // calculateTradingFee returns fee when performing a trade

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey              = ""
-	testAPISecret           = ""
+	apiKey              = ""
+	apiSecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -32,8 +32,8 @@ func TestSetup(t *testing.T) {
 	}
 
 	bitflyerConfig.AuthenticatedAPISupport = true
-	bitflyerConfig.APIKey = testAPIKey
-	bitflyerConfig.APISecret = testAPISecret
+	bitflyerConfig.APIKey = apiKey
+	bitflyerConfig.APISecret = apiSecret
 
 	b.Setup(&bitflyerConfig)
 }
@@ -159,12 +159,27 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 	var feeBuilder = setFeeBuilder()
 
-	if testAPIKey != "" || testAPISecret != "" {
+	if apiKey != "" || apiSecret != "" {
 		// CryptocurrencyTradeFee Basic
 		if resp, err := b.GetFee(feeBuilder); resp != float64(0) || err != nil {
 			t.Error(err)

--- a/exchanges/bitflyer/bitflyer_test.go
+++ b/exchanges/bitflyer/bitflyer_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	apiKey              = ""
-	apiSecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	canManipulateRealOrders = false
 )
 

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -236,5 +236,9 @@ func (b *Bitflyer) GetOrderHistory(getOrdersRequest *exchange.GetOrdersRequest) 
 
 // GetFeeByType returns an estimate of fee based on the type of transaction
 func (b *Bitflyer) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 }

--- a/exchanges/bitflyer/bitflyer_wrapper.go
+++ b/exchanges/bitflyer/bitflyer_wrapper.go
@@ -237,7 +237,7 @@ func (b *Bitflyer) GetOrderHistory(getOrdersRequest *exchange.GetOrdersRequest) 
 // GetFeeByType returns an estimate of fee based on the type of transaction
 func (b *Bitflyer) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -620,7 +620,7 @@ func (b *Bithumb) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.FiatCurrency)
 	case exchange.OfflineTradeFee:
-		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -628,15 +628,9 @@ func (b *Bithumb) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFee calculates the worst case-scenario trading fee
-func getOfflineTradeFee(price, amount float64) float64 {
-	return 0.002 * price * amount
-}
-
 // calculateTradingFee returns fee when performing a trade
 func calculateTradingFee(purchasePrice, amount float64) float64 {
-	fee := 0.0015
-	return fee * amount * purchasePrice
+	return 0.0025 * amount * purchasePrice
 }
 
 // getDepositFee returns fee on a currency when depositing small amounts to bithumb

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -619,11 +619,17 @@ func (b *Bithumb) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.FiatCurrency)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 // calculateTradingFee returns fee when performing a trade

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -619,8 +619,8 @@ func (b *Bithumb) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.FiatCurrency)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -628,7 +628,8 @@ func (b *Bithumb) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 

--- a/exchanges/bithumb/bithumb.go
+++ b/exchanges/bithumb/bithumb.go
@@ -628,7 +628,7 @@ func (b *Bithumb) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -11,8 +11,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey              = ""
-	testAPISecret           = ""
+	apiKey              = ""
+	apiSecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -31,8 +31,8 @@ func TestSetup(t *testing.T) {
 	}
 
 	bitConfig.AuthenticatedAPISupport = true
-	bitConfig.APIKey = testAPIKey
-	bitConfig.APISecret = testAPISecret
+	bitConfig.APIKey = apiKey
+	bitConfig.APISecret = apiSecret
 
 	b.Setup(&bitConfig)
 }
@@ -79,7 +79,7 @@ func TestGetTransactionHistory(t *testing.T) {
 
 func TestGetAccountBalance(t *testing.T) {
 	t.Parallel()
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 
@@ -90,7 +90,7 @@ func TestGetAccountBalance(t *testing.T) {
 }
 
 func TestGetWalletAddress(t *testing.T) {
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 
@@ -159,7 +159,7 @@ func TestWithdrawCrypto(t *testing.T) {
 
 func TestRequestKRWDepositDetails(t *testing.T) {
 	t.Parallel()
-	if testAPIKey == "" || testAPISecret == "" {
+	if apiKey == "" || apiSecret == "" {
 		t.Skip()
 	}
 	_, err := b.RequestKRWDepositDetails()
@@ -198,6 +198,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 		FeeType:       exchange.CryptocurrencyTradeFee,
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
 		PurchasePrice: 1,
+	}
+}
+
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
 	}
 }
 
@@ -406,7 +421,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 
 func TestGetAccountInfo(t *testing.T) {
 	t.Parallel()
-	if testAPIKey != "" || testAPISecret != "" {
+	if apiKey != "" || apiSecret != "" {
 		_, err := b.GetAccountInfo()
 		if err != nil {
 			t.Error("test failed - Bithumb GetAccountInfo() error", err)
@@ -505,7 +520,7 @@ func TestWithdrawInternationalBank(t *testing.T) {
 }
 
 func TestGetDepositAddress(t *testing.T) {
-	if testAPIKey != "" && testAPISecret != "" {
+	if apiKey != "" && apiSecret != "" {
 		_, err := b.GetDepositAddress(currency.BTC, "")
 		if err != nil {
 			t.Error("Test Failed - GetDepositAddress() error", err)

--- a/exchanges/bithumb/bithumb_test.go
+++ b/exchanges/bithumb/bithumb_test.go
@@ -11,8 +11,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	apiKey              = ""
-	apiSecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	canManipulateRealOrders = false
 )
 
@@ -222,25 +222,25 @@ func TestGetFee(t *testing.T) {
 	var feeBuilder = setFeeBuilder()
 
 	// CryptocurrencyTradeFee Basic
-	if resp, err := b.GetFee(feeBuilder); resp != float64(0.0015) || err != nil {
+	if resp, err := b.GetFee(feeBuilder); resp != float64(0.0025) || err != nil {
 		t.Error(err)
-		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.0015), resp)
+		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.0025), resp)
 	}
 
 	// CryptocurrencyTradeFee High quantity
 	feeBuilder = setFeeBuilder()
 	feeBuilder.Amount = 1000
 	feeBuilder.PurchasePrice = 1000
-	if resp, err := b.GetFee(feeBuilder); resp != float64(1500) || err != nil {
-		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(1500), resp)
+	if resp, err := b.GetFee(feeBuilder); resp != float64(2500) || err != nil {
+		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(2500), resp)
 		t.Error(err)
 	}
 
 	// CryptocurrencyTradeFee IsMaker
 	feeBuilder = setFeeBuilder()
 	feeBuilder.IsMaker = true
-	if resp, err := b.GetFee(feeBuilder); resp != float64(0.0015) || err != nil {
-		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.0015), resp)
+	if resp, err := b.GetFee(feeBuilder); resp != float64(0.0025) || err != nil {
+		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.0025), resp)
 		t.Error(err)
 	}
 

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -327,7 +327,7 @@ func (b *Bithumb) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bithumb) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/bithumb/bithumb_wrapper.go
+++ b/exchanges/bithumb/bithumb_wrapper.go
@@ -326,6 +326,10 @@ func (b *Bithumb) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bithumb) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 }
 

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -958,7 +958,6 @@ func getOfflineTradeFee(price, amount float64) float64 {
 // calculateTradingFee returns the fee for trading any currency on Bittrex
 func calculateTradingFee(purchasePrice, amount float64, isMaker bool) float64 {
 	var fee = 0.000750
-
 	if isMaker {
 		fee -= 0.000250
 	}

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -950,7 +950,7 @@ func (b *Bitmex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, err
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.000750 * price * amount
 }

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -941,8 +941,8 @@ func (b *Bitmex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	switch feeBuilder.FeeType {
 	case exchange.CryptocurrencyTradeFee:
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount, feeBuilder.IsMaker)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -950,8 +950,9 @@ func (b *Bitmex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, err
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.000750 * price * amount
 }
 
 // calculateTradingFee returns the fee for trading any currency on Bittrex

--- a/exchanges/bitmex/bitmex.go
+++ b/exchanges/bitmex/bitmex.go
@@ -938,14 +938,20 @@ func (b *Bitmex) CaptureError(resp, reType interface{}) error {
 func (b *Bitmex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	var fee float64
 	var err error
-
-	if feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+	switch feeBuilder.FeeType {
+	case exchange.CryptocurrencyTradeFee:
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount, feeBuilder.IsMaker)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, err
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 // calculateTradingFee returns the fee for trading any currency on Bittrex

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -13,8 +13,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	apiKey              = ""
-	apiSecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	canManipulateRealOrders = false
 )
 

--- a/exchanges/bitmex/bitmex_test.go
+++ b/exchanges/bitmex/bitmex_test.go
@@ -13,8 +13,8 @@ import (
 
 // Please supply your own keys here for due diligence testing
 const (
-	testAPIKey              = ""
-	testAPISecret           = ""
+	apiKey              = ""
+	apiSecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -32,8 +32,8 @@ func TestSetup(t *testing.T) {
 		t.Error("Test Failed - Bitmex Setup() init error")
 	}
 	bitmexConfig.AuthenticatedAPISupport = true
-	bitmexConfig.APIKey = testAPIKey
-	bitmexConfig.APISecret = testAPISecret
+	bitmexConfig.APIKey = apiKey
+	bitmexConfig.APISecret = apiSecret
 
 	b.Setup(&bitmexConfig)
 }
@@ -369,12 +369,26 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)
 
 	var feeBuilder = setFeeBuilder()
-
 	// CryptocurrencyTradeFee Basic
 	if resp, err := b.GetFee(feeBuilder); resp != float64(0.00075) || err != nil {
 		t.Error(err)
@@ -576,7 +590,7 @@ func TestCancelAllExchangeOrders(t *testing.T) {
 }
 
 func TestGetAccountInfo(t *testing.T) {
-	if testAPIKey != "" || testAPISecret != "" {
+	if apiKey != "" || apiSecret != "" {
 		_, err := b.GetAccountInfo()
 		if err != nil {
 			t.Error("Test Failed - GetAccountInfo() error", err)

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -305,6 +305,10 @@ func (b *Bitmex) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bitmex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 }
 

--- a/exchanges/bitmex/bitmex_wrapper.go
+++ b/exchanges/bitmex/bitmex_wrapper.go
@@ -306,7 +306,7 @@ func (b *Bitmex) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bitmex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -164,11 +164,17 @@ func (b *Bitstamp) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankDepositFee(feeBuilder.Amount)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 // getInternationalBankWithdrawalFee returns international withdrawal fee

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -164,8 +164,8 @@ func (b *Bitstamp) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankDepositFee(feeBuilder.Amount)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -173,8 +173,9 @@ func (b *Bitstamp) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0025 * price * amount
 }
 
 // getInternationalBankWithdrawalFee returns international withdrawal fee

--- a/exchanges/bitstamp/bitstamp.go
+++ b/exchanges/bitstamp/bitstamp.go
@@ -173,7 +173,7 @@ func (b *Bitstamp) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0025 * price * amount
 }

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please add your private keys and customerID for better tests
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	apiKey              = ""
+	apiSecret           = ""
 	customerID              = "" // This is the customer id you use to log in
 	canManipulateRealOrders = false
 )
@@ -67,6 +67,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 		FeeType:       exchange.CryptocurrencyTradeFee,
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
 		PurchasePrice: 1,
+	}
+}
+
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
 	}
 }
 

--- a/exchanges/bitstamp/bitstamp_test.go
+++ b/exchanges/bitstamp/bitstamp_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please add your private keys and customerID for better tests
 const (
-	apiKey              = ""
-	apiSecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	customerID              = "" // This is the customer id you use to log in
 	canManipulateRealOrders = false
 )

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -95,7 +95,7 @@ func (b *Bitstamp) GetTickerPrice(p currency.Pair, assetType string) (ticker.Pri
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bitstamp) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/bitstamp/bitstamp_wrapper.go
+++ b/exchanges/bitstamp/bitstamp_wrapper.go
@@ -94,6 +94,10 @@ func (b *Bitstamp) GetTickerPrice(p currency.Pair, assetType string) (ticker.Pri
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bitstamp) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 
 }

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -530,6 +530,8 @@ func (b *Bittrex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee, err = b.GetWithdrawalFee(feeBuilder.Pair.Base)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -551,6 +553,10 @@ func (b *Bittrex) GetWithdrawalFee(c currency.Code) (float64, error) {
 		}
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 // calculateTradingFee returns the fee for trading any currency on Bittrex

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -555,7 +555,7 @@ func (b *Bittrex) GetWithdrawalFee(c currency.Code) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0025 * price * amount
 }

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -531,7 +531,7 @@ func (b *Bittrex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee, err = b.GetWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.OfflineTradeFee:
-		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -553,11 +553,6 @@ func (b *Bittrex) GetWithdrawalFee(c currency.Code) (float64, error) {
 		}
 	}
 	return fee, nil
-}
-
-// getOfflineTradeFee calculates the worst case-scenario trading fee
-func getOfflineTradeFee(price, amount float64) float64 {
-	return 0.0025 * price * amount
 }
 
 // calculateTradingFee returns the fee for trading any currency on Bittrex

--- a/exchanges/bittrex/bittrex.go
+++ b/exchanges/bittrex/bittrex.go
@@ -530,8 +530,8 @@ func (b *Bittrex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee, err = b.GetWithdrawalFee(feeBuilder.Pair.Base)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -555,12 +555,13 @@ func (b *Bittrex) GetWithdrawalFee(c currency.Code) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0025 * price * amount
 }
 
 // calculateTradingFee returns the fee for trading any currency on Bittrex
-func calculateTradingFee(purchasePrice, amount float64) float64 {
-	var fee = 0.0025
-	return fee * purchasePrice * amount
+func calculateTradingFee(price, amount float64) float64 {
+	return 0.0025 * price * amount
+
 }

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please supply you own test keys here to run better tests.
 const (
-	apiKey                  = ""
-	apiSecret               = ""
+	apiKey              = ""
+	apiSecret           = ""
 	canManipulateRealOrders = false
 )
 
@@ -225,6 +225,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 		FeeType:       exchange.CryptocurrencyTradeFee,
 		Pair:          currency.NewPair(currency.BTC, currency.LTC),
 		PurchasePrice: 1,
+	}
+}
+
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
 	}
 }
 

--- a/exchanges/bittrex/bittrex_test.go
+++ b/exchanges/bittrex/bittrex_test.go
@@ -12,8 +12,8 @@ import (
 
 // Please supply you own test keys here to run better tests.
 const (
-	apiKey              = ""
-	apiSecret           = ""
+	apiKey                  = ""
+	apiSecret               = ""
 	canManipulateRealOrders = false
 )
 

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -300,6 +300,10 @@ func (b *Bittrex) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bittrex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 
 }

--- a/exchanges/bittrex/bittrex_wrapper.go
+++ b/exchanges/bittrex/bittrex_wrapper.go
@@ -301,7 +301,7 @@ func (b *Bittrex) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *Bittrex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/btcc/btcc.go
+++ b/exchanges/btcc/btcc.go
@@ -104,11 +104,17 @@ func (b *BTCC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency, feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func getCryptocurrencyWithdrawalFee(c currency.Code) float64 {

--- a/exchanges/btcc/btcc.go
+++ b/exchanges/btcc/btcc.go
@@ -104,8 +104,8 @@ func (b *BTCC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency, feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -113,8 +113,9 @@ func (b *BTCC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.001 * price * amount
 }
 
 func getCryptocurrencyWithdrawalFee(c currency.Code) float64 {

--- a/exchanges/btcc/btcc.go
+++ b/exchanges/btcc/btcc.go
@@ -113,7 +113,7 @@ func (b *BTCC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.001 * price * amount
 }

--- a/exchanges/btcc/btcc_test.go
+++ b/exchanges/btcc/btcc_test.go
@@ -84,6 +84,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -158,6 +158,10 @@ func (b *BTCC) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *BTCC) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 }
 

--- a/exchanges/btcc/btcc_wrapper.go
+++ b/exchanges/btcc/btcc_wrapper.go
@@ -159,7 +159,7 @@ func (b *BTCC) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *BTCC) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -506,8 +506,8 @@ func (b *BTCMarkets) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -515,8 +515,9 @@ func (b *BTCMarkets) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0085 * price * amount
 }
 
 func calculateTradingFee(tradingFee TradingFee, purchasePrice, amount float64) (fee float64) {

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -515,7 +515,7 @@ func (b *BTCMarkets) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0085 * price * amount
 }

--- a/exchanges/btcmarkets/btcmarkets.go
+++ b/exchanges/btcmarkets/btcmarkets.go
@@ -506,11 +506,17 @@ func (b *BTCMarkets) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(tradingFee TradingFee, purchasePrice, amount float64) (fee float64) {

--- a/exchanges/btcmarkets/btcmarkets_test.go
+++ b/exchanges/btcmarkets/btcmarkets_test.go
@@ -174,6 +174,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -333,7 +333,7 @@ func (b *BTCMarkets) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *BTCMarkets) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/btcmarkets/btcmarkets_wrapper.go
+++ b/exchanges/btcmarkets/btcmarkets_wrapper.go
@@ -332,6 +332,10 @@ func (b *BTCMarkets) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *BTCMarkets) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 }
 

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -304,7 +304,7 @@ func (b *BTSE) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0015 * price * amount
 }

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -298,8 +298,14 @@ func (b *BTSE) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankDepositFee(feeBuilder.Amount)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 // getInternationalBankDepositFee returns international deposit fee

--- a/exchanges/btse/btse.go
+++ b/exchanges/btse/btse.go
@@ -298,14 +298,15 @@ func (b *BTSE) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankDepositFee(feeBuilder.Amount)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0015 * price * amount
 }
 
 // getInternationalBankDepositFee returns international deposit fee

--- a/exchanges/btse/btse_test.go
+++ b/exchanges/btse/btse_test.go
@@ -140,6 +140,27 @@ func TestFormatWithdrawPermissions(t *testing.T) {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	feeBuilder := &exchange.FeeBuilder{
+		FeeType: exchange.CryptocurrencyTradeFee,
+		Pair:    currency.NewPair(currency.BTC, currency.USD),
+		IsMaker: true,
+		Amount:  1000,
+	}
+
+	b.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	b.SetDefaults()
 	TestSetup(t)

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -348,5 +348,9 @@ func (b *BTSE) GetOrderHistory(getOrdersRequest *exchange.GetOrdersRequest) ([]e
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *BTSE) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return b.GetFee(feeBuilder)
 }

--- a/exchanges/btse/btse_wrapper.go
+++ b/exchanges/btse/btse_wrapper.go
@@ -349,7 +349,7 @@ func (b *BTSE) GetOrderHistory(getOrdersRequest *exchange.GetOrdersRequest) ([]e
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (b *BTSE) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (b.APIKey == "" || b.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return b.GetFee(feeBuilder)

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -854,8 +854,8 @@ func (c *CoinbasePro) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency)
 	case exchange.InternationalBankDepositFee:
 		fee = getInternationalBankDepositFee(feeBuilder.FiatCurrency)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -865,8 +865,9 @@ func (c *CoinbasePro) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0025 * price * amount
 }
 
 func (c *CoinbasePro) calculateTradingFee(trailingVolume []Volume, base, quote currency.Code, delimiter string, purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -854,6 +854,8 @@ func (c *CoinbasePro) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency)
 	case exchange.InternationalBankDepositFee:
 		fee = getInternationalBankDepositFee(feeBuilder.FiatCurrency)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -861,6 +863,10 @@ func (c *CoinbasePro) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func (c *CoinbasePro) calculateTradingFee(trailingVolume []Volume, base, quote currency.Code, delimiter string, purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/coinbasepro/coinbasepro.go
+++ b/exchanges/coinbasepro/coinbasepro.go
@@ -865,7 +865,7 @@ func (c *CoinbasePro) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0025 * price * amount
 }

--- a/exchanges/coinbasepro/coinbasepro_test.go
+++ b/exchanges/coinbasepro/coinbasepro_test.go
@@ -230,6 +230,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	c.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -288,6 +288,10 @@ func (c *CoinbasePro) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (c *CoinbasePro) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (c.APIKey == "" || c.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return c.GetFee(feeBuilder)
 }
 

--- a/exchanges/coinbasepro/coinbasepro_wrapper.go
+++ b/exchanges/coinbasepro/coinbasepro_wrapper.go
@@ -289,7 +289,7 @@ func (c *CoinbasePro) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (c *CoinbasePro) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (c.APIKey == "" || c.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return c.GetFee(feeBuilder)

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -424,9 +424,8 @@ func (c *COINUT) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
 	if c.IsCryptoFiatPair() {
 		return 0.0035 * price * amount
-	} else {
-		return 0.002 * price * amount
 	}
+	return 0.002 * price * amount
 }
 
 func (c *COINUT) calculateTradingFee(base, quote currency.Code, purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -409,6 +409,8 @@ func (c *COINUT) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	case exchange.InternationalBankDepositFee:
 		fee = getInternationalBankDepositFee(feeBuilder.FiatCurrency,
 			feeBuilder.Amount)
+		case exchange.SimulatedTransactionFee:
+			fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -416,6 +418,10 @@ func (c *COINUT) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func (c *COINUT) calculateTradingFee(base, quote currency.Code, purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -409,8 +409,8 @@ func (c *COINUT) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	case exchange.InternationalBankDepositFee:
 		fee = getInternationalBankDepositFee(feeBuilder.FiatCurrency,
 			feeBuilder.Amount)
-		case exchange.SimulatedTransactionFee:
-			fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -420,8 +420,14 @@ func (c *COINUT) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
+	if c.IsCryptoFiatPair() {
+		return 0.0035 * price * amount
+
+	} else {
+		return 0.002 * price * amount
+	}
 }
 
 func (c *COINUT) calculateTradingFee(base, quote currency.Code, purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -424,7 +424,6 @@ func (c *COINUT) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
 	if c.IsCryptoFiatPair() {
 		return 0.0035 * price * amount
-
 	} else {
 		return 0.002 * price * amount
 	}

--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -420,7 +420,7 @@ func (c *COINUT) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
 	if c.IsCryptoFiatPair() {
 		return 0.0035 * price * amount

--- a/exchanges/coinut/coinut_test.go
+++ b/exchanges/coinut/coinut_test.go
@@ -59,6 +59,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	c.GetFeeByType(feeBuilder)
+	if apiKey == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	c.SetDefaults()
 	TestSetup(t)

--- a/exchanges/coinut/coinut_wrapper.go
+++ b/exchanges/coinut/coinut_wrapper.go
@@ -383,6 +383,10 @@ func (c *COINUT) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (c *COINUT) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if c.APIKey == "" && // Todo check connection status
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return c.GetFee(feeBuilder)
 }
 

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -31,42 +31,42 @@ const (
 )
 
 // FeeType custom type for calculating fees based on method
-type FeeType string
-
-// InternationalBankTransactionType custom type for calculating fees based on fiat transaction types
-type InternationalBankTransactionType string
+type FeeType int
 
 // Const declarations for fee types
 const (
-	BankFee                        FeeType = "bankFee"
-	InternationalBankDepositFee    FeeType = "internationalBankDepositFee"
-	InternationalBankWithdrawalFee FeeType = "internationalBankWithdrawalFee"
-	CryptocurrencyTradeFee         FeeType = "cryptocurrencyTradeFee"
-	CyptocurrencyDepositFee        FeeType = "cyptocurrencyDepositFee"
-	CryptocurrencyWithdrawalFee    FeeType = "cryptocurrencyWithdrawalFee"
-	SimulatedTransactionFee        FeeType = "simulatedTransactionFee"
+	BankFee                        FeeType = 0
+	InternationalBankDepositFee    FeeType = 1
+	InternationalBankWithdrawalFee FeeType = 2
+	CryptocurrencyTradeFee         FeeType = 3
+	CyptocurrencyDepositFee        FeeType = 4
+	CryptocurrencyWithdrawalFee    FeeType = 5
+	OfflineTradeFee        FeeType = 6
 )
+
+// InternationalBankTransactionType custom type for calculating fees based on fiat transaction types
+type InternationalBankTransactionType int
 
 // Const declarations for international transaction types
 const (
-	WireTransfer    InternationalBankTransactionType = "wireTransfer"
-	PerfectMoney    InternationalBankTransactionType = "perfectMoney"
-	Neteller        InternationalBankTransactionType = "neteller"
-	AdvCash         InternationalBankTransactionType = "advCash"
-	Payeer          InternationalBankTransactionType = "payeer"
-	Skrill          InternationalBankTransactionType = "skrill"
-	Simplex         InternationalBankTransactionType = "simplex"
-	SEPA            InternationalBankTransactionType = "sepa"
-	Swift           InternationalBankTransactionType = "swift"
-	RapidTransfer   InternationalBankTransactionType = "rapidTransfer"
-	MisterTangoSEPA InternationalBankTransactionType = "misterTangoSepa"
-	Qiwi            InternationalBankTransactionType = "qiwi"
-	VisaMastercard  InternationalBankTransactionType = "visaMastercard"
-	WebMoney        InternationalBankTransactionType = "webMoney"
-	Capitalist      InternationalBankTransactionType = "capitalist"
-	WesternUnion    InternationalBankTransactionType = "westernUnion"
-	MoneyGram       InternationalBankTransactionType = "moneyGram"
-	Contact         InternationalBankTransactionType = "contact"
+	WireTransfer    InternationalBankTransactionType = 0
+	PerfectMoney    InternationalBankTransactionType = 1
+	Neteller        InternationalBankTransactionType = 2
+	AdvCash         InternationalBankTransactionType = 3
+	Payeer          InternationalBankTransactionType = 4
+	Skrill          InternationalBankTransactionType = 5
+	Simplex         InternationalBankTransactionType = 6
+	SEPA            InternationalBankTransactionType = 7
+	Swift           InternationalBankTransactionType = 8
+	RapidTransfer   InternationalBankTransactionType = 9
+	MisterTangoSEPA InternationalBankTransactionType = 10
+	Qiwi            InternationalBankTransactionType = 11
+	VisaMastercard  InternationalBankTransactionType = 12
+	WebMoney        InternationalBankTransactionType = 13
+	Capitalist      InternationalBankTransactionType = 14
+	WesternUnion    InternationalBankTransactionType = 15
+	MoneyGram       InternationalBankTransactionType = 16
+	Contact         InternationalBankTransactionType = 17
 )
 
 // SubmitOrderResponse is what is returned after submitting an order to an
@@ -79,25 +79,22 @@ type SubmitOrderResponse struct {
 // FeeBuilder is the type which holds all parameters required to calculate a fee
 // for an exchange
 type FeeBuilder struct {
-	FeeType FeeType
-	// Used for calculating crypto trading fees, deposits & withdrawals
-	Pair    currency.Pair
-	IsMaker bool
-	// Fiat currency used for bank deposits & withdrawals
+	IsMaker             bool
+	PurchasePrice       float64
+	Amount              float64
+	FeeType             FeeType
 	FiatCurrency        currency.Code
 	BankTransactionType InternationalBankTransactionType
-	// Used to multiply for fee calculations
-	PurchasePrice float64
-	Amount        float64
+	Pair                currency.Pair
 }
 
 // OrderCancellation type required when requesting to cancel an order
 type OrderCancellation struct {
 	AccountID     string
 	OrderID       string
-	CurrencyPair  currency.Pair
 	WalletAddress string
 	Side          OrderSide
+	CurrencyPair  currency.Pair
 }
 
 // WithdrawRequest used for wrapper crypto and FIAT withdraw methods

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -31,42 +31,42 @@ const (
 )
 
 // FeeType custom type for calculating fees based on method
-type FeeType int
+type FeeType uint8
 
 // Const declarations for fee types
 const (
-	BankFee                        FeeType = 0
-	InternationalBankDepositFee    FeeType = 1
-	InternationalBankWithdrawalFee FeeType = 2
-	CryptocurrencyTradeFee         FeeType = 3
-	CyptocurrencyDepositFee        FeeType = 4
-	CryptocurrencyWithdrawalFee    FeeType = 5
-	OfflineTradeFee                FeeType = 6
+	BankFee FeeType = iota
+	InternationalBankDepositFee
+	InternationalBankWithdrawalFee
+	CryptocurrencyTradeFee
+	CyptocurrencyDepositFee
+	CryptocurrencyWithdrawalFee
+	OfflineTradeFee
 )
 
 // InternationalBankTransactionType custom type for calculating fees based on fiat transaction types
-type InternationalBankTransactionType int
+type InternationalBankTransactionType uint8
 
 // Const declarations for international transaction types
 const (
-	WireTransfer    InternationalBankTransactionType = 0
-	PerfectMoney    InternationalBankTransactionType = 1
-	Neteller        InternationalBankTransactionType = 2
-	AdvCash         InternationalBankTransactionType = 3
-	Payeer          InternationalBankTransactionType = 4
-	Skrill          InternationalBankTransactionType = 5
-	Simplex         InternationalBankTransactionType = 6
-	SEPA            InternationalBankTransactionType = 7
-	Swift           InternationalBankTransactionType = 8
-	RapidTransfer   InternationalBankTransactionType = 9
-	MisterTangoSEPA InternationalBankTransactionType = 10
-	Qiwi            InternationalBankTransactionType = 11
-	VisaMastercard  InternationalBankTransactionType = 12
-	WebMoney        InternationalBankTransactionType = 13
-	Capitalist      InternationalBankTransactionType = 14
-	WesternUnion    InternationalBankTransactionType = 15
-	MoneyGram       InternationalBankTransactionType = 16
-	Contact         InternationalBankTransactionType = 17
+	WireTransfer InternationalBankTransactionType = iota
+	PerfectMoney
+	Neteller
+	AdvCash
+	Payeer
+	Skrill
+	Simplex
+	SEPA
+	Swift
+	RapidTransfer
+	MisterTangoSEPA
+	Qiwi
+	VisaMastercard
+	WebMoney
+	Capitalist
+	WesternUnion
+	MoneyGram
+	Contact
 )
 
 // SubmitOrderResponse is what is returned after submitting an order to an

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -44,6 +44,7 @@ const (
 	CryptocurrencyTradeFee         FeeType = "cryptocurrencyTradeFee"
 	CyptocurrencyDepositFee        FeeType = "cyptocurrencyDepositFee"
 	CryptocurrencyWithdrawalFee    FeeType = "cryptocurrencyWithdrawalFee"
+	SimulatedTransactionFee        FeeType = "simulatedTransactionFee"
 )
 
 // Const declarations for international transaction types

--- a/exchanges/exchange.go
+++ b/exchanges/exchange.go
@@ -41,7 +41,7 @@ const (
 	CryptocurrencyTradeFee         FeeType = 3
 	CyptocurrencyDepositFee        FeeType = 4
 	CryptocurrencyWithdrawalFee    FeeType = 5
-	OfflineTradeFee        FeeType = 6
+	OfflineTradeFee                FeeType = 6
 )
 
 // InternationalBankTransactionType custom type for calculating fees based on fiat transaction types

--- a/exchanges/exmo/exmo.go
+++ b/exchanges/exmo/exmo.go
@@ -443,7 +443,7 @@ func (e *EXMO) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/exmo/exmo.go
+++ b/exchanges/exmo/exmo.go
@@ -432,6 +432,8 @@ func (e *EXMO) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankDepositFee(feeBuilder.FiatCurrency,
 			feeBuilder.Amount,
 			feeBuilder.BankTransactionType)
+		case exchange.SimulatedTransactionFee:
+			fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -439,6 +441,10 @@ func (e *EXMO) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func getCryptocurrencyWithdrawalFee(c currency.Code) float64 {

--- a/exchanges/exmo/exmo.go
+++ b/exchanges/exmo/exmo.go
@@ -433,7 +433,7 @@ func (e *EXMO) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 			feeBuilder.Amount,
 			feeBuilder.BankTransactionType)
 	case exchange.OfflineTradeFee:
-		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -441,11 +441,6 @@ func (e *EXMO) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	}
 
 	return fee, nil
-}
-
-// getOfflineTradeFee calculates the worst case-scenario trading fee
-func getOfflineTradeFee(price, amount float64) float64 {
-	return 0.002 * price * amount
 }
 
 func getCryptocurrencyWithdrawalFee(c currency.Code) float64 {

--- a/exchanges/exmo/exmo.go
+++ b/exchanges/exmo/exmo.go
@@ -421,7 +421,7 @@ func (e *EXMO) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	var fee float64
 	switch feeBuilder.FeeType {
 	case exchange.CryptocurrencyTradeFee:
-		fee = e.calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
 	case exchange.InternationalBankWithdrawalFee:
@@ -432,8 +432,8 @@ func (e *EXMO) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankDepositFee(feeBuilder.FiatCurrency,
 			feeBuilder.Amount,
 			feeBuilder.BankTransactionType)
-		case exchange.SimulatedTransactionFee:
-			fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -443,7 +443,8 @@ func (e *EXMO) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 
@@ -451,14 +452,8 @@ func getCryptocurrencyWithdrawalFee(c currency.Code) float64 {
 	return WithdrawalFees[c]
 }
 
-func (e *EXMO) calculateTradingFee(purchasePrice, amount float64) float64 {
-	fee := 0.002
-	return fee * amount * purchasePrice
-}
-
-func calculateTradingFee(purchasePrice, amount float64) float64 {
-	fee := 0.002
-	return fee * amount * purchasePrice
+func calculateTradingFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func getInternationalBankWithdrawalFee(c currency.Code, amount float64, bankTransactionType exchange.InternationalBankTransactionType) float64 {

--- a/exchanges/exmo/exmo_test.go
+++ b/exchanges/exmo/exmo_test.go
@@ -116,6 +116,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	e.GetFeeByType(feeBuilder)
+	if APIKey == "" || APISecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	e.SetDefaults()
 	TestSetup(t)

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -316,6 +316,10 @@ func (e *EXMO) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (e *EXMO) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (e.APIKey == "" || e.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return e.GetFee(feeBuilder)
 }
 

--- a/exchanges/exmo/exmo_wrapper.go
+++ b/exchanges/exmo/exmo_wrapper.go
@@ -317,7 +317,7 @@ func (e *EXMO) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (e *EXMO) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (e.APIKey == "" || e.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return e.GetFee(feeBuilder)

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -538,6 +538,8 @@ func (g *Gateio) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, err error
 
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -545,6 +547,10 @@ func (g *Gateio) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, err error
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(feeForPair, purchasePrice, amount float64) float64 {

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -549,7 +549,7 @@ func (g *Gateio) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, err error
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -538,8 +538,8 @@ func (g *Gateio) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, err error
 
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getCryptocurrencyWithdrawalFee(feeBuilder.Pair.Base)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -549,7 +549,8 @@ func (g *Gateio) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, err error
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -156,6 +156,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	g.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	g.SetDefaults()
 	TestSetup(t)

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -332,6 +332,10 @@ func (g *Gateio) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (g *Gateio) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (g.APIKey == "" || g.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return g.GetFee(feeBuilder)
 }
 

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -333,7 +333,7 @@ func (g *Gateio) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (g *Gateio) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (g.APIKey == "" || g.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return g.GetFee(feeBuilder)

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -546,12 +546,18 @@ func (g *Gemini) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		// Could do via trade history, but would require analysis of response and dates to determine level of fee
 	case exchange.InternationalBankWithdrawalFee:
 		fee = 0
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(notionVolume *NotionalVolume, purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -556,7 +556,7 @@ func (g *Gemini) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.01 * price * amount
 }

--- a/exchanges/gemini/gemini.go
+++ b/exchanges/gemini/gemini.go
@@ -546,8 +546,8 @@ func (g *Gemini) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		// Could do via trade history, but would require analysis of response and dates to determine level of fee
 	case exchange.InternationalBankWithdrawalFee:
 		fee = 0
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -556,8 +556,9 @@ func (g *Gemini) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.01 * price * amount
 }
 
 func calculateTradingFee(notionVolume *NotionalVolume, purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/gemini/gemini_test.go
+++ b/exchanges/gemini/gemini_test.go
@@ -247,6 +247,24 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	TestAddSession(t)
+	TestSetDefaults(t)
+	TestSetup(t)
+	var feeBuilder = setFeeBuilder()
+	Session[1].GetFeeByType(feeBuilder)
+	if apiKey1 == "" || apiSecret1 == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	var feeBuilder = setFeeBuilder()
 	if apiKey1 != "" && apiSecret1 != "" {
@@ -342,7 +360,6 @@ func TestGetActiveOrders(t *testing.T) {
 	TestAddSession(t)
 	TestSetDefaults(t)
 	TestSetup(t)
-	Session[1].Verbose = true
 
 	var getOrdersRequest = exchange.GetOrdersRequest{
 		OrderType:  exchange.AnyOrderType,
@@ -361,7 +378,6 @@ func TestGetOrderHistory(t *testing.T) {
 	TestAddSession(t)
 	TestSetDefaults(t)
 	TestSetup(t)
-	Session[1].Verbose = true
 
 	var getOrdersRequest = exchange.GetOrdersRequest{
 		OrderType:  exchange.AnyOrderType,

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -260,7 +260,7 @@ func (g *Gemini) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (g *Gemini) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (g.APIKey == "" || g.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return g.GetFee(feeBuilder)

--- a/exchanges/gemini/gemini_wrapper.go
+++ b/exchanges/gemini/gemini_wrapper.go
@@ -259,6 +259,10 @@ func (g *Gemini) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (g *Gemini) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (g.APIKey == "" || g.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return g.GetFee(feeBuilder)
 }
 

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -641,9 +641,18 @@ func (h *HitBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	case exchange.CyptocurrencyDepositFee:
 		fee = calculateCryptocurrencyDepositFee(feeBuilder.Pair.Base,
 			feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	}
+	if fee < 0 {
+		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateCryptocurrencyDepositFee(c currency.Code, amount float64) float64 {

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -651,7 +651,7 @@ func (h *HitBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/hitbtc/hitbtc.go
+++ b/exchanges/hitbtc/hitbtc.go
@@ -641,8 +641,8 @@ func (h *HitBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	case exchange.CyptocurrencyDepositFee:
 		fee = calculateCryptocurrencyDepositFee(feeBuilder.Pair.Base,
 			feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -651,7 +651,8 @@ func (h *HitBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 

--- a/exchanges/hitbtc/hitbtc_test.go
+++ b/exchanges/hitbtc/hitbtc_test.go
@@ -75,6 +75,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	h.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	h.SetDefaults()
 	TestSetup(t)

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -287,7 +287,7 @@ func (h *HitBTC) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (h *HitBTC) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (h.APIKey == "" || h.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return h.GetFee(feeBuilder)

--- a/exchanges/hitbtc/hitbtc_wrapper.go
+++ b/exchanges/hitbtc/hitbtc_wrapper.go
@@ -286,6 +286,10 @@ func (h *HitBTC) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (h *HitBTC) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (h.APIKey == "" || h.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return h.GetFee(feeBuilder)
 }
 

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -913,29 +913,12 @@ func (h *HUOBI) SendAuthenticatedHTTPRequest(method, endpoint string, values url
 
 // GetFee returns an estimate of fee based on type of transaction
 func (h *HUOBI) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
-	var fee float64
-	switch feeBuilder.FeeType {
-	case exchange.CryptocurrencyTradeFee:
-		fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
-	case exchange.OfflineTradeFee:
-		fee = getOfflineTradeFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
-	}
-
+	var fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
-}
-
-// getOfflineTradeFee calculates the worst case-scenario trading fee
-func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
-	if c.IsCryptoFiatPair() {
-		return 0.001 * price * amount
-
-	} else {
-		return 0.002 * price * amount
-	}
 }
 
 func calculateTradingFee(c currency.Pair, price, amount float64) float64 {

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -916,9 +916,9 @@ func (h *HUOBI) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	var fee float64
 	switch feeBuilder.FeeType {
 	case exchange.CryptocurrencyTradeFee:
-		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+		fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -928,11 +928,21 @@ func (h *HUOBI) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
+	if c.IsCryptoFiatPair() {
+		return 0.001 * price * amount
+
+	} else {
+		return 0.002 * price * amount
+	}
 }
 
-func calculateTradingFee(purchasePrice, amount float64) float64 {
-	feePercent := 0.002
-	return feePercent * purchasePrice * amount
+func calculateTradingFee(c currency.Pair, price, amount float64) float64 {
+	if c.IsCryptoFiatPair() {
+		return 0.001 * price * amount
+
+	} else {
+		return 0.002 * price * amount
+	}
 }

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -914,14 +914,22 @@ func (h *HUOBI) SendAuthenticatedHTTPRequest(method, endpoint string, values url
 // GetFee returns an estimate of fee based on type of transaction
 func (h *HUOBI) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	var fee float64
-	if feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+	switch feeBuilder.FeeType {
+	case exchange.CryptocurrencyTradeFee:
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
+
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64) float64 {

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -928,7 +928,7 @@ func (h *HUOBI) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
 	if c.IsCryptoFiatPair() {
 		return 0.001 * price * amount

--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -913,7 +913,10 @@ func (h *HUOBI) SendAuthenticatedHTTPRequest(method, endpoint string, values url
 
 // GetFee returns an estimate of fee based on type of transaction
 func (h *HUOBI) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
-	var fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
+	var fee float64
+	if feeBuilder.FeeType == exchange.OfflineTradeFee || feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
+	}
 	if fee < 0 {
 		fee = 0
 	}
@@ -924,8 +927,6 @@ func (h *HUOBI) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 func calculateTradingFee(c currency.Pair, price, amount float64) float64 {
 	if c.IsCryptoFiatPair() {
 		return 0.001 * price * amount
-
-	} else {
-		return 0.002 * price * amount
 	}
+	return 0.002 * price * amount
 }

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -305,6 +305,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	h.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	t.Parallel()
 	var feeBuilder = setFeeBuilder()

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -393,6 +393,10 @@ func (h *HUOBI) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (h *HUOBI) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (h.APIKey == "" || h.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return h.GetFee(feeBuilder)
 }
 

--- a/exchanges/huobi/huobi_wrapper.go
+++ b/exchanges/huobi/huobi_wrapper.go
@@ -394,7 +394,7 @@ func (h *HUOBI) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (h *HUOBI) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (h.APIKey == "" || h.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return h.GetFee(feeBuilder)

--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -898,7 +898,7 @@ func (h *HUOBIHADAX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
 	if c.IsCryptoFiatPair() {
 		return 0.001 * price * amount

--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -884,7 +884,10 @@ func (h *HUOBIHADAX) SendAuthenticatedHTTPRequest(method, endpoint string, value
 
 // GetFee returns an estimate of fee based on type of transaction
 func (h *HUOBIHADAX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
-	var fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
+	var fee float64
+	if feeBuilder.FeeType == exchange.OfflineTradeFee || feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
+	}
 	if fee < 0 {
 		fee = 0
 	}
@@ -895,10 +898,8 @@ func (h *HUOBIHADAX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 func calculateTradingFee(c currency.Pair, price, amount float64) float64 {
 	if c.IsCryptoFiatPair() {
 		return 0.001 * price * amount
-
-	} else {
-		return 0.002 * price * amount
 	}
+	return 0.002 * price * amount
 }
 
 // GetDepositWithdrawalHistory returns deposit or withdrawal data

--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -884,28 +884,12 @@ func (h *HUOBIHADAX) SendAuthenticatedHTTPRequest(method, endpoint string, value
 
 // GetFee returns an estimate of fee based on type of transaction
 func (h *HUOBIHADAX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
-	var fee float64
-	switch feeBuilder.FeeType {
-	case exchange.CryptocurrencyTradeFee:
-		fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
-	case exchange.OfflineTradeFee:
-		fee = getOfflineTradeFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
-	}
+	var fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
-}
-
-// getOfflineTradeFee calculates the worst case-scenario trading fee
-func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
-	if c.IsCryptoFiatPair() {
-		return 0.001 * price * amount
-
-	} else {
-		return 0.002 * price * amount
-	}
 }
 
 func calculateTradingFee(c currency.Pair, price, amount float64) float64 {

--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -887,9 +887,9 @@ func (h *HUOBIHADAX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	var fee float64
 	switch feeBuilder.FeeType {
 	case exchange.CryptocurrencyTradeFee:
-		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+		fee = calculateTradingFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.Pair, feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -898,13 +898,23 @@ func (h *HUOBIHADAX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(c currency.Pair, price, amount float64) float64 {
+	if c.IsCryptoFiatPair() {
+		return 0.001 * price * amount
+
+	} else {
+		return 0.002 * price * amount
+	}
 }
 
-func calculateTradingFee(purchasePrice, amount float64) float64 {
-	feePercent := 0.002
-	return feePercent * purchasePrice * amount
+func calculateTradingFee(c currency.Pair, price, amount float64) float64 {
+	if c.IsCryptoFiatPair() {
+		return 0.001 * price * amount
+
+	} else {
+		return 0.002 * price * amount
+	}
 }
 
 // GetDepositWithdrawalHistory returns deposit or withdrawal data

--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -885,14 +885,21 @@ func (h *HUOBIHADAX) SendAuthenticatedHTTPRequest(method, endpoint string, value
 // GetFee returns an estimate of fee based on type of transaction
 func (h *HUOBIHADAX) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	var fee float64
-	if feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+	switch feeBuilder.FeeType {
+	case exchange.CryptocurrencyTradeFee:
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64) float64 {

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -285,6 +285,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	h.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	t.Parallel()
 	var feeBuilder = setFeeBuilder()

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -350,7 +350,7 @@ func (h *HUOBIHADAX) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (h *HUOBIHADAX) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (h.APIKey == "" || h.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return h.GetFee(feeBuilder)

--- a/exchanges/huobihadax/huobihadax_wrapper.go
+++ b/exchanges/huobihadax/huobihadax_wrapper.go
@@ -349,6 +349,10 @@ func (h *HUOBIHADAX) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (h *HUOBIHADAX) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (h.APIKey == "" || h.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return h.GetFee(feeBuilder)
 }
 

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -428,6 +428,8 @@ func (i *ItBit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount, feeBuilder.IsMaker)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency, feeBuilder.BankTransactionType)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -435,6 +437,10 @@ func (i *ItBit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64, isMaker bool) float64 {

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -439,7 +439,7 @@ func (i *ItBit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0035 * price * amount
 }

--- a/exchanges/itbit/itbit.go
+++ b/exchanges/itbit/itbit.go
@@ -428,8 +428,8 @@ func (i *ItBit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount, feeBuilder.IsMaker)
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency, feeBuilder.BankTransactionType)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -439,16 +439,17 @@ func (i *ItBit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0035 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64, isMaker bool) float64 {
 	// TODO: Itbit has volume discounts, but not API endpoint to get the exact volume numbers
 	// When support is added, this needs to be updated to calculate the accurate volume fee
-	feePercent := 0.0025
+	feePercent := 0.0035
 	if isMaker {
-		feePercent = 0
+		feePercent = -0.0003
 	}
 	return feePercent * purchasePrice * amount
 }

--- a/exchanges/itbit/itbit_test.go
+++ b/exchanges/itbit/itbit_test.go
@@ -154,21 +154,36 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	i.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	t.Parallel()
 	var feeBuilder = setFeeBuilder()
 	// CryptocurrencyTradeFee Basic
-	if resp, err := i.GetFee(feeBuilder); resp != float64(0.0025) || err != nil {
+	if resp, err := i.GetFee(feeBuilder); resp != float64(0.0035) || err != nil {
 		t.Error(err)
-		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.002), resp)
+		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.0035), resp)
 	}
 
 	// CryptocurrencyTradeFee High quantity
 	feeBuilder = setFeeBuilder()
 	feeBuilder.Amount = 1000
 	feeBuilder.PurchasePrice = 1000
-	if resp, err := i.GetFee(feeBuilder); resp != float64(2500) || err != nil {
-		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(2500), resp)
+	if resp, err := i.GetFee(feeBuilder); resp != float64(3500) || err != nil {
+		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(3500), resp)
 		t.Error(err)
 	}
 

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -301,6 +301,10 @@ func (i *ItBit) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (i *ItBit) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (i.APIKey == "" || i.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return i.GetFee(feeBuilder)
 }
 

--- a/exchanges/itbit/itbit_wrapper.go
+++ b/exchanges/itbit/itbit_wrapper.go
@@ -302,7 +302,7 @@ func (i *ItBit) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (i *ItBit) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (i.APIKey == "" || i.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return i.GetFee(feeBuilder)

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -1020,12 +1020,18 @@ func (k *Kraken) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.FiatCurrency)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func getWithdrawalFee(c currency.Code) float64 {

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -1020,8 +1020,8 @@ func (k *Kraken) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 
 	case exchange.InternationalBankWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.FiatCurrency)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -1030,8 +1030,9 @@ func (k *Kraken) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0016 * price * amount
 }
 
 func getWithdrawalFee(c currency.Code) float64 {

--- a/exchanges/kraken/kraken.go
+++ b/exchanges/kraken/kraken.go
@@ -1030,7 +1030,7 @@ func (k *Kraken) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0016 * price * amount
 }

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -256,6 +256,22 @@ func setFeeBuilder() *exchange.FeeBuilder {
 }
 
 // TestGetFee logic test
+
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	k.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	k.SetDefaults()
 	TestSetup(t)

--- a/exchanges/kraken/kraken_wrapper.go
+++ b/exchanges/kraken/kraken_wrapper.go
@@ -312,6 +312,10 @@ func (k *Kraken) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (k *Kraken) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (k.APIKey == "" || k.APISecret == "") && // Todo check connection status
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return k.GetFee(feeBuilder)
 }
 

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -388,6 +388,8 @@ func (l *LakeBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		// fees for withdrawals are dynamic. They cannot be calculated in
 		// advance as they are manually performed via the website, it can only
 		// be determined when submitting the request
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -395,6 +397,10 @@ func (l *LakeBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64, isMaker bool) (fee float64) {

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -388,8 +388,8 @@ func (l *LakeBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		// fees for withdrawals are dynamic. They cannot be calculated in
 		// advance as they are manually performed via the website, it can only
 		// be determined when submitting the request
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 
 	if fee < 0 {
@@ -399,7 +399,8 @@ func (l *LakeBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 

--- a/exchanges/lakebtc/lakebtc.go
+++ b/exchanges/lakebtc/lakebtc.go
@@ -399,7 +399,7 @@ func (l *LakeBTC) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/lakebtc/lakebtc_test.go
+++ b/exchanges/lakebtc/lakebtc_test.go
@@ -148,6 +148,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	l.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	t.Parallel()
 	var feeBuilder = setFeeBuilder()

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -277,7 +277,7 @@ func (l *LakeBTC) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (l *LakeBTC) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (l.APIKey == "" || l.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return l.GetFee(feeBuilder)

--- a/exchanges/lakebtc/lakebtc_wrapper.go
+++ b/exchanges/lakebtc/lakebtc_wrapper.go
@@ -276,6 +276,10 @@ func (l *LakeBTC) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (l *LakeBTC) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (l.APIKey == "" || l.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return l.GetFee(feeBuilder)
 }
 

--- a/exchanges/localbitcoins/localbitcoins_test.go
+++ b/exchanges/localbitcoins/localbitcoins_test.go
@@ -108,6 +108,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	l.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	l.SetDefaults()
 	var feeBuilder = setFeeBuilder()

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -303,6 +303,10 @@ func (l *LocalBitcoins) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (l *LocalBitcoins) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (l.APIKey == "" || l.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return l.GetFee(feeBuilder)
 }
 

--- a/exchanges/localbitcoins/localbitcoins_wrapper.go
+++ b/exchanges/localbitcoins/localbitcoins_wrapper.go
@@ -304,7 +304,7 @@ func (l *LocalBitcoins) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (l *LocalBitcoins) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (l.APIKey == "" || l.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return l.GetFee(feeBuilder)

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -1040,6 +1040,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	o.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	TestSetDefaults(t)
 	var feeBuilder = setFeeBuilder()
@@ -1059,7 +1074,7 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyTradeFee IsMaker
 	feeBuilder = setFeeBuilder()
 	feeBuilder.IsMaker = true
-	if resp, err := o.GetFee(feeBuilder); resp != float64(0.00100) || err != nil {
+	if resp, err := o.GetFee(feeBuilder); resp != float64(0.0005) || err != nil {
 		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.0005), resp)
 		t.Error(err)
 	}

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1551,6 +1551,26 @@ func TestGetETTOrderDetails(t *testing.T) {
 	testStandardErrorHandling(t, err)
 }
 
+// TestGetETTConstituents API endpoint test
+func TestGetETTConstituents(t *testing.T) {
+	TestSetDefaults(t)
+	t.Parallel()
+	_, err := o.GetETTConstituents("OK06ETT")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// TestGetETTSettlementPriceHistory API endpoint test
+func TestGetETTSettlementPriceHistory(t *testing.T) {
+	TestSetDefaults(t)
+	t.Parallel()
+	_, err := o.GetETTSettlementPriceHistory("OK06ETT")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 // Websocket tests ----------------------------------------------------------------------------------------------
 
 // TestWsLogin API endpoint test
@@ -1789,8 +1809,6 @@ func setFeeBuilder() *exchange.FeeBuilder {
 		BankTransactionType: exchange.WireTransfer,
 	}
 }
-
-// TestGetFee fee calcuation test
 
 // TestGetFeeByTypeOfflineTradeFee logic test
 func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1553,6 +1553,7 @@ func TestGetETTOrderDetails(t *testing.T) {
 
 // TestGetETTConstituents API endpoint test
 func TestGetETTConstituents(t *testing.T) {
+	t.Skip("ETT currently unavailable")
 	TestSetDefaults(t)
 	t.Parallel()
 	_, err := o.GetETTConstituents("OK06ETT")
@@ -1563,6 +1564,7 @@ func TestGetETTConstituents(t *testing.T) {
 
 // TestGetETTSettlementPriceHistory API endpoint test
 func TestGetETTSettlementPriceHistory(t *testing.T) {
+	t.Skip("ETT currently unavailable")
 	TestSetDefaults(t)
 	t.Parallel()
 	_, err := o.GetETTSettlementPriceHistory("OK06ETT")

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1551,26 +1551,6 @@ func TestGetETTOrderDetails(t *testing.T) {
 	testStandardErrorHandling(t, err)
 }
 
-// TestGetETTConstituents API endpoint test
-func TestGetETTConstituents(t *testing.T) {
-	TestSetDefaults(t)
-	t.Parallel()
-	_, err := o.GetETTConstituents("OK06ETT")
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-// TestGetETTSettlementPriceHistory API endpoint test
-func TestGetETTSettlementPriceHistory(t *testing.T) {
-	TestSetDefaults(t)
-	t.Parallel()
-	_, err := o.GetETTSettlementPriceHistory("OK06ETT")
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 // Websocket tests ----------------------------------------------------------------------------------------------
 
 // TestWsLogin API endpoint test
@@ -1811,6 +1791,22 @@ func setFeeBuilder() *exchange.FeeBuilder {
 }
 
 // TestGetFee fee calcuation test
+
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	o.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	TestSetDefaults(t)
 	t.Parallel()
@@ -1833,8 +1829,8 @@ func TestGetFee(t *testing.T) {
 	// CryptocurrencyTradeFee IsMaker
 	feeBuilder = setFeeBuilder()
 	feeBuilder.IsMaker = true
-	if resp, err := o.GetFee(feeBuilder); resp != float64(0.001) || err != nil {
-		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.001), resp)
+	if resp, err := o.GetFee(feeBuilder); resp != float64(0.0005) || err != nil {
+		t.Errorf("Test Failed - GetFee() error. Expected: %f, Received: %f", float64(0.0005), resp)
 		t.Error(err)
 	}
 

--- a/exchanges/okgroup/okgroup.go
+++ b/exchanges/okgroup/okgroup.go
@@ -680,8 +680,8 @@ func (o *OKGroup) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, _ error)
 				break
 			}
 		}
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -690,14 +690,15 @@ func (o *OKGroup) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, _ error)
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
-	return 0.002 * price * amount
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
+	return 0.0015 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64, isMaker bool) (fee float64) {
 	// TODO volume based fees
 	if isMaker {
-		fee = 0.001
+		fee = 0.0005
 	} else {
 		fee = 0.0015
 	}

--- a/exchanges/okgroup/okgroup.go
+++ b/exchanges/okgroup/okgroup.go
@@ -680,12 +680,18 @@ func (o *OKGroup) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, _ error)
 				break
 			}
 		}
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64, isMaker bool) (fee float64) {

--- a/exchanges/okgroup/okgroup.go
+++ b/exchanges/okgroup/okgroup.go
@@ -690,7 +690,7 @@ func (o *OKGroup) GetFee(feeBuilder *exchange.FeeBuilder) (fee float64, _ error)
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.0015 * price * amount
 }

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -414,6 +414,10 @@ func (o *OKGroup) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (o *OKGroup) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (o.APIKey == "" || o.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return o.GetFee(feeBuilder)
 }
 

--- a/exchanges/okgroup/okgroup_wrapper.go
+++ b/exchanges/okgroup/okgroup_wrapper.go
@@ -415,7 +415,7 @@ func (o *OKGroup) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (o *OKGroup) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (o.APIKey == "" || o.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return o.GetFee(feeBuilder)

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -914,8 +914,8 @@ func (p *Poloniex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.Pair.Base)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -924,7 +924,8 @@ func (p *Poloniex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -914,12 +914,18 @@ func (p *Poloniex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.Pair.Base)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(feeInfo Fee, purchasePrice, amount float64, isMaker bool) (fee float64) {

--- a/exchanges/poloniex/poloniex.go
+++ b/exchanges/poloniex/poloniex.go
@@ -924,7 +924,7 @@ func (p *Poloniex) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/poloniex/poloniex_test.go
+++ b/exchanges/poloniex/poloniex_test.go
@@ -99,6 +99,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	p.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	p.SetDefaults()
 	TestSetup(t)

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -310,6 +310,10 @@ func (p *Poloniex) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (p *Poloniex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (p.APIKey == "" || p.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return p.GetFee(feeBuilder)
 }
 

--- a/exchanges/poloniex/poloniex_wrapper.go
+++ b/exchanges/poloniex/poloniex_wrapper.go
@@ -311,7 +311,7 @@ func (p *Poloniex) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (p *Poloniex) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (p.APIKey == "" || p.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return p.GetFee(feeBuilder)

--- a/exchanges/yobit/yobit.go
+++ b/exchanges/yobit/yobit.go
@@ -400,18 +400,13 @@ func (y *Yobit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 			feeBuilder.Amount,
 			feeBuilder.BankTransactionType)
 	case exchange.OfflineTradeFee:
-		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
-}
-
-// getOfflineTradeFee calculates the worst case-scenario trading fee
-func getOfflineTradeFee(price, amount float64) float64 {
-	return 0.002 * price * amount
 }
 
 func calculateTradingFee(price, amount float64) (fee float64) {

--- a/exchanges/yobit/yobit.go
+++ b/exchanges/yobit/yobit.go
@@ -409,7 +409,7 @@ func (y *Yobit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/yobit/yobit.go
+++ b/exchanges/yobit/yobit.go
@@ -399,8 +399,8 @@ func (y *Yobit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency,
 			feeBuilder.Amount,
 			feeBuilder.BankTransactionType)
-		case exchange.SimulatedTransactionFee:
-			fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -409,13 +409,13 @@ func (y *Yobit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 
-func calculateTradingFee(purchasePrice, amount float64) (fee float64) {
-	fee = 0.002
-	return fee * amount * purchasePrice
+func calculateTradingFee(price, amount float64) (fee float64) {
+	return 0.002 * price * amount
 }
 
 func getWithdrawalFee(c currency.Code) float64 {

--- a/exchanges/yobit/yobit.go
+++ b/exchanges/yobit/yobit.go
@@ -399,12 +399,18 @@ func (y *Yobit) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = getInternationalBankWithdrawalFee(feeBuilder.FiatCurrency,
 			feeBuilder.Amount,
 			feeBuilder.BankTransactionType)
+		case exchange.SimulatedTransactionFee:
+			fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64) (fee float64) {

--- a/exchanges/yobit/yobit_test.go
+++ b/exchanges/yobit/yobit_test.go
@@ -147,6 +147,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	y.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	y.SetDefaults()
 	TestSetup(t)

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -280,6 +280,10 @@ func (y *Yobit) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (y *Yobit) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (y.APIKey == "" || y.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return y.GetFee(feeBuilder)
 }
 

--- a/exchanges/yobit/yobit_wrapper.go
+++ b/exchanges/yobit/yobit_wrapper.go
@@ -281,7 +281,7 @@ func (y *Yobit) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (y *Yobit) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (y.APIKey == "" || y.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return y.GetFee(feeBuilder)

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -422,12 +422,18 @@ func (z *ZB) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.Pair.Base)
+	case exchange.SimulatedTransactionFee:
+		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
 	}
 
 	return fee, nil
+}
+
+func getSimulatedFee(price, amount float64) float64 {
+	return 0.002 * price * amount
 }
 
 func calculateTradingFee(purchasePrice, amount float64) (fee float64) {

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -422,8 +422,8 @@ func (z *ZB) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 		fee = calculateTradingFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	case exchange.CryptocurrencyWithdrawalFee:
 		fee = getWithdrawalFee(feeBuilder.Pair.Base)
-	case exchange.SimulatedTransactionFee:
-		fee = getSimulatedFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
+	case exchange.OfflineTradeFee:
+		fee = getOfflineTradeFee(feeBuilder.PurchasePrice, feeBuilder.Amount)
 	}
 	if fee < 0 {
 		fee = 0
@@ -432,7 +432,8 @@ func (z *ZB) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-func getSimulatedFee(price, amount float64) float64 {
+// getOfflineTradeFeecalculates the worst case-scenario trading fee
+func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }
 

--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -432,7 +432,7 @@ func (z *ZB) GetFee(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	return fee, nil
 }
 
-// getOfflineTradeFeecalculates the worst case-scenario trading fee
+// getOfflineTradeFee calculates the worst case-scenario trading fee
 func getOfflineTradeFee(price, amount float64) float64 {
 	return 0.002 * price * amount
 }

--- a/exchanges/zb/zb_test.go
+++ b/exchanges/zb/zb_test.go
@@ -138,6 +138,21 @@ func setFeeBuilder() *exchange.FeeBuilder {
 	}
 }
 
+// TestGetFeeByTypeOfflineTradeFee logic test
+func TestGetFeeByTypeOfflineTradeFee(t *testing.T) {
+	var feeBuilder = setFeeBuilder()
+	z.GetFeeByType(feeBuilder)
+	if apiKey == "" || apiSecret == "" {
+		if feeBuilder.FeeType != exchange.OfflineTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.OfflineTradeFee, feeBuilder.FeeType)
+		}
+	} else {
+		if feeBuilder.FeeType != exchange.CryptocurrencyTradeFee {
+			t.Errorf("Expected %v, received %v", exchange.CryptocurrencyTradeFee, feeBuilder.FeeType)
+		}
+	}
+}
+
 func TestGetFee(t *testing.T) {
 	z.SetDefaults()
 	TestSetup(t)

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -307,6 +307,10 @@ func (z *ZB) GetWebsocket() (*exchange.Websocket, error) {
 
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (z *ZB) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
+	if (z.APIKey == "" || z.APISecret == "") && // Todo check connection status
+	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType = exchange.OfflineTradeFee
+	}
 	return z.GetFee(feeBuilder)
 }
 

--- a/exchanges/zb/zb_wrapper.go
+++ b/exchanges/zb/zb_wrapper.go
@@ -308,7 +308,7 @@ func (z *ZB) GetWebsocket() (*exchange.Websocket, error) {
 // GetFeeByType returns an estimate of fee based on type of transaction
 func (z *ZB) GetFeeByType(feeBuilder *exchange.FeeBuilder) (float64, error) {
 	if (z.APIKey == "" || z.APISecret == "") && // Todo check connection status
-	feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
+		feeBuilder.FeeType == exchange.CryptocurrencyTradeFee {
 		feeBuilder.FeeType = exchange.OfflineTradeFee
 	}
 	return z.GetFee(feeBuilder)


### PR DESCRIPTION
# Description

Adds offline trade fee calculation for each exchange using worst case values. On the wrapper, if the keys aren't set, then switch the fee type to offline to prevent API calls.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've added a logic test `TestGetFeeByTypeOfflineTradeFee` to check if offline trade fee feetype gets hit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules