### PR TITLE
Kraken websocket orderbook buffer

### DIFF
--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -735,6 +735,7 @@ func TestOrderbookBufferReset(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
+
 	obpartial := `[0,{"as":[["5541.30000","2.50700000","0"]],"bs":[["5541.20000","1.52900000","0"]]}]`
 	obupdate1 := `[0,{"a":[["5541.30000","0.00000000","1"]],"b":[["5541.30000","0.00000000","1"]]}]`
 	obupdate2 := `[0,{"a":[["5541.30000","2.50700000","2"]],"b":[["5541.30000","0.00000000","2"]]}]`
@@ -757,7 +758,7 @@ func TestOrderbookBufferReset(t *testing.T) {
 	}
 
 	k.wsProcessOrderBook(
-		channelData,
+		&channelData,
 		obData,
 	)
 
@@ -766,35 +767,35 @@ func TestOrderbookBufferReset(t *testing.T) {
 		t.Errorf("Could not parse, %v", err)
 	}
 	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(channelData, obData)
+	k.wsProcessOrderBook(&channelData, obData)
 
 	err = common.JSONDecode([]byte(obupdate2), &dataResponse)
 	if err != nil {
 		t.Errorf("Could not parse, %v", err)
 	}
 	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(channelData, obData)
+	k.wsProcessOrderBook(&channelData, obData)
 
 	err = common.JSONDecode([]byte(obupdate3), &dataResponse)
 	if err != nil {
 		t.Errorf("Could not parse, %v", err)
 	}
 	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(channelData, obData)
+	k.wsProcessOrderBook(&channelData, obData)
 
 	err = common.JSONDecode([]byte(obupdate4), &dataResponse)
 	if err != nil {
 		t.Errorf("Could not parse, %v", err)
 	}
 	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(channelData, obData)
+	k.wsProcessOrderBook(&channelData, obData)
 
 	err = common.JSONDecode([]byte(obupdate5), &dataResponse)
 	if err != nil {
 		t.Errorf("Could not parse, %v", err)
 	}
 	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(channelData, obData)
+	k.wsProcessOrderBook(&channelData, obData)
 	if len(orderbookBuffer[channelData.ChannelID]) != 0 {
 		t.Errorf("Buffer should reset to 0 after 5 entries, has %v", len(orderbookBuffer[channelData.ChannelID]))
 	}
@@ -804,7 +805,7 @@ func TestOrderbookBufferReset(t *testing.T) {
 		t.Errorf("Could not parse, %v", err)
 	}
 	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(channelData, obData)
+	k.wsProcessOrderBook(&channelData, obData)
 	if len(orderbookBuffer[channelData.ChannelID]) != 1 {
 		t.Error("Buffer should have 1 entry after being reset")
 	}
@@ -838,7 +839,7 @@ func TestOrderBookOutOfOrder(t *testing.T) {
 	}
 
 	k.wsProcessOrderBook(
-		channelData,
+		&channelData,
 		obData,
 	)
 
@@ -847,16 +848,16 @@ func TestOrderBookOutOfOrder(t *testing.T) {
 		t.Errorf("Could not parse, %v", err)
 	}
 	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(channelData, obData)
+	k.wsProcessOrderBook(&channelData, obData)
 
 	err = common.JSONDecode([]byte(obupdate2), &dataResponse)
 	if err != nil {
 		t.Errorf("Could not parse, %v", err)
 	}
 	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(channelData, obData)
+	k.wsProcessOrderBook(&channelData, obData)
 
-	err = k.wsProcessOrderBookUpdate(channelData)
+	err = k.wsProcessOrderBookUpdate(&channelData)
 	if !strings.Contains(err.Error(), "orderbook update out of order") {
 		t.Error("Expected out of order orderbook error")
 	}

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -1,6 +1,7 @@
 package kraken
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -735,15 +736,11 @@ func TestOrderbookBufferReset(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-
+	var obUpdates []string
 	obpartial := `[0,{"as":[["5541.30000","2.50700000","0"]],"bs":[["5541.20000","1.52900000","0"]]}]`
-	obupdate1 := `[0,{"a":[["5541.30000","0.00000000","1"]],"b":[["5541.30000","0.00000000","1"]]}]`
-	obupdate2 := `[0,{"a":[["5541.30000","2.50700000","2"]],"b":[["5541.30000","0.00000000","2"]]}]`
-	obupdate3 := `[0,{"a":[["5541.30000","2.50700000","3"]],"b":[["5541.30000","0.00000000","3"]]}]`
-	obupdate4 := `[0,{"a":[["5541.30000","2.50700000","4"]],"b":[["5541.30000","0.00000000","4"]]}]`
-	obupdate5 := `[0,{"a":[["5541.30000","2.50700000","5"]],"b":[["5541.30000","1.00000000","5"]]}]`
-	obupdate6 := `[0,{"a":[["5541.30000","2.50700000","6"]],"b":[["5541.30000","1.00000000","6"]]}]`
-
+	for i := 1; i < orderbookBufferLimit+2; i++ {
+		obUpdates = append(obUpdates, fmt.Sprintf(`[0,{"a":[["5541.30000","2.50700000","%v"]],"b":[["5541.30000","1.00000000","%v"]]}]`, i, i))
+	}
 	k.Websocket.DataHandler = make(chan interface{}, 10)
 	var dataResponse WebsocketDataResponse
 	err := common.JSONDecode([]byte(obpartial), &dataResponse)
@@ -762,52 +759,20 @@ func TestOrderbookBufferReset(t *testing.T) {
 		obData,
 	)
 
-	err = common.JSONDecode([]byte(obupdate1), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(&channelData, obData)
-
-	err = common.JSONDecode([]byte(obupdate2), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(&channelData, obData)
-
-	err = common.JSONDecode([]byte(obupdate3), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(&channelData, obData)
-
-	err = common.JSONDecode([]byte(obupdate4), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(&channelData, obData)
-
-	err = common.JSONDecode([]byte(obupdate5), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(&channelData, obData)
-	if len(orderbookBuffer[channelData.ChannelID]) != 0 {
-		t.Errorf("Buffer should reset to 0 after 5 entries, has %v", len(orderbookBuffer[channelData.ChannelID]))
-	}
-
-	err = common.JSONDecode([]byte(obupdate6), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(&channelData, obData)
-	if len(orderbookBuffer[channelData.ChannelID]) != 1 {
-		t.Error("Buffer should have 1 entry after being reset")
+	for i := 0; i < len(obUpdates); i++ {
+		err = common.JSONDecode([]byte(obUpdates[i]), &dataResponse)
+		if err != nil {
+			t.Errorf("Could not parse, %v", err)
+		}
+		obData = dataResponse[1].(map[string]interface{})
+		if i < len(obUpdates)-1 {
+			k.wsProcessOrderBook(&channelData, obData)
+		} else if i == len(obUpdates)-1 {
+			k.wsProcessOrderBook(&channelData, obData)
+			if len(orderbookBuffer[channelData.ChannelID]) != 1 {
+				t.Error("Buffer should have 1 entry after being reset")
+			}
+		}
 	}
 }
 

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -746,7 +746,7 @@ func TestSubscribeToChannel(t *testing.T) {
 		k.Websocket.Connect()
 	}
 
-	err := k.WsSubscribeToChannel("ticker", []string{"XTZ-USD"}, 1)
+	err := k.WsSubscribeToChannel("ticker", []string{"XTZ/USD"}, 1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -824,7 +824,7 @@ func TestUnsubscribeWithoutSubscription(t *testing.T) {
 		response := <-k.Websocket.DataHandler
 		t.Log(response)
 		if err, ok := response.(error); ok && err != nil {
-			if err.Error() == "Request: '3'. Error: Subscription Not Found" {
+			if err.Error() == "requestID: '3'. Error: Subscription Not Found" {
 				unsubscriptionError = true
 				break
 			}

--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -39,6 +39,7 @@ func TestSetup(t *testing.T) {
 	krakenConfig.APISecret = apiSecret
 	krakenConfig.ClientID = clientID
 	krakenConfig.WebsocketURL = k.WebsocketURL
+	subscribeToDefaultChannels = false
 	k.Setup(&krakenConfig)
 }
 
@@ -625,6 +626,113 @@ func TestWithdrawCancel(t *testing.T) {
 
 // ---------------------------- Websocket tests -----------------------------------------
 
+// TestOrderbookBufferReset websocket test
+func TestOrderbookBufferReset(t *testing.T) {
+	if k.Name == "" {
+		k.SetDefaults()
+		TestSetup(t)
+	}
+	if !k.Websocket.IsEnabled() {
+		t.Skip("Websocket not enabled, skipping")
+	}
+	if k.WebsocketConn == nil {
+		k.Websocket.Connect()
+	}
+	var obUpdates []string
+	obpartial := `[0,{"as":[["5541.30000","2.50700000","0"]],"bs":[["5541.20000","1.52900000","0"]]}]`
+	for i := 1; i < orderbookBufferLimit+2; i++ {
+		obUpdates = append(obUpdates, fmt.Sprintf(`[0,{"a":[["5541.30000","2.50700000","%v"]],"b":[["5541.30000","1.00000000","%v"]]}]`, i, i))
+	}
+	k.Websocket.DataHandler = make(chan interface{}, 10)
+	var dataResponse WebsocketDataResponse
+	err := common.JSONDecode([]byte(obpartial), &dataResponse)
+	if err != nil {
+		t.Errorf("Could not parse, %v", err)
+	}
+	obData := dataResponse[1].(map[string]interface{})
+	channelData := WebsocketChannelData{
+		ChannelID:    0,
+		Subscription: "orderbook",
+		Pair:         currency.NewPairWithDelimiter("XBT", "USD", "/"),
+	}
+
+	k.wsProcessOrderBookPartial(
+		&channelData,
+		obData,
+	)
+
+	for i := 0; i < len(obUpdates); i++ {
+		err = common.JSONDecode([]byte(obUpdates[i]), &dataResponse)
+		if err != nil {
+			t.Errorf("Could not parse, %v", err)
+		}
+		obData = dataResponse[1].(map[string]interface{})
+		if i < len(obUpdates)-1 {
+			k.wsProcessOrderBookBuffer(&channelData, obData)
+		} else if i == len(obUpdates)-1 {
+			k.wsProcessOrderBookUpdate(&channelData)
+			k.wsProcessOrderBookBuffer(&channelData, obData)
+			if len(orderbookBuffer[channelData.ChannelID]) != 1 {
+				t.Error("Buffer should have 1 entry after being reset")
+			}
+		}
+	}
+}
+
+// TestOrderbookBufferReset websocket test
+func TestOrderBookOutOfOrder(t *testing.T) {
+	if k.Name == "" {
+		k.SetDefaults()
+		TestSetup(t)
+	}
+	if !k.Websocket.IsEnabled() {
+		t.Skip("Websocket not enabled, skipping")
+	}
+	if k.WebsocketConn == nil {
+		k.Websocket.Connect()
+	}
+	obpartial := `[0,{"as":[["5541.30000","2.50700000","0"]],"bs":[["5541.20000","1.52900000","5"]]}]`
+	obupdate1 := `[0,{"a":[["5541.30000","0.00000000","1"]],"b":[["5541.30000","0.00000000","3"]]}]`
+	obupdate2 := `[0,{"a":[["5541.30000","2.50700000","2"]],"b":[["5541.30000","0.00000000","1"]]}]`
+
+	k.Websocket.DataHandler = make(chan interface{}, 10)
+	var dataResponse WebsocketDataResponse
+	err := common.JSONDecode([]byte(obpartial), &dataResponse)
+	if err != nil {
+		t.Errorf("Could not parse, %v", err)
+	}
+	obData := dataResponse[1].(map[string]interface{})
+	channelData := WebsocketChannelData{
+		ChannelID:    0,
+		Subscription: "orderbook",
+		Pair:         currency.NewPairWithDelimiter("XBT", "USD", "/"),
+	}
+
+	k.wsProcessOrderBookPartial(
+		&channelData,
+		obData,
+	)
+
+	err = common.JSONDecode([]byte(obupdate1), &dataResponse)
+	if err != nil {
+		t.Errorf("Could not parse, %v", err)
+	}
+	obData = dataResponse[1].(map[string]interface{})
+	k.wsProcessOrderBookBuffer(&channelData, obData)
+
+	err = common.JSONDecode([]byte(obupdate2), &dataResponse)
+	if err != nil {
+		t.Errorf("Could not parse, %v", err)
+	}
+	obData = dataResponse[1].(map[string]interface{})
+	k.wsProcessOrderBookBuffer(&channelData, obData)
+
+	err = k.wsProcessOrderBookUpdate(&channelData)
+	if !strings.Contains(err.Error(), "orderbook update out of order") {
+		t.Error("Expected out of order orderbook error")
+	}
+}
+
 // TestSubscribeToChannel websocket test
 func TestSubscribeToChannel(t *testing.T) {
 	if k.Name == "" {
@@ -634,12 +742,11 @@ func TestSubscribeToChannel(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if !k.Websocket.IsConnected() {
+	if k.WebsocketConn == nil {
 		k.Websocket.Connect()
 	}
 
-	<-k.Websocket.TrafficAlert
-	err := k.WsSubscribeToChannel("ticker", []string{"XBT/USD"}, 1)
+	err := k.WsSubscribeToChannel("ticker", []string{"XTZ-USD"}, 1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -654,7 +761,7 @@ func TestSubscribeToNonExistentChannel(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if !k.Websocket.IsConnected() {
+	if k.WebsocketConn == nil {
 		k.Websocket.Connect()
 	}
 	err := k.WsSubscribeToChannel("ticker", []string{"pewdiepie"}, 1)
@@ -683,14 +790,14 @@ func TestSubscribeUnsubscribeToChannel(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if !k.Websocket.IsConnected() {
+	if k.WebsocketConn == nil {
 		k.Websocket.Connect()
 	}
-	err := k.WsSubscribeToChannel("ticker", []string{"XBT/USD"}, 1)
+	err := k.WsSubscribeToChannel("ticker", []string{"XRP/JPY"}, 1)
 	if err != nil {
 		t.Error(err)
 	}
-	err = k.WsUnsubscribeToChannel("ticker", []string{"XBT/USD"}, 2)
+	err = k.WsUnsubscribeToChannel("ticker", []string{"XRP/JPY"}, 2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -705,18 +812,19 @@ func TestUnsubscribeWithoutSubscription(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if !k.Websocket.IsConnected() {
+	if k.WebsocketConn == nil {
 		k.Websocket.Connect()
 	}
-	err := k.WsUnsubscribeToChannel("ticker", []string{"XBT/USD"}, 3)
+	err := k.WsUnsubscribeToChannel("ticker", []string{"QTUM/EUR"}, 3)
 	if err != nil {
 		t.Error(err)
 	}
 	unsubscriptionError := false
-	for i := 0; i < 7; i++ {
+	for i := 0; i < 5; i++ {
 		response := <-k.Websocket.DataHandler
+		t.Log(response)
 		if err, ok := response.(error); ok && err != nil {
-			if err.Error() == "Subscription Not Found" {
+			if err.Error() == "Request: '3'. Error: Subscription Not Found" {
 				unsubscriptionError = true
 				break
 			}
@@ -724,107 +832,6 @@ func TestUnsubscribeWithoutSubscription(t *testing.T) {
 	}
 	if !unsubscriptionError {
 		t.Error("Expected error")
-	}
-}
-
-// TestOrderbookBufferReset websocket test
-func TestOrderbookBufferReset(t *testing.T) {
-	if k.Name == "" {
-		k.SetDefaults()
-		TestSetup(t)
-	}
-	if !k.Websocket.IsEnabled() {
-		t.Skip("Websocket not enabled, skipping")
-	}
-	var obUpdates []string
-	obpartial := `[0,{"as":[["5541.30000","2.50700000","0"]],"bs":[["5541.20000","1.52900000","0"]]}]`
-	for i := 1; i < orderbookBufferLimit+2; i++ {
-		obUpdates = append(obUpdates, fmt.Sprintf(`[0,{"a":[["5541.30000","2.50700000","%v"]],"b":[["5541.30000","1.00000000","%v"]]}]`, i, i))
-	}
-	k.Websocket.DataHandler = make(chan interface{}, 10)
-	var dataResponse WebsocketDataResponse
-	err := common.JSONDecode([]byte(obpartial), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData := dataResponse[1].(map[string]interface{})
-	channelData := WebsocketChannelData{
-		ChannelID:    0,
-		Subscription: "orderbook",
-		Pair:         currency.NewPairWithDelimiter("XBT", "USD", "/"),
-	}
-
-	k.wsProcessOrderBook(
-		&channelData,
-		obData,
-	)
-
-	for i := 0; i < len(obUpdates); i++ {
-		err = common.JSONDecode([]byte(obUpdates[i]), &dataResponse)
-		if err != nil {
-			t.Errorf("Could not parse, %v", err)
-		}
-		obData = dataResponse[1].(map[string]interface{})
-		if i < len(obUpdates)-1 {
-			k.wsProcessOrderBook(&channelData, obData)
-		} else if i == len(obUpdates)-1 {
-			k.wsProcessOrderBook(&channelData, obData)
-			if len(orderbookBuffer[channelData.ChannelID]) != 1 {
-				t.Error("Buffer should have 1 entry after being reset")
-			}
-		}
-	}
-}
-
-// TestOrderbookBufferReset websocket test
-func TestOrderBookOutOfOrder(t *testing.T) {
-	if k.Name == "" {
-		k.SetDefaults()
-		TestSetup(t)
-	}
-	k.Verbose = true
-	if !k.Websocket.IsEnabled() {
-		t.Skip("Websocket not enabled, skipping")
-	}
-	obpartial := `[0,{"as":[["5541.30000","2.50700000","0"]],"bs":[["5541.20000","1.52900000","5"]]}]`
-	obupdate1 := `[0,{"a":[["5541.30000","0.00000000","1"]],"b":[["5541.30000","0.00000000","3"]]}]`
-	obupdate2 := `[0,{"a":[["5541.30000","2.50700000","2"]],"b":[["5541.30000","0.00000000","1"]]}]`
-
-	k.Websocket.DataHandler = make(chan interface{}, 10)
-	var dataResponse WebsocketDataResponse
-	err := common.JSONDecode([]byte(obpartial), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData := dataResponse[1].(map[string]interface{})
-	channelData := WebsocketChannelData{
-		ChannelID:    0,
-		Subscription: "orderbook",
-		Pair:         currency.NewPairWithDelimiter("XBT", "USD", "/"),
-	}
-
-	k.wsProcessOrderBook(
-		&channelData,
-		obData,
-	)
-
-	err = common.JSONDecode([]byte(obupdate1), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(&channelData, obData)
-
-	err = common.JSONDecode([]byte(obupdate2), &dataResponse)
-	if err != nil {
-		t.Errorf("Could not parse, %v", err)
-	}
-	obData = dataResponse[1].(map[string]interface{})
-	k.wsProcessOrderBook(&channelData, obData)
-
-	err = k.wsProcessOrderBookUpdate(&channelData)
-	if !strings.Contains(err.Error(), "orderbook update out of order") {
-		t.Error("Expected out of order orderbook error")
 	}
 }
 
@@ -837,18 +844,18 @@ func TestUnsubscribeWithChannelID(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if !k.Websocket.IsConnected() {
+	if k.WebsocketConn == nil {
 		k.Websocket.Connect()
 	}
-	err := k.WsUnsubscribeToChannelByChannelID(3)
+	err := k.WsUnsubscribeToChannelByChannelID(100)
 	if err != nil {
 		t.Error(err)
 	}
 	unsubscriptionError := false
-	for i := 0; i < 7; i++ {
+	for i := 0; i < 5; i++ {
 		response := <-k.Websocket.DataHandler
 		if err, ok := response.(error); ok && err != nil {
-			if err.Error() == "Subscription Not Found" {
+			if err.Error() == "Not subscribed to the requested channelID" {
 				unsubscriptionError = true
 				break
 			}
@@ -859,8 +866,8 @@ func TestUnsubscribeWithChannelID(t *testing.T) {
 	}
 }
 
-// TestUnsubscribeFromNonExistentChennel websocket test
-func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
+// TestUnsubscribeFromNonExistentChannel websocket test
+func TestUnsubscribeFromNonExistentChannel(t *testing.T) {
 	if k.Name == "" {
 		k.SetDefaults()
 		TestSetup(t)
@@ -868,7 +875,7 @@ func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if !k.Websocket.IsConnected() {
+	if k.WebsocketConn == nil {
 		k.Websocket.Connect()
 	}
 	err := k.WsUnsubscribeToChannel("ticker", []string{"tseries"}, 0)
@@ -876,11 +883,13 @@ func TestUnsubscribeFromNonExistentChennel(t *testing.T) {
 		t.Error(err)
 	}
 	unsubscriptionError := false
-	for i := 0; i < 7; i++ {
+	for i := 0; i < 5; i++ {
 		response := <-k.Websocket.DataHandler
 		if err, ok := response.(error); ok && err != nil {
-			unsubscriptionError = true
-			break
+			if err.Error() == "Currency pair not in ISO 4217-A3 format tseries" {
+				unsubscriptionError = true
+				break
+			}
 		}
 	}
 	if !unsubscriptionError {

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -422,7 +422,7 @@ type WebsocketEventResponse struct {
 }
 
 type WebsocketSubscriptionEventResponse struct {
-	ChannelID float64 `json:"channelID"`
+	ChannelID int64 `json:"channelID"`
 }
 
 type WebsocketSubscriptionResponseData struct {
@@ -444,5 +444,5 @@ type WebsocketErrorResponse struct {
 type WebsocketChannelData struct {
 	Subscription string
 	Pair         currency.Pair
-	ChannelID    float64
+	ChannelID    int64
 }

--- a/exchanges/kraken/kraken_types.go
+++ b/exchanges/kraken/kraken_types.go
@@ -415,6 +415,7 @@ type WebsocketEventResponse struct {
 	Event        string                            `json:"event"`
 	Status       string                            `json:"status"`
 	Pair         currency.Pair                     `json:"pair,omitempty"`
+	RequestID    int64                             `json:"reqid,omitempty"` // Optional, client originated ID reflected in response message.
 	Subscription WebsocketSubscriptionResponseData `json:"subscription,omitempty"`
 	WebsocketSubscriptionEventResponse
 	WebsocketStatusResponse

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -60,7 +60,7 @@ var krakenOrderBooks map[int64]orderbook.Base
 
 // orderbookBuffer Stores orderbook updates per channel
 var orderbookBuffer map[int64][]orderbook.Base
-var subscribeToDefaultChannels bool = true
+var subscribeToDefaultChannels = true
 
 // writeToWebsocket sends a message to the websocket endpoint
 func (k *Kraken) writeToWebsocket(message []byte) error {
@@ -300,7 +300,7 @@ func (k *Kraken) WsHandleEventResponse(response *WebsocketEventResponse) {
 		}
 		if response.Status != "subscribed" {
 			if response.RequestID > 0 {
-				k.Websocket.DataHandler <- fmt.Errorf("Request: '%v'. Error: %v", response.RequestID, response.WebsocketErrorResponse.ErrorMessage)
+				k.Websocket.DataHandler <- fmt.Errorf("requestID: '%v'. Error: %v", response.RequestID, response.WebsocketErrorResponse.ErrorMessage)
 			} else {
 				k.Websocket.DataHandler <- fmt.Errorf(response.WebsocketErrorResponse.ErrorMessage)
 			}

--- a/exchanges/kraken/kraken_websocket.go
+++ b/exchanges/kraken/kraken_websocket.go
@@ -46,7 +46,7 @@ const (
 	krakenWsOrderbook          = "book"
 	// Only supported asset type
 	krakenWsAssetType    = "SPOT"
-	orderbookBufferLimit = 5
+	orderbookBufferLimit = 3
 )
 
 // orderbookMutex Ensures if two entries arrive at once, only one can be processed at a time


### PR DESCRIPTION
# Description

Kraken's websocket orderbook has very specific timestamps. Without a checksum, timestamps are the only thing we can rely on to process orderbook updates via WS. 

At the present time REST and Websocket are run simultaneously, so when the orderbook updates via REST, the partial/update system for Kraken WS orderbook is no longer in sync as it relied on `GetOrderbookEx`. So the first change is to internalise WS orderbooks/orderbook channel since we cannot rely on `GetOrderbookEx` right now.

Secondly, there is a potential for Kraken to send out of order WS orderbook updates. So a basic buffer is being introduced to append the last 3 updates/WS orderbook array, reorder and then save the orderbook. 

#### Minor Grievances:
The ask/bid functions are pretty much the same except for what is referenced (bids, asks). I'd send pointers, but it seems like you don't send pointers to slices, so I'm not yet sure on how I'd minimise code for the functions. So if you have a suggestion, I'd be more than happy to do it!

## Fixes # (issue)
Resubscribe loop for Kraken WS orderbook updates
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- I've run the application with all available currencies enabled for a long time and receive zero resubscribes.
Here is an example verbose update:
```
[DEBUG]: 2019/04/10 17:55:08 Kraken Websocket message received: [741,{"a":[["302.400000","30.17450576","1554882911.150218"]]}]
[DEBUG]: 2019/04/10 17:55:08 Kraken Websocket Orderbook data received
[DEBUG]: 2019/04/10 17:55:08 Adding orderbook to buffer for channel 741. Lastupdated: 2019-04-10 17:55:11.150218009 +1000 AEST. 3 / 3
[DEBUG]: 2019/04/10 17:55:08 Current orderbook 'LastUpdated': 2019-04-10 17:54:12.959043979 +1000 AEST
[DEBUG]: 2019/04/10 17:55:08 Sorting orderbook. Earliest 'LastUpdated' entry: 2019-04-10 17:55:10.68444705 +1000 AEST
[DEBUG]: 2019/04/10 17:55:08 Sorted orderbook. Earliest 'LastUpdated' entry: 2019-04-10 17:55:10.68444705 +1000 AEST
[DEBUG]: 2019/04/10 17:55:08 Updating Ask for channel 741. Price 302.4. Old amount 30.17450576, New Amount 10
[DEBUG]: 2019/04/10 17:55:08 Updating Ask for channel 741. Price 302.2. Old amount 26.99, New Amount 10.99
[DEBUG]: 2019/04/10 17:55:08 Updating Ask for channel 741. Price 302.2. Old amount 10.99, New Amount 7.99
[DEBUG]: 2019/04/10 17:55:08 Updating Ask for channel 741. Price 302.4. Old amount 10, New Amount 30.17450576
[DEBUG]: 2019/04/10 17:55:08 Saving orderbook. Lastupdated: 2019-04-10 17:55:11.150218009 +1000 AEST
```


- The test `TestOrderbookBufferReset` ensures the orderbook buffer is set and reset appropriately
- The test `TestOrderBookOutOfOrder` ensures the orderbook ordering is correct when applying orderbook buffers

# Final request:
Could someone test on Linux to prove that resubscribe loops don't occur anymore?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules