### PR TITLE
New NTP Client

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -214,7 +214,7 @@ comm method and add in your contact list if available.
 
 ## Configure Network Time Server 
 
-+ To configure and enable a NPT server you need to set the "enabled" field to one of 3 values -1 is disabled 0 is enabled and alert at start up 1 is enabled and warn at start up
++ To configure and enable a NTP server you need to set the "enabled" field to one of 3 values -1 is disabled 0 is enabled and alert at start up 1 is enabled and warn at start up
 servers are configured by the pool array and attempted first to last allowedDifference and allowedNegativeDifference are how far ahead and behind is acceptable for the time to be out in nanoseconds
 
 ```js

--- a/config/README.md
+++ b/config/README.md
@@ -211,6 +211,23 @@ comm method and add in your contact list if available.
 },
 ```
 
+
+## Configure Network Time Server 
+
++ To configure and enable a NPT server you need to set the "enabled" field to one of 3 values -1 is disabled 0 is enabled and alert at start up 1 is enabled and warn at start up
+servers are configured by the pool array and attempted first to last allowedDifference and allowedNegativeDifference are how far ahead and behind is acceptable for the time to be out in nanoseconds
+
+```js
+ "ntpclient": {
+  "enabled": 0,
+  "pool": [
+   "pool.ntp.org:123"
+  ],
+  "allowedDifference": 0,
+  "allowedNegativeDifference": 0
+ },
+ ```
+
 ### Please click GoDocs chevron above to view current GoDoc information for this package
 
 ## Contribution

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,8 @@ const (
 	configPairsLastUpdatedWarningThreshold = 30 // 30 days
 	configDefaultHTTPTimeout               = time.Second * 15
 	configMaxAuthFailres                   = 3
+	allowedDifference                      = 50000000
+	allowedNegativeDifference              = 50000000
 )
 
 // Constants here hold some messages
@@ -1102,14 +1104,14 @@ func (c *Config) CheckNTPConfig() {
 	m.Lock()
 	defer m.Unlock()
 
-	if c.NTPClient.AllowedDifference == nil {
+	if c.NTPClient.AllowedDifference == nil || *c.NTPClient.AllowedDifference == 0 {
 		c.NTPClient.AllowedDifference = new(time.Duration)
-		*c.NTPClient.AllowedDifference = 50000000
+		*c.NTPClient.AllowedDifference = allowedDifference
 	}
 
-	if c.NTPClient.AllowedNegativeDifference == nil {
+	if c.NTPClient.AllowedNegativeDifference == nil || *c.NTPClient.AllowedNegativeDifference == 0 {
 		c.NTPClient.AllowedNegativeDifference = new(time.Duration)
-		*c.NTPClient.AllowedNegativeDifference = 50000000
+		*c.NTPClient.AllowedNegativeDifference = allowedNegativeDifference
 	}
 
 	if len(c.NTPClient.Pool) < 1 {
@@ -1134,7 +1136,7 @@ func (c *Config) DisableNTPCheck(input io.Reader) (string, error) {
 			return "", err
 		}
 
-		answer = strings.Replace(answer, "\n", "", -1)
+		answer = strings.TrimRight(answer, "\r\n")
 		switch answer {
 		case "a":
 			c.NTPClient.Level = 0

--- a/config/config.go
+++ b/config/config.go
@@ -1127,7 +1127,6 @@ func (c *Config) DisableNTPCheck(input io.Reader) (string, error) {
 		}
 
 		answer = strings.Replace(answer, "\n", "", -1)
-
 		switch answer {
 		case "a":
 			c.NTPClient.Enabled = 1

--- a/config/config.go
+++ b/config/config.go
@@ -1143,10 +1143,6 @@ func (c *Config) DisableNTPCheck(input io.Reader) (string, error) {
 			return "Future notications for out time sync have been disabled", nil
 		}
 	}
-	err := c.SaveConfig("")
-	if err != nil {
-		return "", err
-	}
 	return "", nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ const (
 	configDefaultHTTPTimeout               = time.Second * 15
 	configMaxAuthFailres                   = 3
 	defaultNTPAllowedDifference            = 50000000
-	defaultNTPAllowedNegativeDifference    = -50000000
+	defaultNTPAllowedNegativeDifference    = 50000000
 )
 
 // Constants here hold some messages

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	GlobalHTTPTimeout time.Duration        `json:"globalHTTPTimeout"`
 	Logging           log.Logging          `json:"logging"`
 	Profiler          ProfilerConfig       `json:"profiler"`
+	NTPClient         NTPClientConfig      `json:"ntpclient"`
 	Currency          CurrencyConfig       `json:"currencyConfig"`
 	Communications    CommunicationsConfig `json:"communications"`
 	Portfolio         portfolio.Base       `json:"portfolioAddresses"`
@@ -120,6 +121,11 @@ type Config struct {
 
 type ProfilerConfig struct {
 	Enabled bool `json:"enabled"`
+}
+
+type NTPClientConfig struct {
+	Pool              []string      `json:"pool"`
+	AllowedDifference time.Duration `json:"alloweddifference"`
 }
 
 // ExchangeConfig holds all the information needed for each enabled Exchange.

--- a/config/config.go
+++ b/config/config.go
@@ -1109,7 +1109,7 @@ func (c *Config) CheckNTPConfig() {
 		*c.NTPClient.AllowedDifference = defaultNTPAllowedDifference
 	}
 
-	if c.NTPClient.AllowedNegativeDifference == nil || *c.NTPClient.AllowedNegativeDifference == 0 {
+	if c.NTPClient.AllowedNegativeDifference == nil || *c.NTPClient.AllowedNegativeDifference <= 0 {
 		c.NTPClient.AllowedNegativeDifference = new(time.Duration)
 		*c.NTPClient.AllowedNegativeDifference = defaultNTPAllowedNegativeDifference
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -35,8 +35,8 @@ const (
 	configPairsLastUpdatedWarningThreshold = 30 // 30 days
 	configDefaultHTTPTimeout               = time.Second * 15
 	configMaxAuthFailres                   = 3
-	allowedDifference                      = 50000000
-	allowedNegativeDifference              = 50000000
+	defaultNTPAllowedDifference            = 50000000
+	defaultNTPAllowedNegativeDifference    = -50000000
 )
 
 // Constants here hold some messages
@@ -1106,12 +1106,12 @@ func (c *Config) CheckNTPConfig() {
 
 	if c.NTPClient.AllowedDifference == nil || *c.NTPClient.AllowedDifference == 0 {
 		c.NTPClient.AllowedDifference = new(time.Duration)
-		*c.NTPClient.AllowedDifference = allowedDifference
+		*c.NTPClient.AllowedDifference = defaultNTPAllowedDifference
 	}
 
 	if c.NTPClient.AllowedNegativeDifference == nil || *c.NTPClient.AllowedNegativeDifference == 0 {
 		c.NTPClient.AllowedNegativeDifference = new(time.Duration)
-		*c.NTPClient.AllowedNegativeDifference = allowedNegativeDifference
+		*c.NTPClient.AllowedNegativeDifference = defaultNTPAllowedNegativeDifference
 	}
 
 	if len(c.NTPClient.Pool) < 1 {

--- a/config/config.go
+++ b/config/config.go
@@ -1099,7 +1099,7 @@ func (c *Config) CheckLoggerConfig() error {
 	return nil
 }
 
-// CheckNTPConfig() check for incorrectly configured NTP server config entires and load sane defaults
+// CheckNTPConfig() checks for missing or incorrectly configured NTPClient and recreates with known safe defaults
 func (c *Config) CheckNTPConfig() {
 	m.Lock()
 	defer m.Unlock()

--- a/config/config.go
+++ b/config/config.go
@@ -1110,7 +1110,7 @@ func (c *Config) CheckNTPConfig() {
 	}
 }
 
-// DisableNTPCheck
+// DisableNTPCheck() allows the user to change how they are prompted for timesync alerts
 func (c *Config) DisableNTPCheck(input io.Reader) (string, error) {
 	m.Lock()
 	defer m.Unlock()
@@ -1143,7 +1143,7 @@ func (c *Config) DisableNTPCheck(input io.Reader) (string, error) {
 			return "Future notications for out time sync have been disabled", nil
 		}
 	}
-	return "", nil
+	return "", errors.New("something went wrong NTPCheck should never make it this far")
 }
 
 // GetFilePath returns the desired config file or the default config file name

--- a/config/config.go
+++ b/config/config.go
@@ -124,6 +124,7 @@ type ProfilerConfig struct {
 }
 
 type NTPClientConfig struct {
+	Enabled           bool          `json:"enabled"`
 	Pool              []string      `json:"pool"`
 	AllowedDifference time.Duration `json:"alloweddifference"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -977,11 +977,9 @@ func TestDisableNTPCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _ = ntpclient.NTPClient(c.NTPClient.Pool)
-
 	warn, err := c.DisableNTPCheck(strings.NewReader("w\n"))
 	if err != nil {
-		t.Errorf("failed reason: %v", err)
+		t.Fatalf("test failed to create ntpclient failed reason: %v", err)
 	}
 
 	if warn != "Time sync has been set to warn only" {
@@ -1011,8 +1009,11 @@ func TestCheckNTPConfig(t *testing.T) {
 	c.NTPClient.AllowedNegativeDifference = nil
 	c.NTPClient.AllowedDifference = nil
 
-	_, _ = ntpclient.NTPClient(c.NTPClient.Pool)
 	c.CheckNTPConfig()
+	_, err := ntpclient.NTPClient(c.NTPClient.Pool)
+	if err != nil {
+		t.Fatalf("test failed to create ntpclient failed reason: %v", err)
+	}
 
 	if c.NTPClient.Pool[0] != "pool.ntp.org:123" {
 		t.Error("ntpclient with no valid pool should default to pool.ntp.org ")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -982,25 +982,25 @@ func TestDisableNTPCheck(t *testing.T) {
 
 	warn, err := c.DisableNTPCheck(strings.NewReader("w\n"))
 	if err != nil {
-		t.Errorf("Failed reason: %v", err)
+		t.Errorf("failed reason: %v", err)
 	}
 
 	if warn != "Time sync has been set to warn only" {
-		t.Errorf("Failed expected %v got %v", "Time sync has been set to warn only", warn)
+		t.Errorf("failed expected %v got %v", "Time sync has been set to warn only", warn)
 	}
 	alert, _ := c.DisableNTPCheck(strings.NewReader("a\n"))
 	if alert != "Time sync has been set to alert" {
-		t.Errorf("Failed expected %v got %v", "Time sync has been set to alert", alert)
+		t.Errorf("failed expected %v got %v", "Time sync has been set to alert", alert)
 	}
 
 	disable, _ := c.DisableNTPCheck(strings.NewReader("d\n"))
 	if disable != "Future notications for out time sync have been disabled" {
-		t.Errorf("Failed expected %v got %v", "Future notications for out time sync have been disabled", disable)
+		t.Errorf("failed expected %v got %v", "Future notications for out time sync have been disabled", disable)
 	}
 
 	_, err = c.DisableNTPCheck(strings.NewReader(" "))
 	if err.Error() != "EOF" {
-		t.Errorf("Failed expected EOF got: %v", err)
+		t.Errorf("failed expected EOF got: %v", err)
 	}
 }
 
@@ -1016,14 +1016,14 @@ func TestCheckNTPConfig(t *testing.T) {
 	c.CheckNTPConfig()
 
 	if c.NTPClient.Pool[0] != "pool.ntp.org:123" {
-		t.Error("NTPClient with no valid pool should default to pool.ntp.org ")
+		t.Error("ntpclient with no valid pool should default to pool.ntp.org ")
 	}
 
 	if c.NTPClient.AllowedDifference == nil {
-		t.Error("NTPClient with nil AllowedDifference should default to sane vale")
+		t.Error("ntpclient with nil alloweddifference should default to sane vale")
 	}
 
 	if c.NTPClient.AllowedNegativeDifference == nil {
-		t.Error("NTPClient with nil AllowedNegativeDifference should default to sane vale")
+		t.Error("ntpclient with nil allowednegativedifference should default to sane vale")
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,11 +4,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/thrasher-/gocryptotrader/ntpclient"
-
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/currency"
 	log "github.com/thrasher-/gocryptotrader/logger"
+	"github.com/thrasher-/gocryptotrader/ntpclient"
 )
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1007,12 +1007,23 @@ func TestDisableNTPCheck(t *testing.T) {
 func TestCheckNTPConfig(t *testing.T) {
 	c := GetConfig()
 
-	c.NTPClient.Enabled = 1
+	c.NTPClient.Level = 0
 	c.NTPClient.Pool = nil
+	c.NTPClient.AllowedNegativeDifference = nil
+	c.NTPClient.AllowedDifference = nil
 
 	_, _ = ntpclient.NTPClient(c.NTPClient.Pool)
 	c.CheckNTPConfig()
+
 	if c.NTPClient.Pool[0] != "pool.ntp.org:123" {
 		t.Error("NTPClient with no valid pool should default to pool.ntp.org ")
+	}
+
+	if c.NTPClient.AllowedDifference == nil {
+		t.Error("NTPClient with nil AllowedDifference should default to sane vale")
+	}
+
+	if c.NTPClient.AllowedNegativeDifference == nil {
+		t.Error("NTPClient with nil AllowedNegativeDifference should default to sane vale")
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -984,6 +984,7 @@ func TestDisableNTPCheck(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed reason: %v", err)
 	}
+
 	if warn != "Time sync has been set to warn only" {
 		t.Errorf("Failed expected %v got %v", "Time sync has been set to warn only", warn)
 	}
@@ -995,6 +996,11 @@ func TestDisableNTPCheck(t *testing.T) {
 	disable, _ := c.DisableNTPCheck(strings.NewReader("d\n"))
 	if disable != "Future notications for out time sync have been disabled" {
 		t.Errorf("Failed expected %v got %v", "Future notications for out time sync have been disabled", disable)
+	}
+
+	_, err = c.DisableNTPCheck(strings.NewReader(" "))
+	if err.Error() != "EOF" {
+		t.Errorf("Failed expected EOF got: %v", err)
 	}
 }
 
@@ -1009,5 +1015,4 @@ func TestCheckNTPConfig(t *testing.T) {
 	if c.NTPClient.Pool[0] != "pool.ntp.org:123" {
 		t.Error("NTPClient with no valid pool should default to pool.ntp.org ")
 	}
-
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -982,19 +982,19 @@ func TestDisableNTPCheck(t *testing.T) {
 
 	warn, err := c.DisableNTPCheck(strings.NewReader("w\n"))
 	if err != nil {
-		t.Errorf("test failed reason: %v", err)
+		t.Errorf("Failed reason: %v", err)
 	}
 	if warn != "Time sync has been set to warn only" {
-		t.Errorf("test failed expected %v got %v", "Time sync has been set to warn only", warn)
+		t.Errorf("Failed expected %v got %v", "Time sync has been set to warn only", warn)
 	}
 	alert, _ := c.DisableNTPCheck(strings.NewReader("a\n"))
 	if alert != "Time sync has been set to alert" {
-		t.Errorf("test failed expected %v got %v", "Time sync has been set to alert", alert)
+		t.Errorf("Failed expected %v got %v", "Time sync has been set to alert", alert)
 	}
 
 	disable, _ := c.DisableNTPCheck(strings.NewReader("d\n"))
 	if disable != "Future notications for out time sync have been disabled" {
-		t.Errorf("test failed expected %v got %v", "Future notications for out time sync have been disabled", disable)
+		t.Errorf("Failed expected %v got %v", "Future notications for out time sync have been disabled", disable)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1019,10 +1019,10 @@ func TestCheckNTPConfig(t *testing.T) {
 	}
 
 	if c.NTPClient.AllowedDifference == nil {
-		t.Error("ntpclient with nil alloweddifference should default to sane vale")
+		t.Error("ntpclient with nil alloweddifference should default to sane value")
 	}
 
 	if c.NTPClient.AllowedNegativeDifference == nil {
-		t.Error("ntpclient with nil allowednegativedifference should default to sane vale")
+		t.Error("ntpclient with nil allowednegativedifference should default to sane value")
 	}
 }

--- a/config_example.json
+++ b/config_example.json
@@ -12,6 +12,14 @@
  "profiler": {
     "enabled": false
    },
+  "ntpclient": {
+    "enabled": 1,
+    "pool": [
+     "pool.ntp.org:123"
+    ],
+    "allowedDifference": 50000000,
+    "allowedNegativeDifference": 50000000
+   },
  "currencyConfig": {
   "forexProviders": [
    {

--- a/config_example.json
+++ b/config_example.json
@@ -13,7 +13,7 @@
     "enabled": false
    },
   "ntpclient": {
-    "enabled": 1,
+    "enabled": 0,
     "pool": [
      "pool.ntp.org:123"
     ],

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 			NTPcurrentTimeDifference := NTPTime.Sub(currentTime)
 			if bot.config.NTPClient.Level == 0 {
 				if NTPcurrentTimeDifference >= *bot.config.NTPClient.AllowedDifference || NTPcurrentTimeDifference <= *bot.config.NTPClient.AllowedNegativeDifference {
-					log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+					log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 					disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
 					if errNTP != nil {
 						log.Errorf("failed to disable ntp time check reason: %v", err)
@@ -123,7 +123,7 @@ func main() {
 					log.Info(disable)
 				}
 			} else {
-				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 		log.Errorf("Failed to setup logger reason: %s", err)
 	}
 
-	if bot.config.NTPClient.Enabled >= 1 {
+	if bot.config.NTPClient.Level != -1 {
 		bot.config.CheckNTPConfig()
 		NTPTime, errNTP := ntpclient.NTPClient(bot.config.NTPClient.Pool)
 		currentTime := time.Now()
@@ -113,8 +113,8 @@ func main() {
 			log.Warnf("NTPClient failed to create: %v", errNTP)
 		}
 		NTPcurrentTimeDifference := NTPTime.Sub(currentTime)
-		if bot.config.NTPClient.Enabled == 1 {
-			if NTPcurrentTimeDifference >= bot.config.NTPClient.AllowedDifference || NTPcurrentTimeDifference <= bot.config.NTPClient.AllowedNegativeDifference {
+		if bot.config.NTPClient.Level == 0 {
+			if NTPcurrentTimeDifference >= *bot.config.NTPClient.AllowedDifference || NTPcurrentTimeDifference <= *bot.config.NTPClient.AllowedNegativeDifference {
 				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 				disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
 				if errNTP != nil {

--- a/main.go
+++ b/main.go
@@ -108,10 +108,10 @@ func main() {
 	if bot.config.NTPClient.Enabled >= 1 {
 		bot.config.CheckNTPConfig()
 		NTPTime, errNTP := ntpclient.NTPClient(bot.config.NTPClient.Pool)
+		currentTime := time.Now()
 		if errNTP != nil {
 			log.Warnf("NTPClient failed to create: %v", errNTP)
 		}
-		currentTime := time.Now()
 		NTPcurrentTimeDifference := NTPTime.Sub(currentTime)
 		if bot.config.NTPClient.Enabled == 1 {
 			if NTPcurrentTimeDifference >= bot.config.NTPClient.AllowedDifference || NTPcurrentTimeDifference <= bot.config.NTPClient.AllowedNegativeDifference {

--- a/main.go
+++ b/main.go
@@ -115,11 +115,10 @@ func main() {
 			NTPcurrentTimeDifference := NTPTime.Sub(currentTime)
 			if bot.config.NTPClient.Level == 0 {
 				configTime := *bot.config.NTPClient.AllowedDifference
-				configNegativeTime := *bot.config.NTPClient.AllowedNegativeDifference
-				log.Debugln(configTime)
-				log.Debugln(configNegativeTime)
+				configNegativeTime := (*bot.config.NTPClient.AllowedNegativeDifference - (*bot.config.NTPClient.AllowedNegativeDifference * 2))
+				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 				if NTPcurrentTimeDifference > configTime || NTPcurrentTimeDifference < configNegativeTime {
-					log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+					log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 					disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
 					if errNTP != nil {
 						log.Errorf("failed to disable ntp time check reason: %v", err)
@@ -127,7 +126,7 @@ func main() {
 					log.Info(disable)
 				}
 			} else {
-				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -111,19 +111,20 @@ func main() {
 		currentTime := time.Now()
 		if errNTP != nil {
 			log.Warnf("NTPClient failed to create: %v", errNTP)
-		}
-		NTPcurrentTimeDifference := NTPTime.Sub(currentTime)
-		if bot.config.NTPClient.Level == 0 {
-			if NTPcurrentTimeDifference >= *bot.config.NTPClient.AllowedDifference || NTPcurrentTimeDifference <= *bot.config.NTPClient.AllowedNegativeDifference {
-				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
-				disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
-				if errNTP != nil {
-					log.Errorf("failed to disable ntp time check reason: %v", err)
-				}
-				log.Info(disable)
-			}
 		} else {
-			log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+			NTPcurrentTimeDifference := NTPTime.Sub(currentTime)
+			if bot.config.NTPClient.Level == 0 {
+				if NTPcurrentTimeDifference >= *bot.config.NTPClient.AllowedDifference || NTPcurrentTimeDifference <= *bot.config.NTPClient.AllowedNegativeDifference {
+					log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+					disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
+					if errNTP != nil {
+						log.Errorf("failed to disable ntp time check reason: %v", err)
+					}
+					log.Info(disable)
+				}
+			} else {
+				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -113,20 +113,18 @@ func main() {
 			log.Warnf("NTPClient failed to create: %v", errNTP)
 		} else {
 			NTPcurrentTimeDifference := NTPTime.Sub(currentTime)
-			if bot.config.NTPClient.Level == 0 {
-				configTime := *bot.config.NTPClient.AllowedDifference
-				configNegativeTime := (*bot.config.NTPClient.AllowedNegativeDifference - (*bot.config.NTPClient.AllowedNegativeDifference * 2))
-				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
-				if NTPcurrentTimeDifference > configTime || NTPcurrentTimeDifference < configNegativeTime {
-					log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+			configNTPTime := *bot.config.NTPClient.AllowedDifference
+			configNTPNegativeTime := (*bot.config.NTPClient.AllowedNegativeDifference - (*bot.config.NTPClient.AllowedNegativeDifference * 2))
+			if NTPcurrentTimeDifference > configNTPTime || NTPcurrentTimeDifference < configNTPNegativeTime {
+				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, configNTPTime, configNTPNegativeTime)
+				if bot.config.NTPClient.Level == 0 {
 					disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
 					if errNTP != nil {
 						log.Errorf("failed to disable ntp time check reason: %v", err)
+					} else {
+						log.Info(disable)
 					}
-					log.Info(disable)
 				}
-			} else {
-				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/communications"
@@ -17,6 +18,7 @@ import (
 	"github.com/thrasher-/gocryptotrader/currency/coinmarketcap"
 	exchange "github.com/thrasher-/gocryptotrader/exchanges"
 	log "github.com/thrasher-/gocryptotrader/logger"
+	"github.com/thrasher-/gocryptotrader/ntpclient"
 	"github.com/thrasher-/gocryptotrader/portfolio"
 )
 
@@ -102,6 +104,16 @@ func main() {
 	if err != nil {
 		log.Errorf("Failed to setup logger reason: %s", err)
 	}
+
+	NTPTime, err := ntpclient.NTPClient(bot.config.NTPClient.Pool)
+	currentTime := time.Now()
+	NTPcurrentTimeDifference := currentTime.Sub(NTPTime)
+	if NTPcurrentTimeDifference >= bot.config.NTPClient.AllowedDifference || (bot.config.NTPClient.AllowedDifference <= NTPcurrentTimeDifference) {
+		log.Infof("Time out of sync NTP: %v | time.Now() %v | difference: %v | allowed: %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference)
+	}
+
+	log.Infof("NTP: %v | time.Now() %v | difference: %v | allowed: %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference)
+	os.Exit(0)
 
 	AdjustGoMaxProcs()
 	log.Debugf("Bot '%s' started.\n", bot.config.Name)

--- a/main.go
+++ b/main.go
@@ -114,8 +114,12 @@ func main() {
 		} else {
 			NTPcurrentTimeDifference := NTPTime.Sub(currentTime)
 			if bot.config.NTPClient.Level == 0 {
-				if NTPcurrentTimeDifference >= *bot.config.NTPClient.AllowedDifference || NTPcurrentTimeDifference <= *bot.config.NTPClient.AllowedNegativeDifference {
-					log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+				configTime := *bot.config.NTPClient.AllowedDifference
+				configNegativeTime := *bot.config.NTPClient.AllowedNegativeDifference
+				log.Debugln(configTime)
+				log.Debugln(configNegativeTime)
+				if NTPcurrentTimeDifference > configTime || NTPcurrentTimeDifference < configNegativeTime {
+					log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 					disable, errNTP := bot.config.DisableNTPCheck(os.Stdin)
 					if errNTP != nil {
 						log.Errorf("failed to disable ntp time check reason: %v", err)
@@ -123,7 +127,7 @@ func main() {
 					log.Info(disable)
 				}
 			} else {
-				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / -%v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
+				log.Warnf("Time out of sync (NTP): %v | (time.Now()): %v | (Difference): %v | (Allowed): +%v / %v", NTPTime, currentTime, NTPcurrentTimeDifference, bot.config.NTPClient.AllowedDifference, bot.config.NTPClient.AllowedNegativeDifference)
 			}
 		}
 	}

--- a/ntpclient/ntpclient.go
+++ b/ntpclient/ntpclient.go
@@ -2,6 +2,7 @@ package ntpclient
 
 import (
 	"encoding/binary"
+	"errors"
 	"net"
 	"time"
 
@@ -52,7 +53,7 @@ func NTPClient(pool []string) (time.Time, error) {
 		secs := float64(rsp.TxTimeSec) - 2208988800
 		nanos := (int64(rsp.TxTimeFrac) * 1e9) >> 32
 
-		t = time.Unix(int64(secs), nanos)
+		return time.Unix(int64(secs), nanos), nil
 	}
-	return t, nil
+	return t, errors.New("no valid time servers found")
 }

--- a/ntpclient/ntpclient.go
+++ b/ntpclient/ntpclient.go
@@ -30,9 +30,7 @@ type ntppacket struct {
 // NTPClient create's a new NTPClient and returns local based on ntp servers provided timestamp
 func NTPClient(pool []string) (time.Time, error) {
 
-	var t = time.Unix(0, 0)
-
-	for i := 0; i < len(pool); i++ {
+	for i := range pool {
 		con, err := net.Dial("udp", pool[i])
 		if err != nil {
 			log.Warnf("Unable to connect to hosts %v attempting next", pool[i])
@@ -55,5 +53,5 @@ func NTPClient(pool []string) (time.Time, error) {
 
 		return time.Unix(int64(secs), nanos), nil
 	}
-	return t, errors.New("no valid time servers found")
+	return time.Unix(0, 0), errors.New("no valid time servers")
 }

--- a/ntpclient/ntpclient.go
+++ b/ntpclient/ntpclient.go
@@ -1,0 +1,58 @@
+package ntpclient
+
+import (
+	"encoding/binary"
+	"net"
+	"time"
+
+	log "github.com/thrasher-/gocryptotrader/logger"
+)
+
+type ntppacket struct {
+	Settings       uint8  // leap yr indicator, ver number, and mode
+	Stratum        uint8  // stratum of local clock
+	Poll           int8   // poll exponent
+	Precision      int8   // precision exponent
+	RootDelay      uint32 // root delay
+	RootDispersion uint32 // root dispersion
+	ReferenceID    uint32 // reference id
+	RefTimeSec     uint32 // reference timestamp sec
+	RefTimeFrac    uint32 // reference timestamp fractional
+	OrigTimeSec    uint32 // origin time secs
+	OrigTimeFrac   uint32 // origin time fractional
+	RxTimeSec      uint32 // receive time secs
+	RxTimeFrac     uint32 // receive time frac
+	TxTimeSec      uint32 // transmit time secs
+	TxTimeFrac     uint32 // transmit time frac
+}
+
+// NTPClient create's a new NTPClient and returns local based on ntp servers provided timestamp
+func NTPClient(pool []string) (time.Time, error) {
+
+	var t = time.Unix(0, 0)
+
+	for i := 0; i < len(pool); i++ {
+		con, err := net.Dial("udp", pool[i])
+		if err != nil {
+			log.Warnf("Unable to connect to hosts %v attempting next", pool[i])
+			continue
+		}
+
+		defer con.Close()
+		con.SetDeadline(time.Now().Add(5 * time.Second))
+
+		req := &ntppacket{Settings: 0x1B}
+		binary.Write(con, binary.BigEndian, req)
+
+		rsp := &ntppacket{}
+		if err := binary.Read(con, binary.BigEndian, rsp); err != nil {
+			continue
+		}
+
+		secs := float64(rsp.TxTimeSec) - 2208988800
+		nanos := (int64(rsp.TxTimeFrac) * 1e9) >> 32
+
+		t = time.Unix(int64(secs), nanos)
+	}
+	return t, nil
+}

--- a/ntpclient/ntpclient.go
+++ b/ntpclient/ntpclient.go
@@ -29,7 +29,6 @@ type ntppacket struct {
 
 // NTPClient create's a new NTPClient and returns local based on ntp servers provided timestamp
 func NTPClient(pool []string) (time.Time, error) {
-
 	for i := range pool {
 		con, err := net.Dial("udp", pool[i])
 		if err != nil {
@@ -38,10 +37,13 @@ func NTPClient(pool []string) (time.Time, error) {
 		}
 
 		defer con.Close()
+
 		con.SetDeadline(time.Now().Add(5 * time.Second))
 
 		req := &ntppacket{Settings: 0x1B}
-		binary.Write(con, binary.BigEndian, req)
+		if err := binary.Write(con, binary.BigEndian, req); err != nil {
+			continue
+		}
 
 		rsp := &ntppacket{}
 		if err := binary.Read(con, binary.BigEndian, rsp); err != nil {

--- a/ntpclient/ntpclient_test.go
+++ b/ntpclient/ntpclient_test.go
@@ -1,0 +1,9 @@
+package ntpclient
+
+import (
+	"testing"
+)
+
+func TestNTPClient(t *testing.T) {
+
+}

--- a/ntpclient/ntpclient_test.go
+++ b/ntpclient/ntpclient_test.go
@@ -6,13 +6,11 @@ import (
 
 func TestNTPClient(t *testing.T) {
 	pool := []string{"pool.ntp.org:123", "0.pool.ntp.org:123"}
-	NTPTime, err := NTPClient(pool)
+	_, err := NTPClient(pool)
 	if err != nil {
-		t.Errorf("failed to get time %v", err)
+		t.Fatalf("failed to get time %v", err)
 	}
-	if NTPTime.IsZero() {
-		t.Error("expected time but 0,0 returned")
-	}
+
 	invalidpool := []string{"pool.thisisinvalid.org"}
 	_, err = NTPClient(invalidpool)
 	if err == nil {

--- a/ntpclient/ntpclient_test.go
+++ b/ntpclient/ntpclient_test.go
@@ -5,5 +5,23 @@ import (
 )
 
 func TestNTPClient(t *testing.T) {
+	pool := []string{"pool.ntp.org:123", "0.pool.ntp.org:123"}
+	NTPTime, err := NTPClient(pool)
+	if err != nil {
+		t.Errorf("NTPClient() failed to get time %v", err)
+	}
+	if NTPTime.IsZero() {
+		t.Error("Expected time but 0,0 returned")
+	}
+	invalidpool := []string{"pool.thisisinvalid.org"}
+	_, err = NTPClient(invalidpool)
+	if err == nil {
+		t.Errorf("NTPClient() failed to get time %v", err)
+	}
 
+	firstInvalid := []string{"pool.thisisinvalid.org", "pool.ntp.org:123", "0.pool.ntp.org:123"}
+	_, err = NTPClient(firstInvalid)
+	if err != nil {
+		t.Errorf("NTPClient() failed to get time %v", err)
+	}
 }

--- a/ntpclient/ntpclient_test.go
+++ b/ntpclient/ntpclient_test.go
@@ -8,20 +8,20 @@ func TestNTPClient(t *testing.T) {
 	pool := []string{"pool.ntp.org:123", "0.pool.ntp.org:123"}
 	NTPTime, err := NTPClient(pool)
 	if err != nil {
-		t.Errorf("NTPClient() failed to get time %v", err)
+		t.Errorf("failed to get time %v", err)
 	}
 	if NTPTime.IsZero() {
-		t.Error("Expected time but 0,0 returned")
+		t.Error("expected time but 0,0 returned")
 	}
 	invalidpool := []string{"pool.thisisinvalid.org"}
 	_, err = NTPClient(invalidpool)
 	if err == nil {
-		t.Errorf("NTPClient() failed to get time %v", err)
+		t.Errorf("failed to get time %v", err)
 	}
 
 	firstInvalid := []string{"pool.thisisinvalid.org", "pool.ntp.org:123", "0.pool.ntp.org:123"}
 	_, err = NTPClient(firstInvalid)
 	if err != nil {
-		t.Errorf("NTPClient() failed to get time %v", err)
+		t.Errorf("failed to get time %v", err)
 	}
 }

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -12,6 +12,15 @@
  "profiler": {
   "enabled": false
  },
+ "ntpclient": {
+  "enabled": 0,
+  "pool": [
+   "0.pool.ntp.org:123",
+   "pool.ntp.org:123"
+  ],
+  "allowedDifference": 50000000,
+  "allowedNegativeDifference": 0
+ },
  "currencyConfig": {
   "forexProviders": [
    {

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -19,7 +19,7 @@
    "pool.ntp.org:123"
   ],
   "allowedDifference": 50000000,
-  "allowedNegativeDifference": 50000000
+  "allowedNegativeDifference": -50000000
  },
  "currencyConfig": {
   "forexProviders": [

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -19,7 +19,7 @@
    "pool.ntp.org:123"
   ],
   "allowedDifference": 50000000,
-  "allowedNegativeDifference": -50000000
+  "allowedNegativeDifference": 50000000
  },
  "currencyConfig": {
   "forexProviders": [

--- a/testdata/configtest.json
+++ b/testdata/configtest.json
@@ -19,7 +19,7 @@
    "pool.ntp.org:123"
   ],
   "allowedDifference": 50000000,
-  "allowedNegativeDifference": 0
+  "allowedNegativeDifference": 50000000
  },
  "currencyConfig": {
   "forexProviders": [


### PR DESCRIPTION
# Description

This PR add's a new NTP Client into GCT that can be used for checking time against a remote NTP Server

It also includes a startup check that can be configured that will alert / warn (can also be disabled completely) a user if their current time is outside an allowed difference from the current network time

```js
 "ntpclient": {
  "enabled": 0,
  "pool": [
   "pool.ntp.org:123"
  ],
  "allowedDifference": 0,
  "allowedNegativeDifference": 0
 },
 ```

The configuration options for this are:

enabled: -1 to disable 0 for alert 1 for warn 
pool:  list of time servers to attempt to contact this attempt first to last 
allowedDifference: how far behind the time is allowed before a warning/alert is triggered
allowedNegativeDifference: how far ahead the time is allowed before a warning/alert is triggered

The NTP Client can also be manually created if it is required in other parts of the project such as an exchange level orderbook to confirm the time is correct before processing

This can be achieved by calling ntpclient.NTPClient(pool []string) which will return current network time or an error if one is raised

Configuration backwards compability has been added via config.CheckNTPConfig()
This checks to see if there is any misconfiguration and if so sets the following save known values:

NTPClient.Pool = []string{"pool.ntp.org:123"}
NTPClient.AllowedNegativeDifference = 50000000
NTPClient.AllowedDifference = 50000000

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unit tests have been written to cover creation and possible returns of ntpclient
Unit tests have been written to cover possible configuration values

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules