### PR TITLE
ZB: GetOrderbook out of range fix

### DIFF
--- a/exchanges/zb/zb.go
+++ b/exchanges/zb/zb.go
@@ -285,8 +285,8 @@ func (z *ZB) GetOrderbook(symbol string) (OrderbookResponse, error) {
 
 	// reverse asks data
 	var data [][]float64
-	for x := len(res.Asks) - 1; x != 0; x-- {
-		data = append(data, res.Asks[x])
+	for x := len(res.Asks); x > 0; x-- {
+		data = append(data, res.Asks[x-1])
 	}
 
 	res.Asks = data


### PR DESCRIPTION
# Description

Comparative is true when nothing is returned could force out of range, also misses element if you initialise with -1. 

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local package test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules