### PR TITLE
Gateio expand wrappers, websocket and bug fix

### DIFF
--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -460,6 +460,10 @@ func (g *Gateio) GetTradeHistory(symbol string) (TradHistoryResponse, error) {
 	return result, nil
 }
 
+func (g *Gateio) GenerateSignature(message string) []byte {
+	return common.GetHMAC(common.HashSHA512, []byte(message), []byte(g.APISecret))
+}
+
 // SendAuthenticatedHTTPRequest sends authenticated requests to the Gateio API
 // To use this you must setup an APIKey and APISecret from the exchange
 func (g *Gateio) SendAuthenticatedHTTPRequest(method, endpoint, param string, result interface{}) error {
@@ -472,7 +476,7 @@ func (g *Gateio) SendAuthenticatedHTTPRequest(method, endpoint, param string, re
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 	headers["key"] = g.APIKey
 
-	hmac := common.GetHMAC(common.HashSHA512, []byte(param), []byte(g.APISecret))
+	hmac := g.GenerateSignature(param)
 	headers["sign"] = common.HexEncodeToString(hmac)
 
 	urlPath := fmt.Sprintf("%s/%s/%s", g.APIUrl, gateioAPIVersion, endpoint)

--- a/exchanges/gateio/gateio.go
+++ b/exchanges/gateio/gateio.go
@@ -97,6 +97,7 @@ func (g *Gateio) Setup(exch *config.ExchangeConfig) {
 		g.BaseCurrencies = exch.BaseCurrencies
 		g.AvailablePairs = exch.AvailablePairs
 		g.EnabledPairs = exch.EnabledPairs
+		g.WebsocketURL = gateioWebsocketEndpoint
 		err := g.SetCurrencyPairFormat()
 		if err != nil {
 			log.Fatal(err)

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -78,7 +78,6 @@ func TestCancelExistingOrder(t *testing.T) {
 		t.Skip()
 	}
 
-
 	_, err := g.CancelExistingOrder(917591554, "btc_usdt")
 	if err != nil {
 		t.Errorf("Test failed - Gateio CancelExistingOrder: %s", err)

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -56,7 +56,7 @@ func TestGetMarketInfo(t *testing.T) {
 func TestSpotNewOrder(t *testing.T) {
 	t.Parallel()
 
-	if areTestAPIKeysSet() && !canManipulateRealOrders {
+	if !areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip()
 	}
 
@@ -74,7 +74,7 @@ func TestSpotNewOrder(t *testing.T) {
 func TestCancelExistingOrder(t *testing.T) {
 	t.Parallel()
 
-	if areTestAPIKeysSet() && !canManipulateRealOrders {
+	if !areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip()
 	}
 

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -56,7 +56,7 @@ func TestGetMarketInfo(t *testing.T) {
 func TestSpotNewOrder(t *testing.T) {
 	t.Parallel()
 
-	if apiKey == "" || apiSecret == "" {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip()
 	}
 
@@ -74,9 +74,10 @@ func TestSpotNewOrder(t *testing.T) {
 func TestCancelExistingOrder(t *testing.T) {
 	t.Parallel()
 
-	if apiKey == "" || apiSecret == "" {
+	if areTestAPIKeysSet() && !canManipulateRealOrders {
 		t.Skip()
 	}
+
 
 	_, err := g.CancelExistingOrder(917591554, "btc_usdt")
 	if err != nil {
@@ -483,9 +484,10 @@ func TestGetOrderInfo(t *testing.T) {
 		t.Skip("no API keys set skipping test")
 	}
 
-	order, err := g.GetOrderInfo("917591554")
+	_, err := g.GetOrderInfo("917591554")
 	if err != nil {
-		t.Fatalf("GetOrderInfo() returned an error skipping test: %v", err)
+		if err.Error() != "no order found with id 917591554" && err.Error() != "failed to get open orders" {
+			t.Fatalf("GetOrderInfo() returned an error skipping test: %v", err)
+		}
 	}
-	t.Log(order)
 }

--- a/exchanges/gateio/gateio_test.go
+++ b/exchanges/gateio/gateio_test.go
@@ -475,3 +475,17 @@ func TestGetDepositAddress(t *testing.T) {
 		}
 	}
 }
+func TestGetOrderInfo(t *testing.T) {
+	g.SetDefaults()
+	TestSetup(t)
+
+	if !areTestAPIKeysSet() {
+		t.Skip("no API keys set skipping test")
+	}
+
+	order, err := g.GetOrderInfo("917591554")
+	if err != nil {
+		t.Fatalf("GetOrderInfo() returned an error skipping test: %v", err)
+	}
+	t.Log(order)
+}

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -441,8 +441,8 @@ type WebsocketTrade struct {
 	Type   string  `json:"type"`
 }
 
-// WebSocketBalance holds a slice of WebsocketBalanceCurrency
-type WebSocketBalance struct {
+// WebsocketBalance holds a slice of WebsocketBalanceCurrency
+type WebsocketBalance struct {
 	Currency []WebsocketBalanceCurrency
 }
 

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -54,9 +54,9 @@ type MarketInfoPairsResponse struct {
 
 // BalancesResponse holds the user balances
 type BalancesResponse struct {
-	Result    string            `json:"result"`
-	Available map[string]string `json:"available"`
-	Locked    map[string]string `json:"locked"`
+	Result    string      `json:"result"`
+	Available interface{} `json:"available"`
+	Locked    interface{} `json:"locked"`
 }
 
 // KlinesRequestParams represents Klines request data.

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -35,6 +35,13 @@ var (
 	TimeIntervalDay            = TimeInterval(60 * 60 * 24)
 )
 
+const (
+	IDGeneric    = 0000
+	IDSignIn     = 1010
+	IDBalance    = 2000
+	IDOrderQuery = 3001
+)
+
 // MarketInfoResponse holds the market info data
 type MarketInfoResponse struct {
 	Result string                    `json:"result"`
@@ -397,15 +404,14 @@ type WebsocketRequest struct {
 
 // WebsocketResponse defines a websocket response from gateio
 type WebsocketResponse struct {
-	Time    int64          `json:"time"`
-	Channel string         `json:"channel"`
-	Event   string         `json:""`
-	Error   WebsocketError `json:"error"`
-	Result  struct {
-		Status string `json:"status"`
-	} `json:"result"`
-	Method string            `json:"method"`
-	Params []json.RawMessage `json:"params"`
+	Time    int64             `json:"time"`
+	Channel string            `json:"channel"`
+	Event   string            `json:""`
+	Error   WebsocketError    `json:"error"`
+	Result  json.RawMessage   `json:"result"`
+	ID      int64             `json:"id"`
+	Method  string            `json:"method"`
+	Params  []json.RawMessage `json:"params"`
 }
 
 // WebsocketError defines a websocket error type
@@ -434,4 +440,41 @@ type WebsocketTrade struct {
 	Price  float64 `json:"price,string"`
 	Amount float64 `json:"amount,string"`
 	Type   string  `json:"type"`
+}
+
+// WebSocketBalance holds a slice of WebsocketBalanceCurrency
+type WebSocketBalance struct {
+	Currency []WebsocketBalanceCurrency
+}
+
+// WebsocketBalanceCurrency contains currency name funds available and frozen
+type WebsocketBalanceCurrency struct {
+	Currency  string
+	Available string `json:"available"`
+	Freeze    string `json:"freeze"`
+}
+
+// WebSocketOrderQueryResult data returned from a websocket ordre query holds slice of WebSocketOrderQueryRecords
+type WebSocketOrderQueryResult struct {
+	Limit                      int                          `json:"limit"`
+	Offset                     int                          `json:"offset"`
+	Total                      int                          `json:"total"`
+	WebSocketOrderQueryRecords []WebSocketOrderQueryRecords `json:"records"`
+}
+
+// WebSocketOrderQueryRecords contains order information from a order.query websocket request
+type WebSocketOrderQueryRecords struct {
+	ID           int     `json:"id"`
+	Market       string  `json:"market"`
+	User         int     `json:"user"`
+	Ctime        float64 `json:"ctime"`
+	Mtime        float64 `json:"mtime"`
+	Price        string  `json:"price"`
+	Amount       string  `json:"amount"`
+	Left         string  `json:"left"`
+	DealFee      string  `json:"dealFee"`
+	OrderType    int     `json:"orderType"`
+	Type         int     `json:"type"`
+	FilledAmount string  `json:"filledAmount"`
+	FilledTotal  string  `json:"filledTotal"`
 }

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -451,7 +451,7 @@ type WebSocketBalance struct {
 type WebsocketBalanceCurrency struct {
 	Currency  string
 	Available string `json:"available"`
-	Freeze    string `json:"freeze"`
+	Locked    string `json:"freeze"`
 }
 
 // WebSocketOrderQueryResult data returned from a websocket ordre query holds slice of WebSocketOrderQueryRecords

--- a/exchanges/gateio/gateio_types.go
+++ b/exchanges/gateio/gateio_types.go
@@ -406,7 +406,6 @@ type WebsocketRequest struct {
 type WebsocketResponse struct {
 	Time    int64             `json:"time"`
 	Channel string            `json:"channel"`
-	Event   string            `json:""`
 	Error   WebsocketError    `json:"error"`
 	Result  json.RawMessage   `json:"result"`
 	ID      int64             `json:"id"`

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -46,11 +46,11 @@ func (g *Gateio) WsConnect() error {
 	}
 
 	if g.AuthenticatedAPISupport {
-		err = g.WsServerSignIn()
+		err = g.wsServerSignIn()
 		if err != nil {
 			log.Errorf("Authentication failed ")
 		}
-		time.Sleep(1000 * time.Millisecond)
+		time.Sleep(1000 * time.Millisecond) // sleep to allow server to complete address
 	}
 
 	go g.WsHandleData()
@@ -58,7 +58,7 @@ func (g *Gateio) WsConnect() error {
 	return g.WsSubscribe()
 }
 
-func (g *Gateio) WsServerSignIn() error {
+func (g *Gateio) wsServerSignIn() error {
 	nonce := int(time.Now().Unix() * 1000)
 	sigTemp := g.GenerateSignature(strconv.Itoa(nonce))
 	signature := common.Base64Encode(sigTemp)
@@ -413,7 +413,7 @@ func (g *Gateio) WsHandleData() {
 	}
 }
 
-func (g *Gateio) WsGetBalance() error {
+func (g *Gateio) wsGetBalance() error {
 	balanceWsRequest := WebsocketRequest{
 		ID:     IDBalance,
 		Method: "balance.query",

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -140,7 +140,6 @@ func (g *Gateio) WsSubscribe() error {
 				Method: "order.subscribe",
 				Params: []interface{}{c.String()},
 			}
-			log.Debugln(orderNotification)
 			err := g.WebsocketConn.WriteJSON(orderNotification)
 			if err != nil {
 				return err

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -218,7 +218,7 @@ func (g *Gateio) WsHandleData() {
 							p = WebsocketBalanceCurrency{
 								Currency:  xx,
 								Available: kk["available"].(string),
-								Freeze:    kk["freeze"].(string),
+								Locked:    kk["freeze"].(string),
 							}
 							balance.Currency = append(balance.Currency, p)
 						default:

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -65,7 +65,7 @@ func (g *Gateio) wsServerSignIn() error {
 	signinWsRequest := WebsocketRequest{
 		ID:     IDSignIn,
 		Method: "server.sign",
-		Params: []interface{}{g.APIKey, signature, nonce + 50},
+		Params: []interface{}{g.APIKey, signature, nonce},
 	}
 	return g.WebsocketConn.WriteJSON(signinWsRequest)
 }

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -206,7 +206,7 @@ func (g *Gateio) WsHandleData() {
 
 			switch result.ID {
 			case IDBalance:
-				var balance WebSocketBalance
+				var balance WebsocketBalance
 				var balanceInterface interface{}
 				err = json.Unmarshal(result.Result, &balanceInterface)
 				if err != nil {

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -426,7 +426,7 @@ func (g *Gateio) wsGetBalance() error {
 	return nil
 }
 
-func (g *Gateio) WsGetOrderInfo(market string, offset, limit int) error {
+func (g *Gateio) wsGetOrderInfo(market string, offset, limit int) error {
 	order := WebsocketRequest{
 		ID:     IDOrderQuery,
 		Method: "order.query",

--- a/exchanges/gateio/gateio_websocket.go
+++ b/exchanges/gateio/gateio_websocket.go
@@ -425,3 +425,20 @@ func (g *Gateio) wsGetBalance() error {
 	}
 	return nil
 }
+
+func (g *Gateio) WsGetOrderInfo(market string, offset, limit int) error {
+	order := WebsocketRequest{
+		ID:     IDOrderQuery,
+		Method: "order.query",
+		Params: []interface{}{
+			market,
+			offset,
+			limit,
+		},
+	}
+	err := g.WebsocketConn.WriteJSON(order)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/exchanges/gateio/gateio_wrapper.go
+++ b/exchanges/gateio/gateio_wrapper.go
@@ -307,8 +307,9 @@ func (g *Gateio) GetOrderInfo(orderID string) (exchange.OrderDetail, error) {
 		} else if strings.EqualFold(orders.Orders[x].Type, exchange.BidOrderSide.ToString()) {
 			orderDetail.OrderSide = exchange.BuyOrderSide
 		}
+		return orderDetail, nil
 	}
-	return orderDetail, nil
+	return orderDetail, fmt.Errorf("no order found with id %v", orderID)
 }
 
 // GetDepositAddress returns a deposit address for a specified currency

--- a/restful_router.go
+++ b/restful_router.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/thrasher-/gocryptotrader/common"
 	log "github.com/thrasher-/gocryptotrader/logger"
 
 	_ "net/http/pprof"
@@ -45,7 +46,7 @@ var routes = Routes{}
 // router
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	//listenAddr := bot.config.Webserver.ListenAddress
+	listenAddr := bot.config.Webserver.ListenAddress
 
 	routes = Routes{
 		Route{
@@ -115,8 +116,8 @@ func NewRouter() *mux.Router {
 			Methods(route.Method).
 			Path(route.Pattern).
 			Name(route.Name).
-			Handler(RESTLogger(route.HandlerFunc, route.Name)) //.
-		//Host(common.ExtractHost(listenAddr))
+			Handler(RESTLogger(route.HandlerFunc, route.Name)).
+			Host(common.ExtractHost(listenAddr))
 	}
 
 	if bot.config.Profiler.Enabled {

--- a/restful_router.go
+++ b/restful_router.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/thrasher-/gocryptotrader/common"
 	log "github.com/thrasher-/gocryptotrader/logger"
 
 	_ "net/http/pprof"
@@ -46,7 +45,7 @@ var routes = Routes{}
 // router
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	listenAddr := bot.config.Webserver.ListenAddress
+	//listenAddr := bot.config.Webserver.ListenAddress
 
 	routes = Routes{
 		Route{
@@ -116,8 +115,8 @@ func NewRouter() *mux.Router {
 			Methods(route.Method).
 			Path(route.Pattern).
 			Name(route.Name).
-			Handler(RESTLogger(route.HandlerFunc, route.Name)).
-			Host(common.ExtractHost(listenAddr))
+			Handler(RESTLogger(route.HandlerFunc, route.Name)) //.
+		//Host(common.ExtractHost(listenAddr))
 	}
 
 	if bot.config.Profiler.Enabled {


### PR DESCRIPTION
# Description

1) Adds GetOrderInfo wrapper function to GateIO

- GateIO requires a "market" on its OrderInfo endpoint but we only take OrderID to get around this a query is done against all orders to match passed in Order

2) Adds support for Authenticated Websocket requests
- Following https://www.gate.io/docs/websocket/index.html Sends a "signin" request that is a base64ed HMAC using your api key, secret & nonce 
- I have also added wsGetBalance & wsGetOrderInfo functions to get balance and order information

3) Bug fix for GateIO balance
- GateIO sends different responses depending on if you have no balance a single balance or multiple balances this is a simple work around for that although the code is a little complex over the usual json.Decode it does catch and ignore potentional errors in data miss-matching

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Automated testing using "go clean -testcache && go test ./... -race" to confirm all new and exisiting tests pass

Manual testing has been done with the GateIO exchange including amount with funds/without funds and order testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules