### PR TITLE
RPC server host/port fix

### DIFF
--- a/restful_router.go
+++ b/restful_router.go
@@ -46,7 +46,13 @@ var routes = Routes{}
 // router
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	listenAddr := bot.config.Webserver.ListenAddress
+	var listenAddr string
+
+	if common.ExtractPort(bot.config.Webserver.ListenAddress) == 80 {
+		listenAddr = common.ExtractHost(bot.config.Webserver.ListenAddress)
+	} else {
+		listenAddr = bot.config.Webserver.ListenAddress
+	}
 
 	routes = Routes{
 		Route{
@@ -117,7 +123,7 @@ func NewRouter() *mux.Router {
 			Path(route.Pattern).
 			Name(route.Name).
 			Handler(RESTLogger(route.HandlerFunc, route.Name)).
-			Host(common.ExtractHost(listenAddr))
+			Host(listenAddr)
 	}
 
 	if bot.config.Profiler.Enabled {

--- a/restful_server_test.go
+++ b/restful_server_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
 )
 
@@ -73,7 +72,7 @@ func TestValidHostRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Host = common.ExtractHost(bot.config.Webserver.ListenAddress)
+	req.Host = bot.config.Webserver.ListenAddress
 
 	resp := httptest.NewRecorder()
 	NewRouter().ServeHTTP(resp, req)


### PR DESCRIPTION
# Description

The HTTP standard https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23 requires a port only be sent for the Host header if it is not the "Default" port 80

This is a simple fix to check if the port is 80 and strip if it is

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Automated testing using go test ./...
manually confirming required Host headers are accepted using
- curl -H "Host: localhost:9050" localhost:9050
- curl -H "Host: localhost" localhost:80
- curl -H "Host: invalid:9050" localhost:9050

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules