### PR TITLE
Omit unnecessary else statements when `if` does not flow into the next statement

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -5,6 +5,7 @@ tenets:
   - import: codelingo/effective-go/good-package-name
   - import: codelingo/effective-go/single-method-interface-name
   - import: codelingo/effective-go/underscores-in-name
+  - import: codelingo/effective-go/unnecessary-else
  
   # Overwrite one tenet with custom logic
   # - import: codelingo/effective-go/comment-first-word-when-empty

--- a/config/config.go
+++ b/config/config.go
@@ -1217,7 +1217,7 @@ func GetFilePath(file string) (string, error) {
 		_, err := os.Stat(oldDirs[x])
 		if os.IsNotExist(err) {
 			continue
-		} 
+		}
 		if filepath.Ext(oldDirs[x]) == ".json" {
 			err = os.Rename(oldDirs[x], newDirs[0])
 			if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1217,20 +1217,19 @@ func GetFilePath(file string) (string, error) {
 		_, err := os.Stat(oldDirs[x])
 		if os.IsNotExist(err) {
 			continue
-		} else {
-			if filepath.Ext(oldDirs[x]) == ".json" {
-				err = os.Rename(oldDirs[x], newDirs[0])
-				if err != nil {
-					return "", err
-				}
-				log.Debugf("Renamed old config file %s to %s", oldDirs[x], newDirs[0])
-			} else {
-				err = os.Rename(oldDirs[x], newDirs[1])
-				if err != nil {
-					return "", err
-				}
-				log.Debugf("Renamed old config file %s to %s", oldDirs[x], newDirs[1])
+		} 
+		if filepath.Ext(oldDirs[x]) == ".json" {
+			err = os.Rename(oldDirs[x], newDirs[0])
+			if err != nil {
+				return "", err
 			}
+			log.Debugf("Renamed old config file %s to %s", oldDirs[x], newDirs[0])
+		} else {
+			err = os.Rename(oldDirs[x], newDirs[1])
+			if err != nil {
+				return "", err
+			}
+			log.Debugf("Renamed old config file %s to %s", oldDirs[x], newDirs[1])
 		}
 	}
 

--- a/config/config_encryption.go
+++ b/config/config_encryption.go
@@ -81,7 +81,7 @@ func PromptForConfigKey(initialSetup bool) ([]byte, error) {
 		if bytes.Equal(p1, p2) {
 			cryptoKey = p1
 			break
-		} 
+		}
 		log.Printf("Passwords did not match, please try again.")
 	}
 	return cryptoKey, nil

--- a/config/config_encryption.go
+++ b/config/config_encryption.go
@@ -81,10 +81,8 @@ func PromptForConfigKey(initialSetup bool) ([]byte, error) {
 		if bytes.Equal(p1, p2) {
 			cryptoKey = p1
 			break
-		} else {
-			log.Printf("Passwords did not match, please try again.")
-			continue
-		}
+		} 
+		log.Printf("Passwords did not match, please try again.")
 	}
 	return cryptoKey, nil
 }

--- a/exchange.go
+++ b/exchange.go
@@ -244,12 +244,11 @@ func SetupExchanges() {
 		if !exch.Enabled {
 			log.Debugf("%s: Exchange support: Disabled", exch.Name)
 			continue
-		} else {
-			err := LoadExchange(exch.Name, true, &wg)
-			if err != nil {
-				log.Errorf("LoadExchange %s failed: %s", exch.Name, err)
-				continue
-			}
+		} 
+		err := LoadExchange(exch.Name, true, &wg)
+		if err != nil {
+			log.Errorf("LoadExchange %s failed: %s", exch.Name, err)
+			continue
 		}
 		log.Debugf(
 			"%s: Exchange support: Enabled (Authenticated API support: %s - Verbose mode: %s).\n",

--- a/exchange.go
+++ b/exchange.go
@@ -244,7 +244,7 @@ func SetupExchanges() {
 		if !exch.Enabled {
 			log.Debugf("%s: Exchange support: Disabled", exch.Name)
 			continue
-		} 
+		}
 		err := LoadExchange(exch.Name, true, &wg)
 		if err != nil {
 			log.Errorf("LoadExchange %s failed: %s", exch.Name, err)

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -221,7 +221,7 @@ func TestGetSymbols(t *testing.T) {
 		for _, explicitSymbol := range expectedCurrencies {
 			if common.StringDataCompare(expectedCurrencies, explicitSymbol) {
 				break
-			} 
+			}
 			t.Error("BitfinexGetSymbols currency mismatch with: ", explicitSymbol)
 		}
 	} else {

--- a/exchanges/bitfinex/bitfinex_test.go
+++ b/exchanges/bitfinex/bitfinex_test.go
@@ -221,9 +221,8 @@ func TestGetSymbols(t *testing.T) {
 		for _, explicitSymbol := range expectedCurrencies {
 			if common.StringDataCompare(expectedCurrencies, explicitSymbol) {
 				break
-			} else {
-				t.Error("BitfinexGetSymbols currency mismatch with: ", explicitSymbol)
-			}
+			} 
+			t.Error("BitfinexGetSymbols currency mismatch with: ", explicitSymbol)
 		}
 	} else {
 		t.Error("BitfinexGetSymbols currency mismatch, Expected Currencies < Exchange Currencies")


### PR DESCRIPTION
# Description

Omit unnecessary else statements when `if` does not flow into the next statement, [as specified in Effective Go](https://golang.org/doc/effective_go.html#control-structures).  Previous instances of this issue were fixed in [PR #154](https://github.com/thrasher-/gocryptotrader/pull/154/commits/5de0c94ab891914292d2193e2489f30084b40ebc). 

Adds [unnecessary-else tenet](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/effective-go/unnecessary-else/codelingo.yaml) to your [codelingo.yaml file](https://github.com/leilaes/gocryptotrader/blob/unnecessary-else/codelingo.yaml#L8) to notify you of any future instances of the same issue via code review.

## Type of change

- [x] Code quality


# How Has This Been Tested?

`go test -race -coverprofile=coverage.txt -covermode=atomic  ./...`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally and on Travis with my changes