### PR TITLE
RPC Server Host valdiation fix for #296

### DIFF
--- a/restful_router.go
+++ b/restful_router.go
@@ -52,7 +52,8 @@ func NewRouter() *mux.Router {
 	if common.ExtractPort(bot.config.Webserver.ListenAddress) == 80 {
 		listenAddr = common.ExtractHost(bot.config.Webserver.ListenAddress)
 	} else {
-		listenAddr = common.JoinStrings([]string{common.ExtractHost(bot.config.Webserver.ListenAddress), strconv.Itoa(common.ExtractPort(bot.config.Webserver.ListenAddress))}, ":")
+		listenAddr = common.JoinStrings([]string{common.ExtractHost(bot.config.Webserver.ListenAddress),
+			strconv.Itoa(common.ExtractPort(bot.config.Webserver.ListenAddress))}, ":")
 	}
 
 	routes = Routes{

--- a/restful_router.go
+++ b/restful_router.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -51,7 +52,7 @@ func NewRouter() *mux.Router {
 	if common.ExtractPort(bot.config.Webserver.ListenAddress) == 80 {
 		listenAddr = common.ExtractHost(bot.config.Webserver.ListenAddress)
 	} else {
-		listenAddr = bot.config.Webserver.ListenAddress
+		listenAddr = common.JoinStrings([]string{common.ExtractHost(bot.config.Webserver.ListenAddress), strconv.Itoa(common.ExtractPort(bot.config.Webserver.ListenAddress))}, ":")
 	}
 
 	routes = Routes{
@@ -136,5 +137,4 @@ func NewRouter() *mux.Router {
 
 func getIndex(w http.ResponseWriter, _ *http.Request) {
 	fmt.Fprint(w, "<html>GoCryptoTrader RESTful interface. For the web GUI, please visit the <a href=https://github.com/thrasher-/gocryptotrader/blob/master/web/README.md>web GUI readme.</a></html>")
-	w.WriteHeader(http.StatusOK)
 }

--- a/restful_server_test.go
+++ b/restful_server_test.go
@@ -72,7 +72,7 @@ func TestValidHostRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Host = bot.config.Webserver.ListenAddress
+	req.Host = "localhost:9050"
 
 	resp := httptest.NewRecorder()
 	NewRouter().ServeHTTP(resp, req)


### PR DESCRIPTION
# Description

Changes the listenAddress that is passed to Host() to follow project standard of using "localhost" if no interface is selected (i.e listening on ":9050")

This change does mean in a default configuration the RPC interface will only accept requests on "http://localhost:9050" unless configured otherwise by a user

Also remove the unneeded double status write on getIndex as it will return 200 anyway

Fixes #296 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Automated testing using go test ./...

Manual testing confirms host matches required validation levels

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules