### PR TITLE
WS test improvements

### DIFF
--- a/exchanges/kraken/kraken_test.go
+++ b/exchanges/kraken/kraken_test.go
@@ -651,9 +651,6 @@ func TestOrderbookBufferReset(t *testing.T) {
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if k.WebsocketConn == nil {
-		k.Websocket.Connect()
-	}
 	var obUpdates []string
 	obpartial := `[0,{"as":[["5541.30000","2.50700000","0"]],"bs":[["5541.20000","1.52900000","0"]]}]`
 	for i := 1; i < orderbookBufferLimit+2; i++ {
@@ -703,9 +700,6 @@ func TestOrderBookOutOfOrder(t *testing.T) {
 	}
 	if !k.Websocket.IsEnabled() {
 		t.Skip("Websocket not enabled, skipping")
-	}
-	if k.WebsocketConn == nil {
-		k.Websocket.Connect()
 	}
 	obpartial := `[0,{"as":[["5541.30000","2.50700000","0"]],"bs":[["5541.20000","1.52900000","5"]]}]`
 	obupdate1 := `[0,{"a":[["5541.30000","0.00000000","1"]],"b":[["5541.30000","0.00000000","3"]]}]`

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -810,7 +810,7 @@ func TestSendWsMessages(t *testing.T) {
 	o.WebsocketConn, _, err = dialer.Dial(o.Websocket.GetWebsocketURL(),
 		http.Header{})
 	if err != nil {
-		t.Errorf("%s Unable to connect to Websocket. Error: %s",
+		t.Fatalf("%s Unable to connect to Websocket. Error: %s",
 			o.Name,
 			err)
 	}

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -805,6 +805,7 @@ func TestSendWsMessages(t *testing.T) {
 	}
 	var dialer websocket.Dialer
 	var err error
+	var ok bool
 	o.Websocket.TrafficAlert = make(chan struct{}, 99)
 	o.WebsocketConn, _, err = dialer.Dial(o.Websocket.GetWebsocketURL(),
 		http.Header{})
@@ -825,7 +826,7 @@ func TestSendWsMessages(t *testing.T) {
 	subscription.Channel = "badChannel"
 	o.Subscribe(subscription)
 	response := <-o.Websocket.DataHandler
-	if err, ok := response.(error); ok && err != nil {
+	if err, ok = response.(error); ok && err != nil {
 		if !strings.Contains(response.(error).Error(), subscription.Channel) {
 			t.Error("Expecting OKEX error - 30040 message: Channel badChannel doesn't exist")
 		}

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -823,7 +823,6 @@ func TestSendWsMessages(t *testing.T) {
 	subscription := exchange.WebsocketChannelSubscription{
 		Channel: "badChannel",
 	}
-	subscription.Channel = "badChannel"
 	o.Subscribe(subscription)
 	response := <-o.Websocket.DataHandler
 	if err, ok = response.(error); ok && err != nil {

--- a/exchanges/okcoin/okcoin_test.go
+++ b/exchanges/okcoin/okcoin_test.go
@@ -1,10 +1,13 @@
 package okcoin
 
 import (
+	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
 	"github.com/thrasher-/gocryptotrader/currency"
@@ -90,30 +93,6 @@ func testStandardErrorHandling(t *testing.T, err error) {
 	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Encountered error: %v", err)
 	}
-}
-
-// setupWSConnection Connect to WS, but pass back error so test can handle it if needed
-func setupWSConnection() error {
-	o.Enabled = true
-	err := o.WebsocketSetup(o.WsConnect,
-		nil,
-		nil,
-		o.Name,
-		true,
-		o.Verbose,
-		o.WebsocketURL,
-		o.WebsocketURL)
-	o.Websocket.DataHandler = make(chan interface{}, 500)
-	if err != nil {
-		return err
-	}
-	o.Websocket.SetWsStatusAndConnection(true)
-	return nil
-}
-
-// disconnectFromWS disconnect to WS, but pass back error so test can handle it if needed
-func disconnectFromWS() error {
-	return o.Websocket.Shutdown()
 }
 
 // TestGetAccountCurrencies API endpoint test
@@ -816,88 +795,52 @@ func TestGetMarginTransactionDetails(t *testing.T) {
 
 // Websocket tests ----------------------------------------------------------------------------------------------
 
-// TestWsLogin API endpoint test
-func TestWsLogin(t *testing.T) {
-	TestSetRealOrderDefaults(t)
-	if !websocketEnabled {
-		t.Skip("Websocket not enabled, skipping")
-	}
-	if !o.Websocket.IsConnecting() || !o.Websocket.IsConnected() {
-		o.Websocket.Connect()
-	}
-	err := o.WsLogin()
-	if err != nil {
-		t.Error(err)
-	}
-	var errorReceived bool
-	for i := 0; i < 5; i++ {
-		response := <-o.Websocket.DataHandler
-		if err, ok := response.(error); ok && err != nil {
-			errorReceived = true
-		}
-	}
-	if errorReceived {
-		t.Error("Expecting no errors")
-	}
-}
-
-// TestSubscribeToChannel API endpoint test
-func TestSubscribeToChannel(t *testing.T) {
-	TestSetDefaults(t)
-	if !websocketEnabled {
-		t.Skip("Websocket not enabled, skipping")
-	}
-	if !o.Websocket.IsConnecting() || !o.Websocket.IsConnected() {
-		o.Websocket.Connect()
-	}
-	subscription := exchange.WebsocketChannelSubscription{
-		Channel:  "spot/depth",
-		Currency: currency.NewPairDelimiter("LTC-BTC", "-"),
-	}
-
-	o.Subscribe(subscription)
-	var errorReceived bool
-	for i := 0; i < 5; i++ {
-		response := <-o.Websocket.DataHandler
-		if err, ok := response.(error); ok && err != nil {
-			t.Log(response)
-			if strings.Contains(response.(error).Error(), subscription.Channel) {
-				errorReceived = true
-			}
-		}
-	}
-	if errorReceived {
-		t.Error("Expecting subscription to channel")
-	}
-}
-
-// TestSubscribeToNonExistantChannel Logic test
+// TestSendWsMessages Logic test
 // Attempts to subscribe to a channel that doesn't exist
-// Then captures the error response
-func TestSubscribeToNonExistantChannel(t *testing.T) {
+// Will log in if credentials are present
+func TestSendWsMessages(t *testing.T) {
 	TestSetDefaults(t)
 	if !websocketEnabled {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if !o.Websocket.IsConnecting() || !o.Websocket.IsConnected() {
-		o.Websocket.Connect()
+	var dialer websocket.Dialer
+	var err error
+	o.Websocket.TrafficAlert = make(chan struct{}, 99)
+	o.WebsocketConn, _, err = dialer.Dial(o.Websocket.GetWebsocketURL(),
+		http.Header{})
+	if err != nil {
+		t.Errorf("%s Unable to connect to Websocket. Error: %s",
+			o.Name,
+			err)
 	}
+	defer o.WebsocketConn.Close()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go o.WsHandleData(&wg)
+	wg.Wait()
+
 	subscription := exchange.WebsocketChannelSubscription{
 		Channel: "badChannel",
 	}
+	subscription.Channel = "badChannel"
 	o.Subscribe(subscription)
-	var errorReceived bool
-	for i := 0; i < 5; i++ {
-		response := <-o.Websocket.DataHandler
-		if err, ok := response.(error); ok && err != nil {
-			t.Log(response)
-			if strings.Contains(response.(error).Error(), subscription.Channel) {
-				errorReceived = true
-			}
+	response := <-o.Websocket.DataHandler
+	if err, ok := response.(error); ok && err != nil {
+		if !strings.Contains(response.(error).Error(), subscription.Channel) {
+			t.Error("Expecting OKEX error - 30040 message: Channel badChannel doesn't exist")
 		}
 	}
-	if !errorReceived {
-		t.Error("Expecting OKEX error - 30040 message: Channel badChannel doesn't exist")
+
+	if !areTestAPIKeysSet() {
+		return
+	}
+	err = o.WsLogin()
+	if err != nil {
+		t.Error(err)
+	}
+	response = <-o.Websocket.DataHandler
+	if err, ok := response.(error); ok && err != nil {
+		t.Error(err)
 	}
 }
 

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1570,6 +1570,7 @@ func TestSendWsMessages(t *testing.T) {
 	}
 	var dialer websocket.Dialer
 	var err error
+	var ok bool
 	o.Websocket.TrafficAlert = make(chan struct{}, 99)
 	o.WebsocketConn, _, err = dialer.Dial(o.Websocket.GetWebsocketURL(),
 		http.Header{})
@@ -1590,7 +1591,7 @@ func TestSendWsMessages(t *testing.T) {
 	subscription.Channel = "badChannel"
 	o.Subscribe(subscription)
 	response := <-o.Websocket.DataHandler
-	if err, ok := response.(error); ok && err != nil {
+	if err, ok = response.(error); ok && err != nil {
 		if !strings.Contains(response.(error).Error(), subscription.Channel) {
 			t.Error("Expecting OKEX error - 30040 message: Channel badChannel doesn't exist")
 		}

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1588,7 +1588,6 @@ func TestSendWsMessages(t *testing.T) {
 	subscription := exchange.WebsocketChannelSubscription{
 		Channel: "badChannel",
 	}
-	subscription.Channel = "badChannel"
 	o.Subscribe(subscription)
 	response := <-o.Websocket.DataHandler
 	if err, ok = response.(error); ok && err != nil {

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -1575,7 +1575,7 @@ func TestSendWsMessages(t *testing.T) {
 	o.WebsocketConn, _, err = dialer.Dial(o.Websocket.GetWebsocketURL(),
 		http.Header{})
 	if err != nil {
-		t.Errorf("%s Unable to connect to Websocket. Error: %s",
+		t.Fatalf("%s Unable to connect to Websocket. Error: %s",
 			o.Name,
 			err)
 	}

--- a/exchanges/okex/okex_test.go
+++ b/exchanges/okex/okex_test.go
@@ -2,9 +2,13 @@ package okex
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/thrasher-/gocryptotrader/common"
 	"github.com/thrasher-/gocryptotrader/config"
 	"github.com/thrasher-/gocryptotrader/currency"
@@ -90,26 +94,6 @@ func testStandardErrorHandling(t *testing.T, err error) {
 	if areTestAPIKeysSet() && err != nil {
 		t.Errorf("Encountered error: %v", err)
 	}
-}
-
-// setupWSConnection Connect to WS, but pass back error so test can handle it if needed
-func setupWSConnection() error {
-	if !o.Websocket.IsEnabled() {
-		err := o.WebsocketSetup(o.WsConnect,
-			o.Subscribe,
-			o.Unsubscribe,
-			o.Name,
-			true,
-			o.Verbose,
-			o.WebsocketURL,
-			o.WebsocketURL)
-		o.Websocket.DataHandler = make(chan interface{}, 500)
-		if err != nil {
-			return err
-		}
-		o.Websocket.SetWsStatusAndConnection(true)
-	}
-	return nil
 }
 
 // TestGetAccountCurrencies API endpoint test
@@ -1576,29 +1560,52 @@ func TestGetETTSettlementPriceHistory(t *testing.T) {
 
 // Websocket tests ----------------------------------------------------------------------------------------------
 
-// TestWsLogin API endpoint test
-func TestWsLogin(t *testing.T) {
-	TestSetRealOrderDefaults(t)
+// TestSendWsMessages Logic test
+// Attempts to subscribe to a channel that doesn't exist
+// Will log in if credentials are present
+func TestSendWsMessages(t *testing.T) {
+	TestSetDefaults(t)
 	if !websocketEnabled {
 		t.Skip("Websocket not enabled, skipping")
 	}
-	if !o.Websocket.IsConnecting() || !o.Websocket.IsConnected() {
-		o.Websocket.Connect()
+	var dialer websocket.Dialer
+	var err error
+	o.Websocket.TrafficAlert = make(chan struct{}, 99)
+	o.WebsocketConn, _, err = dialer.Dial(o.Websocket.GetWebsocketURL(),
+		http.Header{})
+	if err != nil {
+		t.Errorf("%s Unable to connect to Websocket. Error: %s",
+			o.Name,
+			err)
 	}
-	err := o.WsLogin()
+	defer o.WebsocketConn.Close()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go o.WsHandleData(&wg)
+	wg.Wait()
+
+	subscription := exchange.WebsocketChannelSubscription{
+		Channel: "badChannel",
+	}
+	subscription.Channel = "badChannel"
+	o.Subscribe(subscription)
+	response := <-o.Websocket.DataHandler
+	if err, ok := response.(error); ok && err != nil {
+		if !strings.Contains(response.(error).Error(), subscription.Channel) {
+			t.Error("Expecting OKEX error - 30040 message: Channel badChannel doesn't exist")
+		}
+	}
+
+	if !areTestAPIKeysSet() {
+		return
+	}
+	err = o.WsLogin()
 	if err != nil {
 		t.Error(err)
 	}
-	var errorReceived bool
-	for i := 0; i < 5; i++ {
-		response := <-o.Websocket.DataHandler
-		if err, ok := response.(error); ok && err != nil {
-			t.Log(response)
-			errorReceived = true
-		}
-	}
-	if errorReceived {
-		t.Error("Expecting no errors")
+	response = <-o.Websocket.DataHandler
+	if err, ok := response.(error); ok && err != nil {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
# Description
OKGroup Websocket tests weren't the best before, and now with the merge of the connection and subscription handler, the chance of their tests failing has increased due to excess noise.

So I've made the following changes:
- OKGroup: Dial the websocket manually and read responses rather than going through WsConnect(). Doing it this way means the connection monitor and subscription handlers aren't run, so the only messages going through the WS connection are from test inputs
- Kraken: The orderbook validation functions don't actually require a WS connection, so I removed it.

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
run package tests,
run all tests
run all tests -race\
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules