### PR TITLE
Replace mutex with atomic operation.

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -8,6 +8,7 @@ tenets:
   - import: codelingo/effective-go/unnecessary-else
   - import: codelingo/code-review-comments/declare-empty-slice 
   - import: codelingo/effective-go/defer-close-file
+  - import: codelingo/thrasher-gocryptotrader
   # Overwrite one tenet with custom logic
   # - import: codelingo/effective-go/comment-first-word-when-empty
   - name: comment-first-word-when-empty

--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func main() {
 	},
 		&currency.MainConfiguration{
 			ForexProviders:         newFxSettings,
-			CryptocurrencyProvider: coinmarketcap.Settings(bot.config.Currency.CryptocurrencyProvider),
+			CryptocurrencyProvider: coinmarketcap.Settings(bot.config.Currency.CryptocurrencyProvider.Load().(config.CryptocurrencyProvider)),
 			Cryptocurrencies:       bot.config.Currency.Cryptocurrencies,
 			FiatDisplayCurrency:    bot.config.Currency.FiatDisplayCurrency,
 			CurrencyDelay:          bot.config.Currency.CurrencyFileUpdateDuration,


### PR DESCRIPTION
# Description

Replace bool and mutex with an atomic value casted as a bool. Atomic operations can be ~10x faster than mutexes according to @thrasher-'s benchmark.
```
BenchmarkRWLock-8 20000000 62.5 ns/op 0 B/op 0 allocs/op
BenchmarkLock-8 30000000 52.6 ns/op 0 B/op 0 allocs/op
BenchmarkAInc-8 200000000 7.77 ns/op 0 B/op 0 allocs/op
``` 

Add tenet to catch short mutexes at code review in the future.

Fixes # (issue)

## Type of change

QA, performance improvement.

# How Has This Been Tested?

`go test -race -coverprofile=coverage.txt -covermode=atomic ./...`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes