### PR TITLE
Config: Fix AuthenticatedAPISupport default values check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -799,17 +799,17 @@ func (c *Config) CheckExchangeConfigValues() error {
 				return fmt.Errorf(ErrExchangeBaseCurrenciesEmpty, c.Exchanges[i].Name)
 			}
 			if c.Exchanges[i].AuthenticatedAPISupport { // non-fatal error
-				if c.Exchanges[i].APIKey == "" || c.Exchanges[i].APISecret == "" ||
-					c.Exchanges[i].APIKey == DefaultUnsetAPIKey ||
-					c.Exchanges[i].APISecret == DefaultUnsetAPISecret {
-					c.Exchanges[i].AuthenticatedAPISupport = false
-					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
-				} else if c.Exchanges[i].Name == "ITBIT" || c.Exchanges[i].Name == "Bitstamp" || c.Exchanges[i].Name == "COINUT" || c.Exchanges[i].Name == "CoinbasePro" {
+				if c.Exchanges[i].Name == "ITBIT" || c.Exchanges[i].Name == "Bitstamp" || c.Exchanges[i].Name == "COINUT" || c.Exchanges[i].Name == "CoinbasePro" {
 					if c.Exchanges[i].ClientID == "" || c.Exchanges[i].ClientID == "ClientID" {
 						c.Exchanges[i].AuthenticatedAPISupport = false
 						log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
 					}
-				}
+				} else if c.Exchanges[i].APIKey == "" || c.Exchanges[i].APISecret == "" ||
+					c.Exchanges[i].APIKey == DefaultUnsetAPIKey ||
+					c.Exchanges[i].APISecret == DefaultUnsetAPISecret {
+					c.Exchanges[i].AuthenticatedAPISupport = false
+					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
+				} 
 			}
 			if !c.Exchanges[i].SupportsAutoPairUpdates {
 				lastUpdated := common.UnixTimestampToTime(c.Exchanges[i].PairsLastUpdated)

--- a/config/config.go
+++ b/config/config.go
@@ -799,14 +799,19 @@ func (c *Config) CheckExchangeConfigValues() error {
 				return fmt.Errorf(ErrExchangeBaseCurrenciesEmpty, c.Exchanges[i].Name)
 			}
 			if c.Exchanges[i].AuthenticatedAPISupport { // non-fatal error
-				if c.Exchanges[i].Name == "ITBIT" || c.Exchanges[i].Name == "Bitstamp" || c.Exchanges[i].Name == "COINUT" || c.Exchanges[i].Name == "CoinbasePro" {
-					if c.Exchanges[i].ClientID == "" || c.Exchanges[i].ClientID == "ClientID" {
-						c.Exchanges[i].AuthenticatedAPISupport = false
-						log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
-					}
-				} else if c.Exchanges[i].APIKey == "" || c.Exchanges[i].APISecret == "" ||
-					c.Exchanges[i].APIKey == DefaultUnsetAPIKey ||
-					c.Exchanges[i].APISecret == DefaultUnsetAPISecret {
+				if c.Exchanges[i].APIKey == "" || c.Exchanges[i].APIKey == DefaultUnsetAPIKey {
+					c.Exchanges[i].AuthenticatedAPISupport = false
+					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
+				}
+
+				if (c.Exchanges[i].APISecret == "" || c.Exchanges[i].APISecret == DefaultUnsetAPISecret) &&
+					c.Exchanges[i].AuthenticatedAPISupport && c.Exchanges[i].Name != "COINUT" {
+					c.Exchanges[i].AuthenticatedAPISupport = false
+					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
+				}
+
+				if (c.Exchanges[i].ClientID == "ClientID" || c.Exchanges[i].ClientID == "") && c.Exchanges[i].AuthenticatedAPISupport &&
+					(c.Exchanges[i].Name == "ITBIT" || c.Exchanges[i].Name == "Bitstamp" || c.Exchanges[i].Name == "COINUT" || c.Exchanges[i].Name == "CoinbasePro") {
 					c.Exchanges[i].AuthenticatedAPISupport = false
 					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -801,18 +801,19 @@ func (c *Config) CheckExchangeConfigValues() error {
 			if c.Exchanges[i].AuthenticatedAPISupport { // non-fatal error
 				if c.Exchanges[i].APIKey == "" || c.Exchanges[i].APIKey == DefaultUnsetAPIKey {
 					c.Exchanges[i].AuthenticatedAPISupport = false
-					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
 				}
 
 				if (c.Exchanges[i].APISecret == "" || c.Exchanges[i].APISecret == DefaultUnsetAPISecret) &&
-					c.Exchanges[i].AuthenticatedAPISupport && c.Exchanges[i].Name != "COINUT" {
+					c.Exchanges[i].Name != "COINUT" {
 					c.Exchanges[i].AuthenticatedAPISupport = false
-					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
 				}
 
-				if (c.Exchanges[i].ClientID == "ClientID" || c.Exchanges[i].ClientID == "") && c.Exchanges[i].AuthenticatedAPISupport &&
+				if (c.Exchanges[i].ClientID == "ClientID" || c.Exchanges[i].ClientID == "") &&
 					(c.Exchanges[i].Name == "ITBIT" || c.Exchanges[i].Name == "Bitstamp" || c.Exchanges[i].Name == "COINUT" || c.Exchanges[i].Name == "CoinbasePro") {
 					c.Exchanges[i].AuthenticatedAPISupport = false
+				}
+
+				if !c.Exchanges[i].AuthenticatedAPISupport {
 					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
 				}
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -809,7 +809,7 @@ func (c *Config) CheckExchangeConfigValues() error {
 					c.Exchanges[i].APISecret == DefaultUnsetAPISecret {
 					c.Exchanges[i].AuthenticatedAPISupport = false
 					log.Warnf(WarningExchangeAuthAPIDefaultOrEmptyValues, c.Exchanges[i].Name)
-				} 
+				}
 			}
 			if !c.Exchanges[i].SupportsAutoPairUpdates {
 				lastUpdated := common.UnixTimestampToTime(c.Exchanges[i].PairsLastUpdated)


### PR DESCRIPTION
# Description
Coinut only uses one key (`APIKey`). If you try and set `AuthenticatedApiSupport: true` in config and only set the `APIKey`, `AuthenticatedApiSupport` will always be set to false due to an if statement that will always match.

I've swapped the if statements around so the more specific scenario is hit first and correctly sets `authenticatedApiSupport`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I was wondering why authenticated WS testing for COINUT wasn't working for way too long before realising that `APIKey`, `ClientId` and  `AuthenticatedApiSupport` were not being properly set due to the above. 

Switching the if around fixed it. All tests pass

Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules