### PR TITLE
COINUT: Fix SendHTTPRequest authenticated requests

### DIFF
--- a/exchanges/coinut/coinut.go
+++ b/exchanges/coinut/coinut.go
@@ -366,7 +366,7 @@ func (c *COINUT) SendHTTPRequest(apiRequest string, params map[string]interface{
 	headers := make(map[string]string)
 	if authenticated {
 		headers["X-USER"] = c.ClientID
-		hmac := common.GetHMAC(common.HashSHA256, payload, []byte(c.APISecret))
+		hmac := common.GetHMAC(common.HashSHA256, payload, []byte(c.APIKey))
 		headers["X-SIGNATURE"] = common.HexEncodeToString(hmac)
 	}
 	headers["Content-Type"] = "application/json"


### PR DESCRIPTION
# Description

Fixes Coinut SendHTTPRequest as it uses ClientID(username) and APIKey only, not an APISecret.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Coinut API authenticated endpoints using an APIKey.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally and on Travis with my changes
- [X] Any dependent changes have been merged and published in downstream modules