### PR TITLE
Fixes to OKEX and Binance WS trades data mapping

### DIFF
--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -250,7 +250,7 @@ func (b *Binance) WsHandleData() {
 
 					b.Websocket.DataHandler <- exchange.TradeData{
 						CurrencyPair: currency.NewPairFromString(trade.Symbol),
-						Timestamp:    time.Unix(0, trade.TimeStamp * 1000000),
+						Timestamp:    time.Unix(0, trade.TimeStamp * int64(time.Millisecond)),
 						Price:        price,
 						Amount:       amount,
 						Exchange:     b.GetName(),

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -250,7 +250,7 @@ func (b *Binance) WsHandleData() {
 
 					b.Websocket.DataHandler <- exchange.TradeData{
 						CurrencyPair: currency.NewPairFromString(trade.Symbol),
-						Timestamp:    time.Unix(0, trade.TimeStamp * int64(time.Millisecond)),
+						Timestamp:    time.Unix(0, trade.TimeStamp*int64(time.Millisecond)),
 						Price:        price,
 						Amount:       amount,
 						Exchange:     b.GetName(),

--- a/exchanges/binance/binance_websocket.go
+++ b/exchanges/binance/binance_websocket.go
@@ -250,7 +250,7 @@ func (b *Binance) WsHandleData() {
 
 					b.Websocket.DataHandler <- exchange.TradeData{
 						CurrencyPair: currency.NewPairFromString(trade.Symbol),
-						Timestamp:    time.Unix(0, trade.TimeStamp),
+						Timestamp:    time.Unix(0, trade.TimeStamp * 1000000),
 						Price:        price,
 						Amount:       amount,
 						Exchange:     b.GetName(),

--- a/exchanges/okgroup/okgroup_websocket.go
+++ b/exchanges/okgroup/okgroup_websocket.go
@@ -452,7 +452,7 @@ func (o *OKGroup) wsProcessTrades(response *WebsocketDataResponse) {
 	for i := range response.Data {
 		instrument := currency.NewPairDelimiter(response.Data[i].InstrumentID, "-")
 		o.Websocket.DataHandler <- exchange.TradeData{
-			Amount:       response.Data[i].Qty,
+			Amount:       response.Data[i].Size,
 			AssetType:    o.GetAssetTypeFromTableName(response.Table),
 			CurrencyPair: instrument,
 			EventTime:    time.Now().Unix(),


### PR DESCRIPTION
# Description

### Binance

Timestamp in raw data feed is in milliseconds whilst it is parsed as nanosecond value using time.Unix(0, trade.TimeStamp).

Actual data:
```
{Timestamp:1970-01-19 05:03:39.862109 +0300 MSK CurrencyPair:BTCUSDT AssetType:SPOT Exchange:Binance EventType: EventTime:0 Price:12181.35 Amount:0.01097 Side:trade}
```
Expected data:
```
{Timestamp:2019-07-09 00:10:01.969 +0300 MSK CurrencyPair:BTCUSDT AssetType:SPOT Exchange:Binance EventType: EventTime:0 Price:12169.83 Amount:0.006087 Side:trade}
```

### OKEX

Zero trade volume amount in incoming WS trade events. Wrong data field is being exposed.

Actual data:
```
{Timestamp:2019-07-08 20:58:21.718 +0000 UTC CurrencyPair:ETH-BTC AssetType:SPOT Exchange:OKEX EventType: EventTime:1562619511 Price:0.02547 Amount:0 Side:sell}
```

Expected data:
```
{Timestamp:2019-07-08 21:00:33.782 +0000 UTC CurrencyPair:TRX-BTC AssetType:SPOT Exchange:OKEX EventType: EventTime:1562619637 Price:2.783e-06 Amount:17128.22 Side:sell}
```

Fixes # (issue)

### Binance

Timestamp is int64 in milliseconds, not in nanoseconds

### OKEX

Right field name is `Size` not `Qty`
https://www.okex.com/docs/en/#spot_ws-trade

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Add API keys for Binance and OKEX to config.json and enable websocket API.