### PR TITLE
Add Huobi GetAggregatedBalance api

### DIFF
--- a/exchanges/huobi/huobi.go
+++ b/exchanges/huobi/huobi.go
@@ -42,6 +42,7 @@ const (
 	huobiTimestamp             = "common/timestamp"
 	huobiAccounts              = "account/accounts"
 	huobiAccountBalance        = "account/accounts/%s/balance"
+	huobiAggregatedBalance     = "subuser/aggregate-balance"
 	huobiOrderPlace            = "order/orders/place"
 	huobiOrderCancel           = "order/orders/%s/submitcancel"
 	huobiOrderCancelBatch      = "order/orders/batchcancel"
@@ -397,6 +398,29 @@ func (h *HUOBI) GetAccountBalance(accountID string) ([]AccountBalanceDetail, err
 		return nil, errors.New(result.ErrorMessage)
 	}
 	return result.AccountBalanceData.AccountBalanceDetails, err
+}
+
+// GetAggregatedBalance returns the balances of all the sub-account aggregated.
+func (h *HUOBI) GetAggregatedBalance() ([]AggregatedBalance, error) {
+	type response struct {
+		Response
+		AggregatedBalances []AggregatedBalance `json:"data"`
+	}
+
+	var result response
+
+	err := h.SendAuthenticatedHTTPRequest(
+		http.MethodGet,
+		huobiAggregatedBalance,
+		nil,
+		nil,
+		&result,
+	)
+
+	if result.ErrorMessage != "" {
+		return nil, errors.New(result.ErrorMessage)
+	}
+	return result.AggregatedBalances, err
 }
 
 // SpotNewOrder submits an order to Huobi

--- a/exchanges/huobi/huobi_test.go
+++ b/exchanges/huobi/huobi_test.go
@@ -210,6 +210,19 @@ func TestGetAccountBalance(t *testing.T) {
 	}
 }
 
+func TestGetAggregatedBalance(t *testing.T) {
+	t.Parallel()
+
+	if h.APIKey == "" || h.APISecret == "" || h.APIAuthPEMKey == "" {
+		t.Skip()
+	}
+
+	_, err := h.GetAggregatedBalance()
+	if err != nil {
+		t.Errorf("Test failed - Huobi GetAggregatedBalance: %s", err)
+	}
+}
+
 func TestSpotNewOrder(t *testing.T) {
 	t.Parallel()
 

--- a/exchanges/huobi/huobi_types.go
+++ b/exchanges/huobi/huobi_types.go
@@ -131,6 +131,12 @@ type AccountBalanceDetail struct {
 	Balance  float64 `json:"balance,string"`
 }
 
+// AggregatedBalance stores balances of all the sub-account
+type AggregatedBalance struct {
+	Currency string  `json:"currency"`
+	Balance  float64 `json:"balance,string"`
+}
+
 // CancelOrderBatch stores the cancel order batch data
 type CancelOrderBatch struct {
 	Success []string `json:"success"`


### PR DESCRIPTION
Add Huobi GetAggregatedBalance api that returns the balances of all the
sub-account aggregated.

See also
  - https://huobiapi.github.io/docs/spot/v1/en/#get-the-aggregated-balance-of-all-sub-accounts-of-the-current-user

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Please also consider improving test coverage whilst working on a certain package

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules