### PR TITLE
Implements endpoint GetAggregatedBalance for Hadax

### DIFF
--- a/exchanges/huobihadax/huobihadax.go
+++ b/exchanges/huobihadax/huobihadax.go
@@ -36,6 +36,7 @@ const (
 	huobihadaxCurrencies            = "common/currencys"
 	huobihadaxTimestamp             = "common/timestamp"
 	huobihadaxAccounts              = "account/accounts"
+	huobihadaxAggregatedBalance     = "subuser/aggregate-balance"
 	huobihadaxAccountBalance        = "account/accounts/%s/balance"
 	huobihadaxOrderPlace            = "order/orders/place"
 	huobihadaxOrderCancel           = "order/orders/%s/submitcancel"
@@ -387,6 +388,28 @@ func (h *HUOBIHADAX) GetAccountBalance(accountID string) ([]AccountBalanceDetail
 		return nil, errors.New(result.ErrorMessage)
 	}
 	return result.AccountBalanceData.AccountBalanceDetails, err
+}
+
+// GetAggregatedBalance returns the balances of all the sub-account aggregated.
+func (h *HUOBIHADAX) GetAggregatedBalance() ([]AggregatedBalance, error) {
+	type response struct {
+		Response
+		AggregatedBalances []AggregatedBalance `json:"data"`
+	}
+
+	var result response
+
+	err := h.SendAuthenticatedHTTPRequest(
+		http.MethodGet,
+		huobihadaxAggregatedBalance,
+		url.Values{},
+		&result,
+	)
+
+	if result.ErrorMessage != "" {
+		return nil, errors.New(result.ErrorMessage)
+	}
+	return result.AggregatedBalances, err
 }
 
 // SpotNewOrder submits an order to Huobi

--- a/exchanges/huobihadax/huobihadax_test.go
+++ b/exchanges/huobihadax/huobihadax_test.go
@@ -202,6 +202,18 @@ func TestGetAccountBalance(t *testing.T) {
 	}
 }
 
+func TestGetAggregatedBalance(t *testing.T) {
+	t.Parallel()
+	if h.APIKey == "" || h.APISecret == "" || h.APIAuthPEMKey == "" {
+		t.Skip()
+	}
+
+	_, err := h.GetAggregatedBalance()
+	if err != nil {
+		t.Errorf("Test failed - Huobi GetAggregatedBalance: %s", err)
+	}
+}
+
 func TestSpotNewOrder(t *testing.T) {
 	t.Parallel()
 

--- a/exchanges/huobihadax/huobihadax_types.go
+++ b/exchanges/huobihadax/huobihadax_types.go
@@ -113,6 +113,12 @@ type AccountBalanceDetail struct {
 	Balance  float64 `json:"balance,string"`
 }
 
+// AggregatedBalance stores balances of all the sub-account
+type AggregatedBalance struct {
+	Currency string  `json:"currency"`
+	Balance  float64 `json:"balance,string"`
+}
+
 // CancelOrderBatch stores the cancel order batch data
 type CancelOrderBatch struct {
 	Success []string `json:"success"`


### PR DESCRIPTION
# Description
 _Shamelessly copies_ hannut91's fine work from https://github.com/thrasher-/gocryptotrader/pull/329 and applies it to `Hadax.go` forcing us to consider merging the two exchanges slightly more

Add ~Huobi~Hadax GetAggregatedBalance api that returns the balances of all the
sub-account aggregated.

See also
  - https://huobiapi.github.io/docs/spot/v1/en/#get-the-aggregated-balance-of-all-sub-accounts-of-the-current-user

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Running test `TestGetAggregatedBalance()` in huobihadax_test.go and seeing the response

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [x] Any dependent changes have been merged and published in downstream modules