### PR TITLE
Bitmex compare initial orderbook snapsnot insensitive

### DIFF
--- a/exchanges/bitmex/bitmex_websocket.go
+++ b/exchanges/bitmex/bitmex_websocket.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -376,7 +377,7 @@ func (b *Bitmex) processOrderbook(data []OrderBookL2, action string, currencyPai
 			var bids, asks []orderbook.Item
 
 			for _, orderbookItem := range data {
-				if orderbookItem.Side == exchange.SellOrderSide.ToString() {
+				if strings.EqualFold(orderbookItem.Side, exchange.SellOrderSide.ToString()) {
 					asks = append(asks, orderbook.Item{
 						Price:  orderbookItem.Price,
 						Amount: float64(orderbookItem.Size),


### PR DESCRIPTION
# Description

Bitmex websocket is not able to initialise order book snapshot due to case sensitive comparison of side:

`[ERROR]: 2019/07/30 21:50:55 routines.go exchange Bitmex websocket error - bitmex_websocket.go error - snapshot not initialised correctly`

Bitmex side is supplied as `Buy` or `Sell` (not all caps) - https://www.bitmex.com/app/wsAPI.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and add an `x` in `[]` as item is complete.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not able to get initial orderbook snapshot without this change.

## Please also consider improving test coverage whilst working on a certain package

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and regenerated documentation via the documentation tool 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally and on Travis with my changes
- [ ] Any dependent changes have been merged and published in downstream modules