### PR TITLE
Fix LRU cache Clear bug

### DIFF
--- a/common/cache/cache_test.go
+++ b/common/cache/cache_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/thrasher-corp/gocryptotrader/common/convert"
 )
 
@@ -55,6 +56,17 @@ func TestClear(t *testing.T) {
 	lruCache.Clear()
 	if lruCache.Len() != 0 {
 		t.Fatal("expected cache to have 0 entries")
+	}
+}
+
+func TestClearRemovesAllEntries(t *testing.T) {
+	lruCache := New(5)
+	for x := range 5 {
+		lruCache.Add(x, x)
+	}
+	lruCache.Clear()
+	for x := range 5 {
+		require.Falsef(t, lruCache.Contains(x), "cache must not contain key %v after Clear()", x)
 	}
 }
 

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -56,7 +56,7 @@ func (l *LRU) getOldest() (key, value any) {
 			return v.key, v.value
 		}
 	}
-	return
+	return key, value
 }
 
 // GetNewest returns the newest entry
@@ -66,13 +66,13 @@ func (l *LRU) getNewest() (key, value any) {
 			return v.key, v.value
 		}
 	}
-	return
+	return key, value
 }
 
 // Contains check if key is in cache this does not update LRU
 func (l *LRU) Contains(key any) (f bool) {
 	_, f = l.items[key]
-	return
+	return f
 }
 
 // Remove removes key from the cache, if the key was removed.
@@ -87,7 +87,7 @@ func (l *LRU) Remove(key any) bool {
 // Clear is used to completely clear the cache.
 func (l *LRU) Clear() {
 	for x := range l.items {
-		delete(l.items, l.items[x])
+		delete(l.items, x)
 	}
 	l.l.Init()
 }


### PR DESCRIPTION
## Summary
- ensure LRU cache `Clear` removes all entries
- add regression test for `Clear`

## Testing
- `go test ./common/cache -run TestClearRemovesAllEntries -count=1`
- `go test ./common/cache -race -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ba7e0563fc832da1ff1f5a07407f3a