### PR TITLE
fix: avoid percentage difference decimal panic

### DIFF
--- a/common/math/math.go
+++ b/common/math/math.go
@@ -52,10 +52,11 @@ func PercentageDifference(x, y float64) float64 {
 
 // PercentageDifferenceDecimal returns the difference between two decimal values as a percentage of their average
 func PercentageDifferenceDecimal(x, y decimal.Decimal) decimal.Decimal {
-	if x.IsZero() && y.IsZero() {
+	sum := x.Add(y)
+	if sum.IsZero() {
 		return decimal.Zero
 	}
-	return x.Sub(y).Abs().Div(x.Add(y).Div(two)).Mul(oneHundred)
+	return x.Sub(y).Abs().Div(sum.Div(two)).Mul(oneHundred)
 }
 
 // CalculateNetProfit returns net profit

--- a/common/math/math_test.go
+++ b/common/math/math_test.go
@@ -67,6 +67,14 @@ func TestPercentageDifferenceDecimal(t *testing.T) {
 	require.Equal(t, "0", PercentageDifferenceDecimal(decimal.Zero, decimal.Zero).String())
 }
 
+func TestPercentageDifferenceDecimalOppositeValues(t *testing.T) {
+	t.Parallel()
+	require.Equal(t,
+		"0",
+		PercentageDifferenceDecimal(decimal.NewFromInt(1), decimal.NewFromInt(-1)).String(),
+		"percentage difference must be zero for opposite values")
+}
+
 // 1585596	       751.8 ns/op	     792 B/op	      27 allocs/op
 func BenchmarkDecimalPercentageDifference(b *testing.B) {
 	d1, d2 := decimal.NewFromFloat(1.469), decimal.NewFromFloat(1.471)


### PR DESCRIPTION
## Summary
- prevent `PercentageDifferenceDecimal` from dividing by zero when values average to zero
- add regression test for opposite value inputs

## Testing
- `make gofumpt`
- `golangci-lint run ./...` *(fails: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25))*
- `go test ./common/... -race -count=1` *(fails: Writer should fail with no write permissions)*
- `go test ./common/math -race -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ba880b81c4832da0f7592d9025892f